### PR TITLE
Issue 36: Benchmark , Reader and Wrtiers are generic

### DIFF
--- a/driver-kafka/src/main/java/io/sbk/Kafka/Kafka.java
+++ b/driver-kafka/src/main/java/io/sbk/Kafka/Kafka.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 /**
- * class for Kafka Benchmarking.
+ * Class for Kafka Benchmarking.
  */
 public class Kafka implements Benchmark<byte[]> {
     private String brokerUri;

--- a/driver-kafka/src/main/java/io/sbk/Kafka/Kafka.java
+++ b/driver-kafka/src/main/java/io/sbk/Kafka/Kafka.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 /**
  * class for Kafka Benchmarking.
  */
-public class Kafka implements Benchmark {
+public class Kafka implements Benchmark<byte[]> {
     private String brokerUri;
     private String topicName;
     private int partitions;

--- a/driver-kafka/src/main/java/io/sbk/Kafka/KafkaReader.java
+++ b/driver-kafka/src/main/java/io/sbk/Kafka/KafkaReader.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 /**
  * Class for Kafka reader/consumer.
  */
-public class KafkaReader implements Reader {
+public class KafkaReader implements Reader<byte[]> {
     final private KafkaConsumer<byte[], byte[]> consumer;
     final private Duration timeoutDuration;
 

--- a/driver-kafka/src/main/java/io/sbk/Kafka/KafkaTopicHandler.java
+++ b/driver-kafka/src/main/java/io/sbk/Kafka/KafkaTopicHandler.java
@@ -29,7 +29,6 @@ public class KafkaTopicHandler {
     final private AdminClient admin;
     final private NewTopic topic;
 
-
     public KafkaTopicHandler(String brokerUri, String topicName, int partitions,
                               short replicationFactor, short minSync) throws IOException {
             adminProperties = new Properties();

--- a/driver-kafka/src/main/java/io/sbk/Kafka/KafkaWriter.java
+++ b/driver-kafka/src/main/java/io/sbk/Kafka/KafkaWriter.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 /**
  * Class for Kafka writer/producer.
  */
-public class KafkaWriter implements Writer {
+public class KafkaWriter implements Writer<byte[]> {
     final private KafkaProducer<byte[], byte[]> producer;
     final private String topicName;
 
@@ -33,11 +33,11 @@ public class KafkaWriter implements Writer {
     }
 
     @Override
-    public long recordWrite(byte[] data, QuadConsumer record) {
+    public long recordWrite(byte[] data, int size, QuadConsumer record) {
         final long time = System.currentTimeMillis();
         producer.send(new ProducerRecord<>(topicName, data), (metadata, exception) -> {
             final long endTime = System.currentTimeMillis();
-            record.accept(time, endTime, data.length, 1);
+            record.accept(time, endTime, size, 1);
         });
         return time;
     }

--- a/driver-pravega/src/main/java/io/sbk/Pravega/Pravega.java
+++ b/driver-pravega/src/main/java/io/sbk/Pravega/Pravega.java
@@ -29,7 +29,7 @@ import io.pravega.client.EventStreamClientFactory;
 /**
  * class for Pravega benchmarking.
  */
-public class Pravega implements Benchmark {
+public class Pravega implements Benchmark<byte[]> {
     static final String DEFAULT_SCOPE = "Scope";
     private String scopeName;
     private String streamName;

--- a/driver-pravega/src/main/java/io/sbk/Pravega/Pravega.java
+++ b/driver-pravega/src/main/java/io/sbk/Pravega/Pravega.java
@@ -27,7 +27,7 @@ import io.pravega.client.stream.impl.ControllerImplConfig;
 import io.pravega.client.EventStreamClientFactory;
 
 /**
- * class for Pravega benchmarking.
+ * Class for Pravega benchmarking.
  */
 public class Pravega implements Benchmark<byte[]> {
     static final String DEFAULT_SCOPE = "Scope";

--- a/driver-pravega/src/main/java/io/sbk/Pravega/PravegaReader.java
+++ b/driver-pravega/src/main/java/io/sbk/Pravega/PravegaReader.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 /**
  * Class for Pravega reader/consumer.
  */
-public class PravegaReader implements Reader {
+public class PravegaReader implements Reader<byte[]> {
     private final Parameters params;
     private final EventStreamReader<byte[]> reader;
 

--- a/driver-pravega/src/main/java/io/sbk/Pravega/PravegaWriter.java
+++ b/driver-pravega/src/main/java/io/sbk/Pravega/PravegaWriter.java
@@ -24,7 +24,7 @@ import io.pravega.client.EventStreamClientFactory;
 /**
  * Class for Pravega writer/producer.
  */
-public class PravegaWriter implements Writer {
+public class PravegaWriter implements Writer<byte[]> {
     final EventStreamWriter<byte[]> producer;
 
     public PravegaWriter(int id, Parameters params, String streamName, EventStreamClientFactory factory) throws IOException {
@@ -37,17 +37,18 @@ public class PravegaWriter implements Writer {
      * Writes the data and benchmark.
      *
      * @param data   data to write
+     * @param size   size of the data
      * @param record to call for benchmarking
      * @return time return the data sent time
      */
     @Override
-    public long recordWrite(byte[] data, QuadConsumer record) throws IOException {
+    public long recordWrite(byte[] data, int size, QuadConsumer record) throws IOException {
         CompletableFuture ret;
         final long time = System.currentTimeMillis();
         ret = writeAsync(data);
         ret.thenAccept(d -> {
             final long endTime = System.currentTimeMillis();
-            record.accept(time, endTime, data.length, 1);
+            record.accept(time, endTime, size, 1);
         });
         return time;
     }

--- a/driver-pulsar/src/main/java/io/sbk/Pulsar/Pulsar.java
+++ b/driver-pulsar/src/main/java/io/sbk/Pulsar/Pulsar.java
@@ -21,7 +21,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 /**
  * class for Pulsar Benchmarking.
  */
-public class Pulsar implements Benchmark {
+public class Pulsar implements Benchmark<byte[]> {
     static final String DEFAULT_NAMESPACE = null;
     static final String DEFAULT_TENANT = null;
     static final String DEFAULT_CLUSTER = null;

--- a/driver-pulsar/src/main/java/io/sbk/Pulsar/Pulsar.java
+++ b/driver-pulsar/src/main/java/io/sbk/Pulsar/Pulsar.java
@@ -19,7 +19,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 
 /**
- * class for Pulsar Benchmarking.
+ * Class for Pulsar Benchmarking.
  */
 public class Pulsar implements Benchmark<byte[]> {
     static final String DEFAULT_NAMESPACE = null;

--- a/driver-pulsar/src/main/java/io/sbk/Pulsar/PulsarReader.java
+++ b/driver-pulsar/src/main/java/io/sbk/Pulsar/PulsarReader.java
@@ -24,7 +24,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 /**
  * Class for Pulsar reader/consumer.
  */
-public class PulsarReader implements Reader {
+public class PulsarReader implements Reader<byte[]> {
     final private Consumer<byte[]> consumer;
     final private Parameters params;
 

--- a/driver-pulsar/src/main/java/io/sbk/Pulsar/PulsarWriter.java
+++ b/driver-pulsar/src/main/java/io/sbk/Pulsar/PulsarWriter.java
@@ -14,13 +14,14 @@ import io.sbk.api.Parameters;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import lombok.Synchronized;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 /**
  * Class for Pulsar writer/producer.
  */
-public class PulsarWriter implements Writer {
+public class PulsarWriter implements Writer<byte[]> {
     final private Producer<byte[]> producer;
 
     public PulsarWriter(int writerID, Parameters params, String topicName, PulsarClient client) throws IOException {
@@ -50,7 +51,8 @@ public class PulsarWriter implements Writer {
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    @Synchronized
+    public void close() throws IOException {
         try {
             producer.close();
         } catch (PulsarClientException ex) {

--- a/sbk-api/build.gradle
+++ b/sbk-api/build.gradle
@@ -17,5 +17,6 @@ dependencies {
     compile 'org.projectlombok:lombok:1.18.10'
     compile "io.pravega:pravega-common:0.6.0"
     compile 'org.reflections:reflections:0.9.12'
+    compile group: 'com.google.guava', name: 'guava', version: '23.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/sbk-api/src/main/java/io/sbk/api/Benchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/Benchmark.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 /**
  * Interface for Benchmarking.
  */
-public interface Benchmark {
+public interface Benchmark<T> {
 
     /**
      * Add the driver specific command line arguments.
@@ -52,7 +52,7 @@ public interface Benchmark {
      *              see {@link io.sbk.api.Parameters} to get the basic benchmarking parameters.
      * @return Writer return the Writer , null in case of failure
      */
-    Writer<byte[]> createWriter(final int id, final Parameters params);
+    Writer<T> createWriter(final int id, final Parameters params);
 
     /**
      * Create a Single Reader / Consumer.
@@ -61,5 +61,5 @@ public interface Benchmark {
      *              see {@link io.sbk.api.Parameters} to get the basic benchmarking parameters.
      * @return Reader return the Reader , null in case of failure
      */
-    Reader<byte[]> createReader(final int id, final Parameters params);
+    Reader<T> createReader(final int id, final Parameters params);
 }

--- a/sbk-api/src/main/java/io/sbk/api/Benchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/Benchmark.java
@@ -9,6 +9,7 @@
  */
 
 package io.sbk.api;
+import io.sbk.api.impl.ByteArray;
 import java.io.IOException;
 
 /**
@@ -62,4 +63,14 @@ public interface Benchmark<T> {
      * @return Reader return the Reader , null in case of failure
      */
     Reader<T> createReader(final int id, final Parameters params);
+
+    /**
+     * Default implementation to create a payload or data to write/read.
+     * default data type is byte[].
+     * if your Benchmark type <T> is other than byte[] then you need to implement your own Data class.
+     * @return Data Data interface, null in case of failure
+     */
+    default DataType dataType() {
+         return new ByteArray();
+    }
 }

--- a/sbk-api/src/main/java/io/sbk/api/Benchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/Benchmark.java
@@ -11,6 +11,8 @@
 package io.sbk.api;
 import io.sbk.api.impl.ByteArray;
 import java.io.IOException;
+import com.google.common.reflect.TypeToken;
+import java.lang.reflect.Type;
 
 /**
  * Interface for Benchmarking.
@@ -69,8 +71,16 @@ public interface Benchmark<T> {
      * default data type is byte[].
      * if your Benchmark type <T> is other than byte[] then you need to implement your own Data class.
      * @return Data Data interface, null in case of failure
+     * @throws IllegalArgumentException if data type is other than byte[]
      */
-    default DataType dataType() {
-         return new ByteArray();
+    default DataType getDataType() throws IllegalArgumentException {
+        final TypeToken<T> typeToken = new TypeToken<T>(getClass()) { };
+        final Type type = typeToken.getComponentType().getType();
+        if (type.getTypeName().equals("byte")) {
+            return new ByteArray();
+        } else {
+            throw new IllegalArgumentException("The data type is your class which implements Benchmark interface is not byte[]"+
+                    ", Override/Implement the 'dataType' method");
+        }
     }
 }

--- a/sbk-api/src/main/java/io/sbk/api/Benchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/Benchmark.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 /**
  * Interface for Benchmarking.
  */
-public interface  Benchmark {
+public interface Benchmark {
 
     /**
      * Add the driver specific command line arguments.
@@ -52,7 +52,7 @@ public interface  Benchmark {
      *              see {@link io.sbk.api.Parameters} to get the basic benchmarking parameters.
      * @return Writer return the Writer , null in case of failure
      */
-    Writer createWriter(final int id, final Parameters params);
+    Writer<byte[]> createWriter(final int id, final Parameters params);
 
     /**
      * Create a Single Reader / Consumer.
@@ -61,5 +61,5 @@ public interface  Benchmark {
      *              see {@link io.sbk.api.Parameters} to get the basic benchmarking parameters.
      * @return Reader return the Reader , null in case of failure
      */
-    Reader createReader(final int id, final Parameters params);
+    Reader<byte[]> createReader(final int id, final Parameters params);
 }

--- a/sbk-api/src/main/java/io/sbk/api/Data.java
+++ b/sbk-api/src/main/java/io/sbk/api/Data.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.api;
+
+public interface Data<T> {
+
+    /**
+     * Create the data.
+     * @param size size (number of bytes) of the data to create.
+     * @return T return the data.
+     */
+    T create(int size);
+
+    /**
+     * get the size of the given data in terms of number of bytes.
+     * @param  data data
+     * @return return size of the data.
+     */
+    int length(T data);
+
+    /**
+     * set the time for data.
+     * @param  data data
+     * @param  time time to set
+     * @return T return the data.
+     */
+    T setTime(T data, long time);
+
+    /**
+     * get the time of data.
+     * @param  data data
+     * @return long return the time set by last {@link io.sbk.api.Data#setTime(Object, long)}}.
+     */
+    long getTime(T data);
+}

--- a/sbk-api/src/main/java/io/sbk/api/DataType.java
+++ b/sbk-api/src/main/java/io/sbk/api/DataType.java
@@ -9,6 +9,9 @@
  */
 package io.sbk.api;
 
+/**
+ * Interface for Data Type operations.
+ */
 public interface DataType<T> {
 
     /**
@@ -19,14 +22,14 @@ public interface DataType<T> {
     T create(int size);
 
     /**
-     * get the size of the given data in terms of number of bytes.
+     * Get the size of the given data in terms of number of bytes.
      * @param  data data
      * @return return size of the data.
      */
     int length(T data);
 
     /**
-     * set the time for data.
+     * Set the time for data.
      * @param  data data
      * @param  time time to set
      * @return T return the data.
@@ -34,7 +37,7 @@ public interface DataType<T> {
     T setTime(T data, long time);
 
     /**
-     * get the time of data.
+     * Get the time of data.
      * @param  data data
      * @return long return the time set by last {@link DataType#setTime(Object, long)}}.
      */

--- a/sbk-api/src/main/java/io/sbk/api/DataType.java
+++ b/sbk-api/src/main/java/io/sbk/api/DataType.java
@@ -9,7 +9,7 @@
  */
 package io.sbk.api;
 
-public interface Data<T> {
+public interface DataType<T> {
 
     /**
      * Create the data.
@@ -36,7 +36,7 @@ public interface Data<T> {
     /**
      * get the time of data.
      * @param  data data
-     * @return long return the time set by last {@link io.sbk.api.Data#setTime(Object, long)}}.
+     * @return long return the time set by last {@link DataType#setTime(Object, long)}}.
      */
     long getTime(T data);
 }

--- a/sbk-api/src/main/java/io/sbk/api/Reader.java
+++ b/sbk-api/src/main/java/io/sbk/api/Reader.java
@@ -15,13 +15,13 @@ import java.io.IOException;
 /**
  * Interface for Readers.
  */
-public interface Reader {
+public interface Reader<T> {
     /**
      * read the data.
-     * @return byte[] return the data.
+     * @return T return the data.
      * @throws IOException If an exception occurred.
      */
-    byte[] read() throws IOException;
+    T read() throws IOException;
 
     /**
      * close the consumer/reader.

--- a/sbk-api/src/main/java/io/sbk/api/Writer.java
+++ b/sbk-api/src/main/java/io/sbk/api/Writer.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Interface for Writers.
  */
-public interface Writer {
+public interface Writer<T>  {
 
     /**
      * Asynchronously Writes the data .
@@ -24,7 +24,7 @@ public interface Writer {
      * @return CompletableFuture completable future. null if the write completed synchronously .
      * @throws IOException If an exception occurred
      */
-    CompletableFuture writeAsync(byte[] data) throws IOException;
+    CompletableFuture writeAsync(T data) throws IOException;
 
     /**
      * Flush the  data.
@@ -39,27 +39,28 @@ public interface Writer {
     void close() throws IOException;
 
     /**
-     * Default implementation for writing data using {@link io.sbk.api.Writer#writeAsync(byte[])}
+     * Default implementation for writing data using {@link io.sbk.api.Writer#writeAsync(Object)}  )}
      * and recording the benchmark statistics.
-     * if you are intend to not use the CompletableFuture returned by {@link io.sbk.api.Writer#writeAsync(byte[])}
+     * if you are intend to not use the CompletableFuture returned by {@link io.sbk.api.Writer#writeAsync(Object)}  )}
      * then you can override this method. otherwise, use the default implementation and don't override this method.
      *
      * @param data   data to write
+     * @param size  size of the data
      * @param recordTime to call for benchmarking
      * @return time return the data sent time
      * @throws IOException If an exception occurred.
      */
-    default long recordWrite(byte[] data, QuadConsumer recordTime) throws IOException {
+    default long recordWrite(T data, int size, QuadConsumer recordTime) throws IOException {
         CompletableFuture ret;
         final long time = System.currentTimeMillis();
         ret = writeAsync(data);
         if (ret == null) {
             final long endTime = System.currentTimeMillis();
-            recordTime.accept(time, endTime, data.length, 1);
+            recordTime.accept(time, endTime, size, 1);
         } else {
             ret.thenAccept(d -> {
                 final long endTime = System.currentTimeMillis();
-                recordTime.accept(time, endTime, data.length, 1);
+                recordTime.accept(time, endTime, size, 1);
             });
         }
         return time;

--- a/sbk-api/src/main/java/io/sbk/api/impl/ByteArray.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/ByteArray.java
@@ -11,16 +11,16 @@
 
 package io.sbk.api.impl;
 
-import io.sbk.api.Data;
+import io.sbk.api.DataType;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
 
-public class ByteData implements Data<byte[]> {
+public class ByteArray implements DataType<byte[]> {
     final static int TIME_HEADER_SIZE = 8;
 
     /**
-     * Create byte the data.
+     * Create byte array data.
      * @param size size (number of bytes) of the data to create.
      * @return T return the data.
      */
@@ -60,7 +60,7 @@ public class ByteData implements Data<byte[]> {
     /**
      * get the time of data.
      * @param  data data
-     * @return long return the time set by last {@link io.sbk.api.impl.ByteData#setTime(byte[], long)}  } )}}.
+     * @return long return the time set by last {@link ByteArray#setTime(byte[], long)}  } )}}.
      */
     @Override
     public long getTime(byte[] data) {

--- a/sbk-api/src/main/java/io/sbk/api/impl/ByteArray.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/ByteArray.java
@@ -7,15 +7,15 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-
-
 package io.sbk.api.impl;
 
 import io.sbk.api.DataType;
-
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+/**
+ * Class for processing byte[] data.
+ */
 public class ByteArray implements DataType<byte[]> {
     final static int TIME_HEADER_SIZE = 8;
 
@@ -35,7 +35,7 @@ public class ByteArray implements DataType<byte[]> {
     }
 
     /**
-     * get the size of the given data in terms of number of bytes.
+     * Get the size of the given data in terms of number of bytes.
      * @param  data data
      * @return return size of the data.
      */
@@ -45,7 +45,7 @@ public class ByteArray implements DataType<byte[]> {
     }
 
     /**
-     * set the time for data.
+     * Set the time for data.
      * @param  data data
      * @param  time time to set
      * @return byte[] return the data.
@@ -58,7 +58,7 @@ public class ByteArray implements DataType<byte[]> {
     }
 
     /**
-     * get the time of data.
+     * Get the time of data.
      * @param  data data
      * @return long return the time set by last {@link ByteArray#setTime(byte[], long)}  } )}}.
      */

--- a/sbk-api/src/main/java/io/sbk/api/impl/ByteData.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/ByteData.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+
+package io.sbk.api.impl;
+
+import io.sbk.api.Data;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+public class ByteData implements Data<byte[]> {
+    final static int TIME_HEADER_SIZE = 8;
+
+    /**
+     * Create byte the data.
+     * @param size size (number of bytes) of the data to create.
+     * @return T return the data.
+     */
+    @Override
+    public byte[] create(int size) {
+        Random random = new Random();
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; ++i) {
+            bytes[i] = (byte) (random.nextInt(26) + 65);
+        }
+        return bytes;
+    }
+
+    /**
+     * get the size of the given data in terms of number of bytes.
+     * @param  data data
+     * @return return size of the data.
+     */
+    @Override
+    public int length(byte[] data) {
+        return data.length;
+    }
+
+    /**
+     * set the time for data.
+     * @param  data data
+     * @param  time time to set
+     * @return byte[] return the data.
+     */
+    @Override
+    public byte[] setTime(byte[] data, long time) {
+        byte[] bytes = ByteBuffer.allocate(TIME_HEADER_SIZE).putLong(0, time).array();
+        System.arraycopy(bytes, 0, data, 0, TIME_HEADER_SIZE);
+        return data;
+    }
+
+    /**
+     * get the time of data.
+     * @param  data data
+     * @return long return the time set by last {@link io.sbk.api.impl.ByteData#setTime(byte[], long)}  } )}}.
+     */
+    @Override
+    public long getTime(byte[] data) {
+        return ByteBuffer.allocate(TIME_HEADER_SIZE).put(data, 0, TIME_HEADER_SIZE).getLong(0);
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkParameters.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkParameters.java
@@ -22,12 +22,10 @@ import org.apache.commons.cli.ParseException;
 import java.util.List;
 
 /**
- * class for processing command Line arguments/parameters.
+ * Class for processing command Line arguments/parameters.
  */
 @Slf4j
 final public class SbkParameters implements Parameters {
-    static final int MAXTIME = 60 * 60 * 24;
-    static final int TIMEOUT = 1000;
     final private String benchmarkName;
     final private String className;
     final private String desc;

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
@@ -10,7 +10,7 @@
 
 package io.sbk.api.impl;
 
-import io.sbk.api.Data;
+import io.sbk.api.DataType;
 import io.sbk.api.Parameters;
 import io.sbk.api.QuadConsumer;
 import io.sbk.api.Reader;
@@ -22,13 +22,13 @@ import java.util.concurrent.ExecutionException;
 /**
  * Reader Implementation.
  */
-public class SbkReader<T> extends Worker implements Callable<Void> {
+public class SbkReader extends Worker implements Callable<Void> {
     final private static int MS_PER_SEC = 1000;
-    final private Data<T> data;
-    final private Reader<T> reader;
+    final private DataType data;
+    final private Reader reader;
     final private RunBenchmark perf;
 
-    public SbkReader(int readerId, Parameters params, QuadConsumer recordTime, Data<T> data, Reader<T> reader) {
+    public SbkReader(int readerId, Parameters params, QuadConsumer recordTime, DataType data, Reader reader) {
         super(readerId, params, recordTime);
         this.data = data;
         this.reader = reader;
@@ -58,7 +58,7 @@ public class SbkReader<T> extends Worker implements Callable<Void> {
 
 
     final public void RecordsReader() throws IOException {
-        T ret = null;
+        Object ret = null;
         try {
             int i = 0;
             while (i < params.getRecordsCount()) {
@@ -77,7 +77,7 @@ public class SbkReader<T> extends Worker implements Callable<Void> {
 
 
     final public void RecordsReaderRW() throws IOException {
-        T ret = null;
+        Object ret = null;
         try {
             int i = 0;
             while (i < params.getRecordsCount()) {
@@ -98,7 +98,7 @@ public class SbkReader<T> extends Worker implements Callable<Void> {
     final public void RecordsTimeReader() throws IOException {
         final long startTime = params.getStartTime();
         final long msToRun = params.getSecondsToRun() * MS_PER_SEC;
-        T ret = null;
+        Object ret = null;
         long time = System.currentTimeMillis();
         try {
             while ((time - startTime) < msToRun) {
@@ -117,7 +117,7 @@ public class SbkReader<T> extends Worker implements Callable<Void> {
     final public void RecordsTimeReaderRW() throws IOException {
         final long startTime = params.getStartTime();
         final long msToRun = params.getSecondsToRun() * MS_PER_SEC;
-        T ret = null;
+        Object ret;
         long time = System.currentTimeMillis();
         try {
             while ((time - startTime) < msToRun) {

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
@@ -10,35 +10,29 @@
 
 package io.sbk.api.impl;
 
+import io.sbk.api.Data;
 import io.sbk.api.Parameters;
 import io.sbk.api.QuadConsumer;
 import io.sbk.api.Reader;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 /**
  * Reader Implementation.
  */
-public class SbkReader extends Worker implements Callable<Void> {
+public class SbkReader<T> extends Worker implements Callable<Void> {
     final private static int MS_PER_SEC = 1000;
-    final private Reader reader;
+    final private Data<T> data;
+    final private Reader<T> reader;
     final private RunBenchmark perf;
 
-    public SbkReader(int readerId, Parameters params, QuadConsumer recordTime, Reader reader) {
+    public SbkReader(int readerId, Parameters params, QuadConsumer recordTime, Data<T> data, Reader<T> reader) {
         super(readerId, params, recordTime);
+        this.data = data;
         this.reader = reader;
         this.perf = createBenchmark();
-    }
-
-    public byte[] read() throws IOException {
-        return reader.read();
-    }
-
-    public void close() throws IOException {
-        reader.close();
     }
 
     @Override
@@ -64,42 +58,39 @@ public class SbkReader extends Worker implements Callable<Void> {
 
 
     final public void RecordsReader() throws IOException {
-        byte[] ret = null;
+        T ret = null;
         try {
             int i = 0;
             while (i < params.getRecordsCount()) {
                 final long startTime = System.currentTimeMillis();
-                ret = read();
+                ret = reader.read();
                 if (ret != null) {
                     final long endTime = System.currentTimeMillis();
-                    recordTime.accept(startTime, endTime, ret.length, 1);
+                    recordTime.accept(startTime, endTime, data.length(ret), 1);
                     i++;
                 }
             }
         } finally {
-            close();
+            reader.close();
         }
     }
 
 
     final public void RecordsReaderRW() throws IOException {
-        final ByteBuffer timeBuffer = ByteBuffer.allocate(TIME_HEADER_SIZE);
-        byte[] ret = null;
+        T ret = null;
         try {
             int i = 0;
             while (i < params.getRecordsCount()) {
                 ret = reader.read();
                 if (ret != null) {
                     final long endTime = System.currentTimeMillis();
-                    timeBuffer.clear();
-                    timeBuffer.put(ret, 0, TIME_HEADER_SIZE);
-                    final long start = timeBuffer.getLong(0);
-                    recordTime.accept(start, endTime, ret.length, 1);
+                    final long start = data.getTime(ret);
+                    recordTime.accept(start, endTime, data.length(ret), 1);
                     i++;
                 }
             }
         } finally {
-            close();
+            reader.close();
         }
     }
 
@@ -107,7 +98,7 @@ public class SbkReader extends Worker implements Callable<Void> {
     final public void RecordsTimeReader() throws IOException {
         final long startTime = params.getStartTime();
         final long msToRun = params.getSecondsToRun() * MS_PER_SEC;
-        byte[] ret = null;
+        T ret = null;
         long time = System.currentTimeMillis();
         try {
             while ((time - startTime) < msToRun) {
@@ -115,33 +106,30 @@ public class SbkReader extends Worker implements Callable<Void> {
                 ret = reader.read();
                 if (ret != null) {
                     final long endTime = System.currentTimeMillis();
-                    recordTime.accept(time, endTime, ret.length, 1);
+                    recordTime.accept(time, endTime, data.length(ret), 1);
                 }
             }
         } finally {
-            close();
+            reader.close();
         }
     }
 
     final public void RecordsTimeReaderRW() throws IOException {
         final long startTime = params.getStartTime();
         final long msToRun = params.getSecondsToRun() * MS_PER_SEC;
-        final ByteBuffer timeBuffer = ByteBuffer.allocate(TIME_HEADER_SIZE);
-        byte[] ret = null;
+        T ret = null;
         long time = System.currentTimeMillis();
         try {
             while ((time - startTime) < msToRun) {
-                ret = read();
+                ret = reader.read();
                 time = System.currentTimeMillis();
                 if (ret != null) {
-                    timeBuffer.clear();
-                    timeBuffer.put(ret, 0, TIME_HEADER_SIZE);
-                    final long start = timeBuffer.getLong(0);
-                    recordTime.accept(start, time, ret.length, 1);
+                    final long start = data.getTime(ret);
+                    recordTime.accept(start, time, data.length(ret), 1);
                 }
             }
         } finally {
-            close();
+            reader.close();
         }
     }
 }

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkWriter.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkWriter.java
@@ -10,42 +10,32 @@
 
 package io.sbk.api.impl;
 
-import io.sbk.api.Data;
+import io.sbk.api.DataType;
 import io.sbk.api.Parameters;
 import io.sbk.api.QuadConsumer;
 import io.sbk.api.Writer;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 /**
  * Writer Implementation.
  */
-public class SbkWriter<T> extends Worker implements Callable<Void> {
+public class SbkWriter extends Worker implements Callable<Void> {
     final private static int MS_PER_SEC = 1000;
-    final private Data<T> data;
-    final private Writer<T> writer;
+    final private DataType data;
+    final private Writer writer;
     final private RunBenchmark perf;
-    final private T payload;
+    final private Object payload;
 
-    public SbkWriter(int writerID, Parameters params, QuadConsumer recordTime, Data<T> data, Writer<T> writer) {
+    public SbkWriter(int writerID, Parameters params, QuadConsumer recordTime, DataType data, Writer writer) {
         super(writerID, params, recordTime);
         this.data = data;
         this.writer = writer;
         this.payload = data.create(params.getRecordSize());
         this.perf = createBenchmark();
-    }
-
-    private byte[] createPayload(int size) {
-        Random random = new Random();
-        byte[] bytes = new byte[size];
-        for (int i = 0; i < size; ++i) {
-            bytes[i] = (byte) (random.nextInt(26) + 65);
-        }
-        return bytes;
     }
 
     @Override

--- a/sbk-api/src/main/java/io/sbk/api/impl/Worker.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/Worker.java
@@ -17,8 +17,6 @@ import io.sbk.api.QuadConsumer;
  * Abstract class for Writers and Readers.
  */
 public abstract class Worker {
-    final static int TIME_HEADER_SIZE = 8;
-
     protected final int workerID;
     protected final Parameters params;
     protected final QuadConsumer recordTime;

--- a/sbk-api/src/main/java/io/sbk/main/SbkMain.java
+++ b/sbk-api/src/main/java/io/sbk/main/SbkMain.java
@@ -11,14 +11,13 @@
 package io.sbk.main;
 
 import io.sbk.api.Benchmark;
-import io.sbk.api.Data;
+import io.sbk.api.DataType;
 import io.sbk.api.Parameters;
 import io.sbk.api.Performance;
 import io.sbk.api.QuadConsumer;
 import io.sbk.api.Reader;
 import io.sbk.api.ResultLogger;
 import io.sbk.api.Writer;
-import io.sbk.api.impl.ByteData;
 import io.sbk.api.impl.SbkParameters;
 import io.sbk.api.impl.SbkPerformance;
 import io.sbk.api.impl.SbkReader;
@@ -104,7 +103,7 @@ public class SbkMain {
             System.exit(0);
         }
 
-        final Benchmark<byte[]> benchmark = obj;
+        final Benchmark benchmark = obj;
         if (benchmark == null) {
             System.out.println("Failure to create Benchmark object");
             System.exit(0);
@@ -170,26 +169,26 @@ public class SbkMain {
             readStats = null;
             readTime = null;
         }
-        final Data<byte[]> byteData = new ByteData();
+        final DataType data = benchmark.dataType();
         try {
-            final List<Writer<byte[]>> writers = IntStream.range(0, params.getWritersCount())
+            final List<Writer> writers = IntStream.range(0, params.getWritersCount())
                                                 .boxed()
                                                 .map(i -> benchmark.createWriter(i, params))
                                                 .collect(Collectors.toList());
 
-            final List<Reader<byte[]>> readers = IntStream.range(0, params.getReadersCount())
+            final List<Reader> readers = IntStream.range(0, params.getReadersCount())
                                                 .boxed()
                                                 .map(i -> benchmark.createReader(i, params))
                                                 .collect(Collectors.toList());
 
-            final List<SbkWriter<byte[]>> sbkWriters =  IntStream.range(0, params.getWritersCount())
+            final List<SbkWriter> sbkWriters =  IntStream.range(0, params.getWritersCount())
                                             .boxed()
-                                            .map(i -> new SbkWriter<byte[]>(i, params, writeTime, byteData, writers.get(i)))
+                                            .map(i -> new SbkWriter(i, params, writeTime, data, writers.get(i)))
                                             .collect(Collectors.toList());
 
-            final List<SbkReader<byte[]>> sbkReaders = IntStream.range(0, params.getReadersCount())
+            final List<SbkReader> sbkReaders = IntStream.range(0, params.getReadersCount())
                                             .boxed()
-                                            .map(i -> new SbkReader<byte[]>(i, params, readTime, byteData, readers.get(i)))
+                                            .map(i -> new SbkReader(i, params, readTime, data, readers.get(i)))
                                             .collect(Collectors.toList());
 
             final List<Callable<Void>> workers = Stream.of(sbkReaders, sbkWriters)

--- a/sbk-api/src/main/java/io/sbk/main/SbkMain.java
+++ b/sbk-api/src/main/java/io/sbk/main/SbkMain.java
@@ -104,7 +104,7 @@ public class SbkMain {
             System.exit(0);
         }
 
-        final Benchmark benchmark = obj;
+        final Benchmark<byte[]> benchmark = obj;
         if (benchmark == null) {
             System.out.println("Failure to create Benchmark object");
             System.exit(0);

--- a/sbk-api/src/main/java/io/sbk/main/SbkMain.java
+++ b/sbk-api/src/main/java/io/sbk/main/SbkMain.java
@@ -11,10 +11,14 @@
 package io.sbk.main;
 
 import io.sbk.api.Benchmark;
+import io.sbk.api.Data;
 import io.sbk.api.Parameters;
 import io.sbk.api.Performance;
 import io.sbk.api.QuadConsumer;
+import io.sbk.api.Reader;
 import io.sbk.api.ResultLogger;
+import io.sbk.api.Writer;
+import io.sbk.api.impl.ByteData;
 import io.sbk.api.impl.SbkParameters;
 import io.sbk.api.impl.SbkPerformance;
 import io.sbk.api.impl.SbkReader;
@@ -166,19 +170,29 @@ public class SbkMain {
             readStats = null;
             readTime = null;
         }
-
+        final Data<byte[]> byteData = new ByteData();
         try {
-            final List<SbkWriter> writers =  IntStream.range(0, params.getWritersCount())
+            final List<Writer<byte[]>> writers = IntStream.range(0, params.getWritersCount())
+                                                .boxed()
+                                                .map(i -> benchmark.createWriter(i, params))
+                                                .collect(Collectors.toList());
+
+            final List<Reader<byte[]>> readers = IntStream.range(0, params.getReadersCount())
+                                                .boxed()
+                                                .map(i -> benchmark.createReader(i, params))
+                                                .collect(Collectors.toList());
+
+            final List<SbkWriter<byte[]>> sbkWriters =  IntStream.range(0, params.getWritersCount())
                                             .boxed()
-                                            .map(i -> new SbkWriter(i, params, writeTime, benchmark.createWriter(i, params)))
+                                            .map(i -> new SbkWriter<byte[]>(i, params, writeTime, byteData, writers.get(i)))
                                             .collect(Collectors.toList());
 
-            final List<SbkReader> readers = IntStream.range(0, params.getReadersCount())
+            final List<SbkReader<byte[]>> sbkReaders = IntStream.range(0, params.getReadersCount())
                                             .boxed()
-                                            .map(i -> new SbkReader(i, params, readTime, benchmark.createReader(i, params)))
+                                            .map(i -> new SbkReader<byte[]>(i, params, readTime, byteData, readers.get(i)))
                                             .collect(Collectors.toList());
 
-            final List<Callable<Void>> workers = Stream.of(readers, writers)
+            final List<Callable<Void>> workers = Stream.of(sbkReaders, sbkWriters)
                     .filter(x -> x != null)
                     .flatMap(x -> x.stream())
                     .collect(Collectors.toList());

--- a/sbk-api/src/main/java/io/sbk/main/SbkMain.java
+++ b/sbk-api/src/main/java/io/sbk/main/SbkMain.java
@@ -169,7 +169,7 @@ public class SbkMain {
             readStats = null;
             readTime = null;
         }
-        final DataType data = benchmark.dataType();
+        final DataType data = benchmark.getDataType();
         try {
             final List<Writer> writers = IntStream.range(0, params.getWritersCount())
                                                 .boxed()


### PR DESCRIPTION
**Change log description**
Benchmark, Reader and Writers are implemented with generic types.

**Purpose of the change**
The readers and writers are data type independent.

**Purpose of the change**
Fixes #36 

**What the code does**
The Benchmark, Reader and Writer use the generics; The Pulsar, Kafka and Pravega drivers implements these interfaces with Byte[] data type.
The Benchmark interface implements the default method to operate on byte[] (byte array) data type. 

**How to verify it**
Tested the SBK with Pravega and Pulsar bench marking on standalone implementations.