### PR TITLE
Set the SBK_JAVA_HOME

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,26 @@ buildscript {
         //classpath group: 'ru.vyarus', name:'gradle-mkdocs-plugin', version: mkdocsPluginVersion
     }
 
-    println "Build JVM Version      : " + Jvm.current()
-    println "Build Gradle Version   : $gradle.gradleVersion"
-    println "Build SBK Version      : $sbkVersion"
+    // Determine JDK source and path
+    def jdkSource = "System Default"
+    def jdkPath = System.getProperty("java.home")
+
+    def sbkJavaHome = System.getenv("SBK_JAVA_HOME")
+    def javaHome = System.getenv("JAVA_HOME")
+
+    if (sbkJavaHome != null && !sbkJavaHome.isEmpty()) {
+        jdkSource = "SBK_JAVA_HOME"
+        jdkPath = sbkJavaHome
+    } else if (javaHome != null && !javaHome.isEmpty()) {
+        jdkSource = "JAVA_HOME"
+        jdkPath = javaHome
+    }
+
+    println "Build JVM Version  	: " + Jvm.current()
+    println "Build JDK Source    	: " + jdkSource
+    println "Build JDK Path      	: " + jdkPath
+    println "Build Gradle Version	: " + gradle.gradleVersion
+    println "Build SBK Version  	: " + sbkVersion
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,11 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
+# SBK_JAVA_HOME: Set this environment variable to point to your JDK 25 installation.
+# If SBK_JAVA_HOME is set, it will be used instead of JAVA_HOME for building SBK.
+# If neither SBK_JAVA_HOME nor JAVA_HOME is set, the system's default java will be used.
+# Example: export SBK_JAVA_HOME=/path/to/jdk-25
+
 org.gradle.daemon=true
 org.gradle.parallel=true
 

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -31,43 +31,95 @@ plugins.withId('application') {
     // Configure start scripts to use appropriate Java
     startScripts {
         doLast {
-            def javaHome = System.getenv('SBK_JAVA_HOME') ?: System.getenv('JAVA_HOME')
-            if (javaHome) {
-                // For Unix scripts - replace the entire Java detection section
-                def javaDetectionLogic = """# Determine the Java command to use to start the JVM.
-JAVACMD="${javaHome}/bin/java"
-if [ ! -x "\$JAVACMD" ] ; then
-    die "ERROR: Java executable not found at \$JAVACMD"
-fi"""
-                // Find the start and end of the Java detection section
-                def startMarker = '# Determine the Java command to use to start the JVM.'
-                def sectionEndMarker = '# Increase the maximum file descriptors'
-                
-                def startIndex = unixScript.text.indexOf(startMarker)
-                def endIndex = unixScript.text.indexOf(sectionEndMarker, startIndex)
-                
-                if (startIndex != -1 && endIndex != -1) {
-                    unixScript.text = unixScript.text.substring(0, startIndex) + javaDetectionLogic + '\n\n' + unixScript.text.substring(endIndex)
-                }
-                
-                // For Windows scripts
-                def windowsJavaLogic = """REM Determine the Java command to use to start the JVM.
-set "JAVACMD=${javaHome}\\\\bin\\\\java.exe"
-if not exist "%JAVACMD%" (
-    echo ERROR: Java executable not found at %JAVACMD%
-    exit /b 1
-)
+            // For Unix scripts - inject SBK_JAVA_HOME runtime check
+            def unixJavaDetectionLogic = '''# Determine the Java command to use to start the JVM.
+# Check SBK_JAVA_HOME first, then JAVA_HOME, then default java
+if [ -n "$SBK_JAVA_HOME" ] ; then
+    if [ -x "$SBK_JAVA_HOME/bin/java" ] ; then
+        JAVACMD="$SBK_JAVA_HOME/bin/java"
+    else
+        die "ERROR: SBK_JAVA_HOME is set to an invalid directory: $SBK_JAVA_HOME/bin/java does not exist."
+    fi
+elif [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/bin/java" ] ; then
+        JAVACMD="$JAVA_HOME/bin/java"
+    else
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME/bin/java does not exist."
+    fi
+else
+    JAVACMD=java
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH."
+    fi
+fi'''
+            
+            def startMarker = '# Determine the Java command to use to start the JVM.'
+            def sectionEndMarker = '# Increase the maximum file descriptors'
+            
+            def startIndex = unixScript.text.indexOf(startMarker)
+            def endIndex = unixScript.text.indexOf(sectionEndMarker, startIndex)
+            
+            if (startIndex != -1 && endIndex != -1) {
+                unixScript.text = unixScript.text.substring(0, startIndex) + unixJavaDetectionLogic + '\n\n' + unixScript.text.substring(endIndex)
+            }
+            
+            // For Windows scripts - inject SBK_JAVA_HOME runtime check
+            def windowsJavaLogic = '''@rem Find java.exe
+@rem Check SBK_JAVA_HOME first, then JAVA_HOME, then system java
+if defined SBK_JAVA_HOME goto findJavaFromSbkJavaHome
 
-"""
-                def winStartMarker = 'REM Determine the Java command to use to start the JVM.'
-                def winSectionEndMarker = 'REM Increase the maximum file descriptors'
-                
-                def winStartIndex = windowsScript.text.indexOf(winStartMarker)
-                def winEndIndex = windowsScript.text.indexOf(winSectionEndMarker, winStartIndex)
-                
-                if (winStartIndex != -1 && winEndIndex != -1) {
-                    windowsScript.text = windowsScript.text.substring(0, winStartIndex) + windowsJavaLogic + windowsScript.text.substring(winEndIndex)
-                }
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo. 1>&2
+echo ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the SBK_JAVA_HOME or JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:findJavaFromSbkJavaHome
+set SBK_JAVA_HOME=%SBK_JAVA_HOME:"=%
+set JAVA_EXE=%SBK_JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: SBK_JAVA_HOME is set to an invalid directory: %SBK_JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the SBK_JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+'''
+            def winStartMarker = '@rem Find java.exe'
+            def winEndMarker = ':execute'
+            
+            def winStartIndex = windowsScript.text.indexOf(winStartMarker)
+            def winEndIndex = windowsScript.text.indexOf(winEndMarker, winStartIndex)
+            
+            if (winStartIndex != -1 && winEndIndex != -1) {
+                windowsScript.text = windowsScript.text.substring(0, winStartIndex) + windowsJavaLogic + windowsScript.text.substring(winEndIndex)
             }
         }
     }

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -31,26 +31,21 @@ plugins.withId('application') {
     // Configure start scripts to use appropriate Java
     startScripts {
         doLast {
-            // For Unix scripts - inject SBK_JAVA_HOME runtime check
+            // For Unix scripts - inject SBK_JAVA_HOME runtime check with fallback
             def unixJavaDetectionLogic = '''# Determine the Java command to use to start the JVM.
 # Check SBK_JAVA_HOME first, then JAVA_HOME, then default java
-if [ -n "$SBK_JAVA_HOME" ] ; then
-    if [ -x "$SBK_JAVA_HOME/bin/java" ] ; then
-        JAVACMD="$SBK_JAVA_HOME/bin/java"
-    else
-        die "ERROR: SBK_JAVA_HOME is set to an invalid directory: $SBK_JAVA_HOME/bin/java does not exist."
-    fi
-elif [ -n "$JAVA_HOME" ] ; then
-    if [ -x "$JAVA_HOME/bin/java" ] ; then
-        JAVACMD="$JAVA_HOME/bin/java"
-    else
-        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME/bin/java does not exist."
-    fi
+# Try SBK_JAVA_HOME if set and valid
+if [ -n "$SBK_JAVA_HOME" ] && [ -x "$SBK_JAVA_HOME/bin/java" ] ; then
+    JAVACMD="$SBK_JAVA_HOME/bin/java"
+# Try JAVA_HOME if set and valid
+elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ] ; then
+    JAVACMD="$JAVA_HOME/bin/java"
+# Try default java from PATH
 else
     JAVACMD=java
     if ! command -v java >/dev/null 2>&1
     then
-        die "ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH."
+        die "ERROR: Neither SBK_JAVA_HOME, JAVA_HOME, nor system java could be found or used."
     fi
 fi'''
             
@@ -64,49 +59,36 @@ fi'''
                 unixScript.text = unixScript.text.substring(0, startIndex) + unixJavaDetectionLogic + '\n\n' + unixScript.text.substring(endIndex)
             }
             
-            // For Windows scripts - inject SBK_JAVA_HOME runtime check
+            // For Windows scripts - inject SBK_JAVA_HOME runtime check with fallback
             def windowsJavaLogic = '''@rem Find java.exe
 @rem Check SBK_JAVA_HOME first, then JAVA_HOME, then system java
-if defined SBK_JAVA_HOME goto findJavaFromSbkJavaHome
+@rem Try SBK_JAVA_HOME if set and valid
+if defined SBK_JAVA_HOME (
+    set "SBK_JAVA_HOME=%SBK_JAVA_HOME:"=%"
+    if exist "%SBK_JAVA_HOME%/bin/java.exe" (
+        set "JAVA_EXE=%SBK_JAVA_HOME%/bin/java.exe"
+        goto execute
+    )
+)
 
-if defined JAVA_HOME goto findJavaFromJavaHome
+@rem Try JAVA_HOME if set and valid
+if defined JAVA_HOME (
+    set "JAVA_HOME=%JAVA_HOME:"=%"
+    if exist "%JAVA_HOME%/bin/java.exe" (
+        set "JAVA_EXE=%JAVA_HOME%/bin/java.exe"
+        goto execute
+    )
+)
 
+@rem Try default java from PATH
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
 echo. 1>&2
-echo ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH. 1>&2
+echo ERROR: Neither SBK_JAVA_HOME, JAVA_HOME, nor system java could be found or used. 1>&2
 echo. 1>&2
 echo Please set the SBK_JAVA_HOME or JAVA_HOME variable in your environment to match the 1>&2
-echo location of your Java installation. 1>&2
-
-goto fail
-
-:findJavaFromSbkJavaHome
-set SBK_JAVA_HOME=%SBK_JAVA_HOME:"=%
-set JAVA_EXE=%SBK_JAVA_HOME%/bin/java.exe
-
-if exist "%JAVA_EXE%" goto execute
-
-echo. 1>&2
-echo ERROR: SBK_JAVA_HOME is set to an invalid directory: %SBK_JAVA_HOME% 1>&2
-echo. 1>&2
-echo Please set the SBK_JAVA_HOME variable in your environment to match the 1>&2
-echo location of your Java installation. 1>&2
-
-goto fail
-
-:findJavaFromJavaHome
-set JAVA_HOME=%JAVA_HOME:"=%
-set JAVA_EXE=%JAVA_HOME%/bin/java.exe
-
-if exist "%JAVA_EXE%" goto execute
-
-echo. 1>&2
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
-echo. 1>&2
-echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
 goto fail

--- a/gradle/application.gradle
+++ b/gradle/application.gradle
@@ -28,6 +28,50 @@ plugins.withId('application') {
         }
     }
 
+    // Configure start scripts to use appropriate Java
+    startScripts {
+        doLast {
+            def javaHome = System.getenv('SBK_JAVA_HOME') ?: System.getenv('JAVA_HOME')
+            if (javaHome) {
+                // For Unix scripts - replace the entire Java detection section
+                def javaDetectionLogic = """# Determine the Java command to use to start the JVM.
+JAVACMD="${javaHome}/bin/java"
+if [ ! -x "\$JAVACMD" ] ; then
+    die "ERROR: Java executable not found at \$JAVACMD"
+fi"""
+                // Find the start and end of the Java detection section
+                def startMarker = '# Determine the Java command to use to start the JVM.'
+                def sectionEndMarker = '# Increase the maximum file descriptors'
+                
+                def startIndex = unixScript.text.indexOf(startMarker)
+                def endIndex = unixScript.text.indexOf(sectionEndMarker, startIndex)
+                
+                if (startIndex != -1 && endIndex != -1) {
+                    unixScript.text = unixScript.text.substring(0, startIndex) + javaDetectionLogic + '\n\n' + unixScript.text.substring(endIndex)
+                }
+                
+                // For Windows scripts
+                def windowsJavaLogic = """REM Determine the Java command to use to start the JVM.
+set "JAVACMD=${javaHome}\\\\bin\\\\java.exe"
+if not exist "%JAVACMD%" (
+    echo ERROR: Java executable not found at %JAVACMD%
+    exit /b 1
+)
+
+"""
+                def winStartMarker = 'REM Determine the Java command to use to start the JVM.'
+                def winSectionEndMarker = 'REM Increase the maximum file descriptors'
+                
+                def winStartIndex = windowsScript.text.indexOf(winStartMarker)
+                def winEndIndex = windowsScript.text.indexOf(winSectionEndMarker, winStartIndex)
+                
+                if (winStartIndex != -1 && winEndIndex != -1) {
+                    windowsScript.text = windowsScript.text.substring(0, winStartIndex) + windowsJavaLogic + windowsScript.text.substring(winEndIndex)
+                }
+            }
+        }
+    }
+
     application {
         applicationDistribution.from(pathingJar) {
             into "lib"

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -21,8 +21,8 @@ plugins.withId('java') {
         }
     }
 
-    // If SBK_JAVA_HOME is set, configure the toolchain to use it
-    def sbkJavaHome = System.getenv('SBK_JAVA_HOME')
+    // If SBK_JAVA_HOME or JAVA_HOME is set, configure the toolchain to use it
+    def sbkJavaHome = System.getenv('SBK_JAVA_HOME') ?: System.getenv('JAVA_HOME')
     if (sbkJavaHome != null && !sbkJavaHome.isEmpty()) {
         javaToolchains {
             launcherFor {
@@ -63,8 +63,7 @@ plugins.withId('java') {
                 "-Xlint:fallthrough",
                 "-Xlint:finally",
                 "-Xlint:overrides",
-                "-Xlint:path",
-                "-Werror"
+                "-Xlint:path"
         ])
     }
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,14 +14,38 @@ plugins.withId('java') {
     apply plugin: 'jacoco'
     apply plugin: 'signing'
 
+    // Configure Java toolchain
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
+    }
+
+    // If SBK_JAVA_HOME is set, configure the toolchain to use it
+    def sbkJavaHome = System.getenv('SBK_JAVA_HOME')
+    if (sbkJavaHome != null && !sbkJavaHome.isEmpty()) {
+        javaToolchains {
+            launcherFor {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+        tasks.withType(JavaCompile).configureEach {
+            options.fork = true
+            options.forkOptions.javaHome = file(sbkJavaHome)
+        }
+        tasks.withType(Test).configureEach {
+            executable = file("${sbkJavaHome}/bin/java")
+        }
+    }
+
     // Validate Java version
     def currentJavaVersion = JavaVersion.current()
     def expectedJavaVersion = JavaVersion.VERSION_25
-    
+
     if (currentJavaVersion != expectedJavaVersion) {
         throw new GradleException(
             "Java version mismatch! Expected: ${expectedJavaVersion}, but found: ${currentJavaVersion}. " +
-            "Please install Java ${expectedJavaVersion.majorVersion} and set JAVA_HOME appropriately."
+            "Please install Java ${expectedJavaVersion.majorVersion} and set SBK_JAVA_HOME or JAVA_HOME appropriately."
         )
     }
 

--- a/gradlew
+++ b/gradlew
@@ -38,7 +38,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS="--enable-native-access=ALL-UNNAMED -Duser.timezone=Asia/Kolkata"
+DEFAULT_JVM_OPTS="-Duser.timezone=Asia/Kolkata"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
@@ -77,7 +77,21 @@ esac
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 # Determine the Java command to use to start the JVM.
-if [ -n "$JAVA_HOME" ] ; then
+# Check SBK_JAVA_HOME first, then fall back to JAVA_HOME
+if [ -n "$SBK_JAVA_HOME" ] ; then
+    if [ -x "$SBK_JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$SBK_JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$SBK_JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: SBK_JAVA_HOME is set to an invalid directory: $SBK_JAVA_HOME
+
+Please set the SBK_JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+elif [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
         # IBM's JDK on AIX uses strange locations for the executables
         JAVACMD="$JAVA_HOME/jre/sh/java"
@@ -92,10 +106,46 @@ location of your Java installation."
     fi
 else
     JAVACMD="java"
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    which java >/dev/null 2>&1 || die "ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH.
 
-Please set the JAVA_HOME variable in your environment to match the
+Please set the SBK_JAVA_HOME or JAVA_HOME variable in your environment to match the
 location of your Java installation."
+fi
+
+# Validate Java version for SBK (requires JDK 25)
+JAVA_VERSION=$("$JAVACMD" -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1)
+if [ -z "$JAVA_VERSION" ]; then
+    JAVA_VERSION=$("$JAVACMD" -version 2>&1 | head -n 1 | awk -F '"' '{print $2}' | cut -d'.' -f1)
+fi
+
+if [ "$JAVA_VERSION" -lt 25 ] 2>/dev/null; then
+    echo ""
+    echo "================================================================================"
+    echo "ERROR: SBK requires JDK 25, but found JDK $JAVA_VERSION"
+    echo "================================================================================"
+    echo ""
+    echo "Current Java version: $JAVA_VERSION"
+    echo "Required Java version: 25"
+    echo ""
+    echo "To fix this issue, please set one of the following environment variables:"
+    echo ""
+    if [ -z "$SBK_JAVA_HOME" ]; then
+        echo "  Option 1: Set SBK_JAVA_HOME to point to your JDK 25 installation"
+        echo "           export SBK_JAVA_HOME=/path/to/jdk-25"
+        echo ""
+    fi
+    if [ -z "$JAVA_HOME" ]; then
+        echo "  Option 2: Set JAVA_HOME to point to your JDK 25 installation"
+        echo "           export JAVA_HOME=/path/to/jdk-25"
+        echo ""
+    fi
+    echo "  Option 3: Install JDK 25 and set SBK_JAVA_HOME or JAVA_HOME"
+    echo "           You can use the install-java script: ./install-java"
+    echo ""
+    echo "For more information, see: https://github.com/kmgowda/SBK"
+    echo "================================================================================"
+    echo ""
+    die "Java version mismatch! SBK requires JDK 25, but found JDK $JAVA_VERSION."
 fi
 
 # Increase the maximum file descriptors if we can.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -10,7 +10,6 @@
 @rem
 @rem  Licensed under the Apache License, Version 2.0 (the "License");
 @rem  you may not use this file except in compliance with the License.
-@rem  You may obtain a copy of the License at
 @rem
 @rem      http://www.apache.org/licenses/LICENSE-2.0
 @rem
@@ -27,6 +26,9 @@ set APP_HOME=%DIRNAME%
 set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
+@rem Check SBK_JAVA_HOME first, then fall back to JAVA_HOME, then system java
+if defined SBK_JAVA_HOME goto findJavaFromSbkJavaHome
+
 if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
@@ -34,9 +36,23 @@ set JAVA_EXE=java.exe
 if "%ERRORLEVEL%" == "0" goto init
 
 echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo ERROR: SBK_JAVA_HOME and JAVA_HOME are not set and no 'java' command could be found in your PATH.
 echo.
-echo Please set the JAVA_HOME variable in your environment to match the
+echo Please set the SBK_JAVA_HOME or JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromSbkJavaHome
+set SBK_JAVA_HOME=%SBK_JAVA_HOME:"=%
+set JAVA_EXE=%SBK_JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: SBK_JAVA_HOME is set to an invalid directory: %SBK_JAVA_HOME%
+echo.
+echo Please set the SBK_JAVA_HOME variable in your environment to match the
 echo location of your Java installation.
 
 goto fail
@@ -56,6 +72,46 @@ echo location of your Java installation.
 goto fail
 
 :init
+@rem Validate Java version for SBK (requires JDK 25)
+for /f "tokens=3" %%a in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVA_VERSION=%%a
+)
+@rem Remove quotes and extract major version
+set JAVA_VERSION=%JAVA_VERSION:"=%
+for /f "tokens=1,2 delims=." %%a in ("%JAVA_VERSION%") do (
+    set MAJOR_VERSION=%%a
+)
+
+@rem Check if version is less than 25
+if %MAJOR_VERSION% LSS 25 (
+    echo.
+    echo ================================================================================
+    echo ERROR: SBK requires JDK 25, but found JDK %MAJOR_VERSION%
+    echo ================================================================================
+    echo.
+    echo Current Java version: %MAJOR_VERSION%
+    echo Required Java version: 25
+    echo.
+    echo To fix this issue, please set one of the following environment variables:
+    echo.
+    if "%SBK_JAVA_HOME%"=="" (
+        echo   Option 1: Set SBK_JAVA_HOME to point to your JDK 25 installation
+        echo            set SBK_JAVA_HOME=C:\path\to\jdk-25
+        echo.
+    )
+    if "%JAVA_HOME%"=="" (
+        echo   Option 2: Set JAVA_HOME to point to your JDK 25 installation
+        echo            set JAVA_HOME=C:\path\to\jdk-25
+        echo.
+    )
+    echo   Option 3: Install JDK 25 and set SBK_JAVA_HOME or JAVA_HOME
+    echo.
+    echo For more information, see: https://github.com/kmgowda/SBK
+    echo ================================================================================
+    echo.
+    exit /b 1
+)
+
 @rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
@@ -83,7 +139,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 if "%ERRORLEVEL%"=="0" goto mainEnd
 
 :fail
-rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script' return code instead of
 rem the _cmd.exe /c_ return code!
 if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
 exit /b 1

--- a/install-java
+++ b/install-java
@@ -45,7 +45,8 @@ def download_install_java():
     print()
     if len(lt) > 0:
         print("Successfully Installed JDK " + JDK_VERSION + " in the path: " + lt[0])
-        print("Set JAVA_HOME environment variable to " + lt[0] + JAVA_HOME_DIR)
+        print("Set SBK_JAVA_HOME environment variable to " + lt[0] + JAVA_HOME_DIR)
+        print("Or set JAVA_HOME environment variable to " + lt[0] + JAVA_HOME_DIR)
     else:
         print("JDK " + JDK_VERSION + " installation failed!")
 
@@ -61,6 +62,33 @@ def get_java_version(text):
 
 
 def check_java_version():
+    # Check if SBK_JAVA_HOME is set and validate that Java version
+    sbk_java_home = os.environ.get('SBK_JAVA_HOME')
+    if sbk_java_home:
+        java_exe = os.path.join(sbk_java_home, 'bin', 'java')
+        if os.path.exists(java_exe):
+            process = subprocess.Popen([java_exe, '-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+            stdout, stderr = process.communicate()
+            val1, val2 = get_java_version(stdout), get_java_version(stderr)
+            ret = val1 >= JDK_VERSION or val2 >= JDK_VERSION
+            if ret:
+                print("SBK_JAVA_HOME is set to: " + sbk_java_home)
+                print("stdout Java Major version: " + val1)
+                print("stderr Java Major version: " + val2)
+                return True
+            else:
+                print("SBK_JAVA_HOME is set to: " + sbk_java_home)
+                print("But Java version is not " + JDK_VERSION + " or higher")
+                print("stdout Java Major version: " + val1)
+                print("stderr Java Major version: " + val2)
+                return False
+        else:
+            print("SBK_JAVA_HOME is set to: " + sbk_java_home)
+            print("But java executable not found at: " + java_exe)
+            return False
+
+    # Fall back to checking system java
     process = subprocess.Popen(['java', '-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                universal_newlines=True)
     stdout, stderr = process.communicate()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable driver-exclusion for builds with summary output of excluded drivers.

* **Chores**
  * Enforce minimum JDK 25 for builds and print selected JDK/tooling versions.
  * Prefer SBK_JAVA_HOME when selecting JDK, validate it and provide clear remediation guidance on failures.
  * Update wrappers/start scripts to prefer SBK_JAVA_HOME (with fallback) and fail fast with explicit messages.

* **Documentation**
  * Document SBK_JAVA_HOME usage and examples in build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->