### PR TITLE
Add Docker image for H2 database driver

### DIFF
--- a/dockers/sbk-h2
+++ b/dockers/sbk-h2
@@ -1,0 +1,55 @@
+##
+# Copyright (c) KMG. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+##
+
+# Building Container
+FROM gradle:7.2.0-jdk17 as GradleBuilder
+MAINTAINER Keshava Munegowda <keshava.gowda@gmail.com>
+USER root
+
+COPY ca-certificates/* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+ENV APP_NAME=sbk
+ENV SBK_PROJECT=driver-h2
+ENV APP_HOME=/opt/${APP_NAME}
+
+WORKDIR /opt/sbk
+
+COPY --chown=root:root gradle ${APP_HOME}/gradle
+COPY --chown=root:root build.gradle ${APP_HOME}/build.gradle
+COPY --chown=root:root gradle.properties ${APP_HOME}/gradle.properties
+COPY --chown=root:root settings.gradle ${APP_HOME}/settings.gradle
+COPY --chown=root:root gradlew ${APP_HOME}/gradlew
+COPY --chown=root:root checkstyle ${APP_HOME}/checkstyle
+COPY --chown=root:root sbk-api ${APP_HOME}/sbk-api
+
+# Copy the SBK storage drivers
+COPY --chown=root:root driver-jdbc ${APP_HOME}/driver-jdbc
+COPY --chown=root:root driver-h2 ${APP_HOME}/driver-h2
+
+
+
+ENV GRADLE_USER_HOME=/opt/SBK
+RUN gradle  :${SBK_PROJECT}:build --no-daemon --info --stacktrace
+
+# Runtime Container
+FROM openjdk:17.0-jre
+ENV APP_NAME=sbk
+ENV SBK_PROJECT=driver-h2
+ENV APP_HOME=/opt/${APP_NAME}
+
+COPY --from=GradleBuilder ${APP_HOME}/${SBK_PROJECT}/build/distributions/${APP_NAME}-*.tar /opt/${APP_NAME}.tar
+
+RUN tar -xvf /opt/${APP_NAME}.tar -C /opt/.
+RUN mv /opt/${APP_NAME}-* /opt/${APP_NAME}
+
+EXPOSE 9718
+
+ENTRYPOINT ["/opt/sbk/bin/sbk-h2"]


### PR DESCRIPTION
**Describe the Issue (Bug/Feature) or Change log description**  

Feature: Add Docker image for H2 database driver. Issue #347  

**Purpose of the change** 

Add the Docker image file `sbk-h2` as a part of Docker images for H2 database driver.