### PR TITLE
Add SBK driver for performance benchmarking of H2 database 

### DIFF
--- a/build-drivers.gradle
+++ b/build-drivers.gradle
@@ -51,6 +51,7 @@ dependencies {
     api project(':driver-cephs3')
     api project(':driver-openio')
     api project(':driver-leveldb')
+    api project(':driver-h2')
     /* api project(':driver-sbktemplate') */
     /* above line is a signature */
 }

--- a/driver-h2/build.gradle
+++ b/driver-h2/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'java'
+}
+
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api project(":driver-jdbc")
+}

--- a/driver-h2/src/main/java/io/sbk/H2/H2.java
+++ b/driver-h2/src/main/java/io/sbk/H2/H2.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.sbk.H2;
+
+import io.sbk.Jdbc.Jdbc;
+
+/**
+ * Class for H2.
+ */
+public class H2 extends Jdbc {
+    private final static String CONFIGFILE = "H2.properties";
+
+    @Override
+    public String getConfigFile() {
+        return CONFIGFILE;
+    }
+}

--- a/driver-h2/src/main/resources/H2.properties
+++ b/driver-h2/src/main/resources/H2.properties
@@ -1,0 +1,21 @@
+#Copyright (c) KMG. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# H2 storage driver default Properties/parameters
+
+#Driver Name
+driver=org.h2.Driver
+
+#url
+url=jdbc:h2:tcp://localhost/~/test
+
+#Table
+table=test
+
+#Username
+user=sa

--- a/driver-jdbc/build.gradle
+++ b/driver-jdbc/build.gradle
@@ -40,4 +40,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.ignite/ignite-spring
     api group: 'org.apache.ignite', name: 'ignite-spring', version: '2.12.0'
      */
+
+    // https://mvnrepository.com/artifact/com.h2database/h2
+    api group: 'com.h2database', name: 'h2', version: '2.1.210'
+
 }

--- a/driver-jdbc/src/main/java/io/sbk/Jdbc/Jdbc.java
+++ b/driver-jdbc/src/main/java/io/sbk/Jdbc/Jdbc.java
@@ -38,6 +38,7 @@ public class Jdbc implements Storage<String> {
     private final static String POSTGRESQL_NAME = "postgresql";
     private final static String MSSQL_NAME = "sqlserver";
     private final static String SQLITE_NAME = "sqlite";
+    private final static String H2_NAME = "h2";
 
     private final static String CONFIGFILE = "jdbc.properties";
     final public DataType<String> dType = new SbkString();
@@ -88,6 +89,10 @@ public class Jdbc implements Storage<String> {
                     "(ID BIGINT IDENTITY(1,1) PRIMARY KEY" +
                     ", DATA VARCHAR(" + params.getRecordSize() + ") NOT NULL)";
         } else if (driverType.equalsIgnoreCase(SQLITE_NAME)) {
+            query = "CREATE TABLE " + config.table +
+                    "(ID INTEGER PRIMARY KEY AUTOINCREMENT" +
+                    ", DATA VARCHAR(" + params.getRecordSize() + ") NOT NULL)";
+        } else if (driverType.equalsIgnoreCase(H2_NAME)) {
             query = "CREATE TABLE " + config.table +
                     "(ID INTEGER PRIMARY KEY AUTOINCREMENT" +
                     ", DATA VARCHAR(" + params.getRecordSize() + ") NOT NULL)";

--- a/settings-drivers.gradle
+++ b/settings-drivers.gradle
@@ -50,5 +50,6 @@ include 'driver-db2'
 include 'driver-cephs3'
 include 'driver-openio'
 include 'driver-leveldb'
+include 'driver-h2'
 /* include 'driver-sbktemplate' */
 /* above line is a signature */


### PR DESCRIPTION
**Describe the Issue (Bug/Feature) or Change log description**  

Feature: Add SBK driver for H2 database(https://h2database.com/html/main.html). Issue #336 

**Purpose of the change** 

By adding the H2 database driver, we can get the performance benchmarking for it using SBK.

**What the code does**  

The code and all its related files adds a driver for H2 database.

**How to verify it**  

Use the command `build\install\sbk\bin\sbk -class h2 -writers 1 -size 100 -seconds 100` to get the performance benchmarking for H2 database.
