### PR TITLE
move the metrics configuration to sbk.properties and make the '9718' as the default metric port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,6 @@ RUN tar -xvf /opt/${APP_NAME}.tar -C /opt/.
 
 RUN mv /opt/${APP_NAME}-* /opt/${APP_NAME}
 
-EXPOSE 8080
+EXPOSE 9718
 
 ENTRYPOINT ["/opt/sbk/bin/sbk"]

--- a/Dockerfile-local-build
+++ b/Dockerfile-local-build
@@ -23,5 +23,5 @@ ENV APP_NAME=sbk
 COPY --chown=root:root   build/install/${APP_NAME}   /opt/${APP_NAME}
 
 WORKDIR /opt/${APP_NAME}
-
+EXPOSE 9718
 ENTRYPOINT ["/opt/sbk/bin/sbk"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Running SBK locally:
                      MongoDB, Nats, NatsStream, Nsq, Pravega, Pulsar,
                      RabbitMQ, RocketMQ, RocksDB]
  -context <arg>      Prometheus Metric context;default context:
-                     8080/metrics; 'no' disables the  metrics
+                     9718/metrics; 'no' disables the  metrics
  -help               Help message
  -readers <arg>      Number of readers
  -records <arg>      Number of records(events) if 'time' not specified;
@@ -163,10 +163,10 @@ Writing(Total)    1116193 records,   19795.9 records/sec,    18.88 MB/sec,     4
 ```
 
 ### Grafana Dashboards of SBK
-When you run the SBK, by default it starts the http server and all the output benchmark data are directed to the default port number: **8080** and **metrics** context.
+When you run the SBK, by default it starts the http server and all the output benchmark data are directed to the default port number: **9718** and **metrics** context.
 if you want to change the port number and context, you can use the command line argument **-context** to change the same.
 you have to run the prometheus monitoring system (server [default port number is 9090] cum client) which pulls/fetches the benchmark data from the local/remote http server.
-In case, if you are fetching metrics/benchmark data from remote http server , or from port number other than 8080 or from the context other than **metrics** then you need to change the [default prometheus server configuration](https://github.com/kmgowda/SBK/blob/master/config/metrics/prometheus/sample-config/sbk-prometheus-sample-config.yml) too.
+In case, if you are fetching metrics/benchmark data from remote http server , or from port number other than 9718 or from the context other than **metrics** then you need to change the [default prometheus server configuration](https://github.com/kmgowda/SBK/blob/master/config/metrics/prometheus/sample-config/sbk-prometheus-sample-config.yml) too.
 Run the grafana server (cum client) to fetch the benchmark data from  prometheus.
 For example, if you are running local grafana server then by default it  fetches the data from prometheus server at the local port 9090.
 You can access the local grafana server at localhost:3000 in your browser using **admin/admin** as default user name / password.
@@ -177,7 +177,7 @@ The sample output of Standalone Pulsar benchmark data with grafana is below
 [![Pulsar Grafana Dashboard](images/pulsar-grafana.jpg)](https://github.com/kmgowda/SBK/blob/gh-pages/images/pulsar-grafana.jpg)
 
 #### Port conflicts between strage servers and grafana/prometheus
-* If you have running Pulsar server in standalone/local mode or if you are running SBK in the same system in which Pulsar broker is also running, then using the local port 8080 conflicts with the Pulsar Admin which runs at same port. So, either you change the Pulsar admin port or change the SBK's http port usig **-metrics** option.
+* If you have running Pulsar server in standalone/local mode or if you are running SBK in the same system in which Pulsar broker is also running, then using the local port 9718 conflicts with the Pulsar Admin which runs at same port. So, either you change the Pulsar admin port or change the SBK's http port usig **-metrics** option.
 * If you are running Pravega server in standalone/local mode or if you are running SBK in the same system in which Pravega controller is also running, then Prometheus port 9090 conflicts with the Pravega controller. So, either you change the Pravega controller port number or change the Prometheus port number in the [prometheus configuraiton file](https://github.com/kmgowda/SBK/blob/master/config/metrics/prometheus/sample-config/sbk-prometheus-sample-config.yml) before deploying the prometheus. 
 
 
@@ -191,9 +191,9 @@ docker pull kmgowda/sbk
 
 you can strightaway run the docker image too, For example
 ```
-docker run  -p 127.0.0.1:8080:8080/tcp  kmgowda/sbk:latest -class  rabbitmq  -broker 192.168.0.192 -topic kmg-topic-11  -writers 5  -readers 1 -size 100 -time 60
+docker run  -p 127.0.0.1:9718:9718/tcp  kmgowda/sbk:latest -class  rabbitmq  -broker 192.168.0.192 -topic kmg-topic-11  -writers 5  -readers 1 -size 100 -time 60
 ```
-* Note that the option **-p 127.0.0.1:8080:8080/tcp** redirects the 8080 port to local port for fetch the performance metric data for Prometheus.  
+* Note that the option **-p 127.0.0.1:9718:9718/tcp** redirects the 9718 port to local port for fetch the performance metric data for Prometheus.  
 * Avoid using the **--network host** option , because this option overrides the port redirection.
 
 #### [SBK Kubernetes Deployments samples](https://github.com/kmgowda/SBK/tree/master/config/kubernetes) 
@@ -442,7 +442,7 @@ usage: sbk -class Pulsar
                         Pulsar, RabbitMQ, RocketMQ, RocksDB]
  -cluster <arg>         Cluster name (optional parameter)
  -context <arg>         Prometheus Metric context;default context:
-                        8080/metrics; 'no' disables the  metrics
+                        9718/metrics; 'no' disables the  metrics
  -deduplication <arg>   Enable or Disable Deduplication; default: false
  -ensembleSize <arg>    EnsembleSize default: 1
  -help                  Help message

--- a/docker-compose-sbk-build.yml
+++ b/docker-compose-sbk-build.yml
@@ -31,6 +31,6 @@ services:
       - prometheus
       - grafana
     expose:
-      - 8080
+      - 9718
     ports:
-      - "8080:8080"
+      - "9718:9718"

--- a/docker-compose-static-ip.yml
+++ b/docker-compose-static-ip.yml
@@ -31,9 +31,9 @@ services:
       - prometheus
       - grafana
     expose:
-      - 8080
+      - 9718
     ports:
-      - "8080:8080"
+      - "9718:9718"
     networks:
       kmgbr:
         ipv4_address: 18.7.0.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,6 @@ services:
       - prometheus
       - grafana
     expose:
-      - 8080
+      - 9718
     ports:
-      - "8080:8080"
+      - "9718:9718"

--- a/grafana/prometheus/targets.json
+++ b/grafana/prometheus/targets.json
@@ -1,7 +1,7 @@
 [
   {
     "targets": [
-      "localhost:8080", "127.0.0.1:8080", "sbk:8080", "host.docker.internal:8080", "18.7.0.9:8080"
+      "localhost:9718", "127.0.0.1:9718", "sbk:9718", "host.docker.internal:9718", "18.7.0.9:9718"
     ]
   }
 ]

--- a/sbk-api/src/main/java/io/sbk/api/Config.java
+++ b/sbk-api/src/main/java/io/sbk/api/Config.java
@@ -37,6 +37,8 @@ public class Config {
     final public static  double[] PERCENTILES = {10, 25, 50, 75, 95, 99, 99.9, 99.99};
 
     public String packageName;
+    public int port;
+    public String context;
     public boolean fork;
     public TimeUnit timeUnit;
     public int reportingMS;

--- a/sbk-api/src/main/java/io/sbk/api/impl/MetricImpl.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/MetricImpl.java
@@ -25,22 +25,26 @@ import java.net.InetSocketAddress;
  * Class for Implementing Prometheus MeterRegistry for metrics.
  */
 public class MetricImpl implements Metric {
-    private final static int DEFAULT_PORT = 8080;
-    private final static String DEFAULT_CONTEXT = "/metrics";
-    private final static String DEFAULT_FULL_CONTEXT = DEFAULT_PORT + DEFAULT_CONTEXT;
     private  int port;
     private String context;
     private boolean disabled;
 
+
+    public MetricImpl(int port, String context) {
+        this.port = port;
+        this.context = context;
+        this.disabled = false;
+    }
+
     @Override
     public void addArgs(final Parameters params) {
         params.addOption("context", true, "Prometheus Metric context;" +
-                "default context: " + DEFAULT_FULL_CONTEXT + "; 'no' disables the  metrics");
+                "default context: " + port + context + "; 'no' disables the metrics");
     }
 
     @Override
     public void parseArgs(final Parameters params) throws IllegalArgumentException {
-        final String fullContext =  params.getOptionValue("context", DEFAULT_FULL_CONTEXT);
+        final String fullContext =  params.getOptionValue("context", port + context);
         if (fullContext.equalsIgnoreCase("no")) {
             disabled = true;
         } else {
@@ -49,8 +53,6 @@ public class MetricImpl implements Metric {
             port = Integer.parseInt(str[0]);
             if (str.length == 2 && str[1] != null) {
                 context = "/" + str[1];
-            } else {
-                context = DEFAULT_CONTEXT;
             }
         }
     }

--- a/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
@@ -89,7 +89,7 @@ public class Sbk {
                         .addOption("class", true, "Benchmark Class"),
                 args, true);
         if (outLogger == null) {
-            metric = new MetricImpl();
+            metric = new MetricImpl(config.port, config.context);
         } else {
             metric = null;
         }

--- a/sbk-api/src/main/resources/sbk.properties
+++ b/sbk-api/src/main/resources/sbk.properties
@@ -9,6 +9,12 @@
 # Package Name to fetch the storage drivers
 packageName=io.sbk
 
+#metrics port
+port=9718
+
+#metric context
+context=/metrics
+
 # Use the Fork Join Model
 fork=true
 


### PR DESCRIPTION

Signed-off-by: Keshava Munegowda <keshava.gowda@gmail.com>