### PR TITLE
Add local live web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart LR
     WORKERS --> DRIVER
     WORKERS --> CHANNEL[PerL channels]
     CHANNEL --> RECORDER[Latency recorder]
-    RECORDER --> OUTPUT[Console / CSV / Prometheus / gRPC]
+    RECORDER --> OUTPUT[Console / CSV / Web dashboard / Prometheus / gRPC]
     OUTPUT -->|gRPC mode| SBM[SBM aggregator]
     GEM[SBK-GEM] -->|SSH orchestration| CLI
     GEM --> SBM
@@ -167,7 +167,7 @@ Driver-specific options are added after SBK discovers `-class`. Use the selected
 | `-sync N` | Records per flush/sync or transaction |
 | `-ro true` | With readers and writers configured, read without writing new records |
 | `-thread p\|f\|v` | Platform, fork-join, or virtual worker executor |
-| `-out NAME` | Output logger, such as `SystemLogger`, `CSVLogger`, `PrometheusLogger`, or `GrpcLogger` |
+| `-out NAME` | Output logger, such as `SystemLogger`, `CSVLogger`, `WebLogger`, `PrometheusLogger`, or `GrpcLogger` |
 
 Always treat `-help` as authoritative because drivers and loggers add their own options at runtime.
 
@@ -194,8 +194,35 @@ SBK currently ships these logger implementations:
 - `SystemLogger`: human-readable periodic and final output.
 - `Sl4jLogger`: SLF4J-backed output.
 - `CSVLogger`: results written in CSV form.
+- `WebLogger`: console/CSV output plus an embedded, dependency-free live browser dashboard.
 - `PrometheusLogger`: CSV behavior plus Prometheus metrics exposure.
 - `GrpcLogger`: forwards measurements to SBM for distributed aggregation.
+
+### Local live dashboard
+
+Use `WebLogger` when you want live graphs without Docker, Prometheus, or Grafana:
+
+```bash
+./build/install/sbk/bin/sbk -class file -file /tmp/sbk.bin \
+  -writers 4 -size 4096 -seconds 60 -out WebLogger
+```
+
+SBK opens `http://127.0.0.1:9720` in the default browser. The lightweight Java server retains bounded history in
+memory and streams new summaries with server-sent events. A later SBK process reuses a compatible server already on
+that port. Use `-dashboardopen false` on headless hosts, `-dashboardstart false` to require a pre-existing server, and
+`-dashboardport PORT` to select another port. Run `sbk -out WebLogger -help` for the complete option set.
+
+Distributed monitoring uses the same dashboard and data model:
+
+```bash
+# Standalone SBM aggregate dashboard
+sbm -out SbmWebLogger -class file -action r
+
+# SBK-GEM aggregate dashboard; remote nodes continue sending results through GrpcLogger
+sbk-gem -out GemWebLogger -class file -nodes host1,host2 -writers 2 -size 4096 -seconds 60
+```
+
+The default listener is loopback-only. Bind it to a non-loopback address only on a trusted benchmark network.
 
 ## Distributed execution
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Choose the guide that matches your task:
 | Build and run SBK | This README |
 | Understand modules and runtime flow | [Architecture and code flow](docs/ARCHITECTURE.md) |
 | Browse all documentation | [Documentation index](docs/README.md) |
+| View live graphs without Docker | [WebLogger guide](docs/WEB_LOGGER.md) |
 | Add or modify a storage driver | [Driver guide](docs/DRIVER_GUIDE.md) |
 | Make a code contribution | [Contributing guide](CONTRIBUTING.md) |
 | Follow a task-specific procedure | [Engineering recipes](docs/AGENT_RECIPES.md) |
@@ -207,10 +208,31 @@ Use `WebLogger` when you want live graphs without Docker, Prometheus, or Grafana
   -writers 4 -size 4096 -seconds 60 -out WebLogger
 ```
 
+For a filesystem read benchmark, first create an input file and then read it with `WebLogger`. The record size must
+match between preparation and reading:
+
+```bash
+# Prepare a 1 GiB file: 1,048,576 records x 1,024 bytes.
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -writers 1 -size 1024 -records 1048576
+
+# Measure filesystem reads for 60 seconds and display live graphs.
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60 \
+  -out WebLogger
+```
+
 SBK opens `http://127.0.0.1:9720` in the default browser. The lightweight Java server retains bounded history in
 memory and streams new summaries with server-sent events. A later SBK process reuses a compatible server already on
-that port. Use `-dashboardopen false` on headless hosts, `-dashboardstart false` to require a pre-existing server, and
+that port. The server accepts one active SBK, SBM, or SBK-GEM benchmark at a time and reports an error if another
+WebLogger benchmark already owns it. Completed graphs remain available while a browser is connected; after the
+benchmark has finished and no browser has been connected for one minute, the server exits automatically. Use
+`-dashboardopen false` on headless hosts, `-dashboardstart false` to require a pre-existing server, and
 `-dashboardport PORT` to select another port. Run `sbk -out WebLogger -help` for the complete option set.
+See the [WebLogger guide](docs/WEB_LOGGER.md) for every option, dashboard lifecycle, distributed usage, security,
+and troubleshooting.
 
 Distributed monitoring uses the same dashboard and data model:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,6 +230,7 @@ Primary sources:
 | `SystemLogger` | Default terminal output |
 | `Sl4jLogger` | SLF4J logging path |
 | `CSVLogger` | CSV result persistence |
+| `WebLogger` | Console/CSV behavior plus dependency-free local live graphs; see [WebLogger guide](WEB_LOGGER.md) |
 | `PrometheusLogger` | Metrics endpoint plus inherited result behavior |
 | `GrpcLogger` | SBP/gRPC forwarding to SBM |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,9 @@ This directory contains the authoritative engineering documentation for Storage 
 ### New user
 
 1. [Project README](../README.md): requirements, build, first benchmark, and module overview.
-2. The README under the selected `drivers/<name>/` directory: backend prerequisites and examples.
-3. [Architecture and code flow](ARCHITECTURE.md): what happens after the command starts.
+2. [WebLogger guide](WEB_LOGGER.md): dependency-free local live graphs for SBK, SBM, and SBK-GEM.
+3. The README under the selected `drivers/<name>/` directory: backend prerequisites and examples.
+4. [Architecture and code flow](ARCHITECTURE.md): what happens after the command starts.
 
 ### New contributor
 
@@ -59,6 +60,7 @@ This directory contains the authoritative engineering documentation for Storage 
 | [AGENTS.md](../AGENTS.md) | Agent rules and repository-specific constraints |
 | [AGENT_RECIPES.md](AGENT_RECIPES.md) | Exact task procedures |
 | [DRIVER_SPECIFICATION.md](DRIVER_SPECIFICATION.md) | Fillable design template for new drivers |
+| [WEB_LOGGER.md](WEB_LOGGER.md) | Local live dashboard usage, lifecycle, options, security, and troubleshooting |
 | [sbk-internals.md](sbk-internals.md) | Detailed design rationale and research-oriented treatment |
 | Component READMEs | Component operation and component-specific examples |
 | Driver READMEs | Backend prerequisites, properties, limitations, and example commands |

--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -1,0 +1,167 @@
+<!--
+Copyright (c) KMG. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# WebLogger: local live benchmark graphs
+
+WebLogger displays SBK measurements in a local browser without Docker, Prometheus, or Grafana. It uses the same
+periodic and total measurements printed by SBK, so enabling it does not add measurement sampling or storage-driver
+work. The dashboard server is implemented with the JDK HTTP server, retains a bounded in-memory history, and sends
+new summaries to browsers with server-sent events (SSE).
+
+Use the logger matching the application:
+
+| Application | Logger | Displayed result |
+|---|---|---|
+| `sbk` or `sbk-yal` | `WebLogger` | One local SBK workload |
+| `sbm` | `SbmWebLogger` | Aggregated results received from distributed SBK clients |
+| `sbk-gem` or `sbk-gem-yal` | `GemWebLogger` | Cluster aggregate produced by GEM's embedded SBM |
+
+The default dashboard URL is <http://127.0.0.1:9720>. The exact run URL is printed when the logger starts.
+
+## Quick start: filesystem read benchmark
+
+A read benchmark needs an existing data file. First create one using records of the same size that the reader will
+request. This preparation command creates a 1 GiB file from 1,048,576 records of 1,024 bytes:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -writers 1 -size 1024 -records 1048576
+```
+
+Then run a 60-second filesystem read benchmark with live graphs:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60 \
+  -out WebLogger
+```
+
+SBK starts the dashboard when necessary and normally opens the run URL in the default browser. On a headless host,
+disable automatic browser opening and connect through an appropriate secure tunnel:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60 \
+  -out WebLogger -dashboardopen false
+```
+
+The graphs show completed record rate and throughput, write/read request rates, worker and connection counts,
+pending requests, timeout and invalid-latency counts, average/minimum/maximum latency, and configured latency
+percentiles. The final total snapshot remains selectable after the benchmark finishes.
+
+## Dashboard options
+
+Logger options appear only after selecting the WebLogger class. Treat generated help as authoritative:
+
+```bash
+./build/install/sbk/bin/sbk -out WebLogger -help
+./build/install/sbk/bin/sbm -out SbmWebLogger -help
+./build/install/sbk/bin/sbk-gem -out GemWebLogger -help
+```
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `-dashboardhost HOST` | `127.0.0.1` | Address on which the local HTTP server listens |
+| `-dashboardport PORT` | `9720` | Dashboard HTTP port |
+| `-dashboardstart true\|false` | `true` | Start a compatible server when none is reachable |
+| `-dashboardopen true\|false` | `true` | Ask the local desktop to open the run URL |
+| `-dashboardretention N` | `3600` | Maximum snapshots retained for each run |
+| `-dashboardname NAME` | empty | Human-readable name shown for the run |
+
+`-dashboardstart false` is useful when an operator manages the dashboard process separately. If no compatible
+server is available, SBK continues without live graphs and reports the reason. A different service or an older,
+incompatible dashboard on the configured port is never treated as the SBK dashboard.
+
+## Server ownership and shutdown
+
+One dashboard server accepts one active `WebLogger`, `SbmWebLogger`, or `GemWebLogger` benchmark at a time. This
+prevents unrelated runs from being presented as one active experiment. A second active benchmark exits with an
+ownership error identifying the current run.
+
+The server lifecycle is:
+
+1. The first WebLogger application starts a server when one is not already reachable.
+2. A compatible idle server is reused; another server process is not started.
+3. When the benchmark finishes, its bounded history and final snapshot remain in server memory.
+4. An open browser renews a lightweight lease every 15 seconds, keeping the completed graphs available.
+5. If a browser connects during the one-minute idle grace period, the pending shutdown is cancelled while that
+   browser remains connected.
+6. If SBK, SBM, or SBK-GEM connects during the grace period, it becomes the active run and cancels the pending
+   shutdown.
+7. When no benchmark is active and no browser lease is present for one minute, the server exits gracefully.
+
+Closing a browser releases its lease. If a browser or network disappears without a clean close, the lease expires
+from its last renewal, so a dead TCP connection cannot keep the process alive indefinitely.
+
+## Distributed WebLogger modes
+
+For manually launched distributed clients, start SBM with `SbmWebLogger`:
+
+```bash
+./build/install/sbk/bin/sbm \
+  -out SbmWebLogger -class file -action r
+```
+
+Then point each SBK client at the SBM host. Remote clients use `GrpcLogger`; only SBM owns the dashboard:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60 \
+  -out GrpcLogger -sbm <sbm-host> -sbmport 9717
+```
+
+For SSH-orchestrated benchmarking, select `GemWebLogger` on SBK-GEM:
+
+```bash
+./build/install/sbk/bin/sbk-gem \
+  -out GemWebLogger -nodes host1,host2 \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60
+```
+
+GEM starts an embedded SBM. Remote SBK processes send SBP/gRPC measurements to that aggregator, and
+`GemWebLogger` publishes only the combined cluster result to the browser.
+
+## Network and security
+
+The default loopback binding restricts access to the benchmark host. To view a remote loopback dashboard, prefer an
+SSH tunnel rather than exposing the port:
+
+```bash
+ssh -L 9720:127.0.0.1:9720 user@benchmark-host
+```
+
+Then open <http://127.0.0.1:9720> locally. The dashboard has no authentication or TLS. Bind
+`-dashboardhost 0.0.0.0` only on an isolated, trusted benchmark network protected by host and network controls.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+|---|---|
+| Browser does not open | Copy the printed URL manually, or use `-dashboardopen false` on headless systems |
+| Dashboard unavailable | Check `-dashboardhost`, `-dashboardport`, local firewall rules, and whether startup is disabled |
+| Port is incompatible | Stop the unrelated/older service or select another `-dashboardport` |
+| Dashboard already in use | Wait for the named active benchmark to finish; do not combine independent experiments |
+| Read benchmark reports no useful data | Create and verify the input file first; use the same record size for preparation and reading |
+| Graph disappears after completion | Keep a browser page connected; otherwise the server intentionally exits after one idle minute |
+| Remote browser cannot connect | Keep loopback binding and use an SSH tunnel, or review trusted-network routing explicitly |
+
+The implementation is under `sbk-api/src/main/java/io/sbk/dashboard`. `DashboardLoggerSupport` is shared by SBK,
+SBM, and SBK-GEM; `DashboardServer` owns run registration, bounded histories, browser leases, SSE, and idle shutdown.

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1165,7 +1165,7 @@ public non-sealed interface RWLogger
         extends Logger, CountRW, WriteRequestsLogger, ReadRequestsLogger, RWPrint { ... }
 ```
 
-Five shipping implementations:
+Six shipping implementations:
 
 | Class | Output target | When to use |
 |---|---|---|
@@ -1173,6 +1173,7 @@ Five shipping implementations:
 | `Sl4jLogger` | SLF4J facade | Integrating SBK into another Java app |
 | `CSVLogger` | CSV file | Post-run analysis with pandas / Excel |
 | `PrometheusLogger` | Prometheus scrape endpoint (port 9718) | Real-time Grafana dashboards |
+| `WebLogger` | Embedded HTTP server and browser dashboard (port 9720) | Dependency-free local live graphs |
 | `GrpcLogger` | gRPC to SBM | Distributed benchmarks (§6) |
 
 Selected at runtime by `-out <ClassName>`. The driver discovery and
@@ -2237,7 +2238,7 @@ Drop the class into `io.sbk.logger.impl`, run
 `./build/install/sbk/bin/sbk -class minio -out InfluxLogger ...`, and you have InfluxDB
 metrics. **No changes to the harness.**
 
-### 10.2 Five shipping logger options at a glance
+### 10.2 Six shipping logger options at a glance
 
 ```mermaid
 flowchart LR
@@ -2246,22 +2247,57 @@ flowchart LR
         SLF["<b>Sl4jLogger</b><br/>SLF4J facade"]
         CSV["<b>CSVLogger</b><br/>file output"]
         PRM["<b>PrometheusLogger</b><br/>:9718 scrape"]
-        GRP["<b>GrpcLogger</b><br/>→ SBM (gRPC)"]
+        WEB["<b>WebLogger</b><br/>:9720 local dashboard"]
+        GRP["<b>GrpcLogger</b><br/>to SBM (gRPC)"]
     end
     USE1["Local interactive"] --> SYS
     USE2["Embedded in Java app"] --> SLF
     USE3["Post-run analysis"] --> CSV
     USE4["Live dashboards"] --> PRM
-    USE5["Distributed runs"] --> GRP
+    USE5["Live graphs without Docker"] --> WEB
+    USE6["Distributed runs"] --> GRP
 
     classDef opt fill:#ecfeff,stroke:#0e7490,color:#000
-    class SYS,SLF,CSV,PRM,GRP opt
+    class SYS,SLF,CSV,PRM,WEB,GRP opt
 ```
 
 The selection is made via the `-out` flag (default `SystemLogger`). Select
 `-out PrometheusLogger` explicitly when an HTTP metrics endpoint is required.
+Select `-out WebLogger` when a self-contained browser dashboard is preferred.
 The same class-name discovery used for drivers is
 used for loggers, so adding a new one is purely additive.
+
+### 10.3 How WebLogger stays alive after a benchmark
+
+`WebLogger`, `SbmWebLogger`, and `GemWebLogger` use the same dashboard client
+and server protocol. The logger publishes the already-computed periodic and
+total summaries; it does not sample storage operations or insert HTTP work into
+the writer/reader hot path. The server keeps a bounded history and streams new
+summaries to browsers with server-sent events (SSE).
+
+```mermaid
+flowchart LR
+    HOT["Writer and reader hot paths"] --> PERL["PerL measurement pipeline"]
+    PERL --> SUMMARY["Periodic and total summaries"]
+    SUMMARY --> LOGGER["WebLogger family"]
+    LOGGER -->|HTTP publish| SERVER["Reusable dashboard server"]
+    SERVER --> HISTORY["Bounded run history"]
+    SERVER -->|SSE| BROWSER["Browser graphs"]
+
+    classDef hot fill:#fee2e2,stroke:#b91c1c,color:#000
+    classDef control fill:#e0f2fe,stroke:#0369a1,color:#000
+    classDef view fill:#dcfce7,stroke:#15803d,color:#000
+    class HOT,PERL hot
+    class SUMMARY,LOGGER,SERVER,HISTORY control
+    class BROWSER view
+```
+
+Only one benchmark owns a dashboard server at a time. A completed run remains
+available while a browser renews its lease. With no active SBK, SBM, or SBK-GEM
+publisher and no browser lease, the server exits after a one-minute idle grace
+period. A browser or new benchmark connecting during that grace period cancels
+the pending shutdown. See the [WebLogger guide](WEB_LOGGER.md) for commands,
+options, distributed modes, security, and troubleshooting.
 
 ---
 

--- a/drivers/file/README.md
+++ b/drivers/file/README.md
@@ -11,6 +11,27 @@ You may obtain a copy of the License at
 The File system driver for SBK supports single Writer , single reader and multiple readers performance benchmarking.
 SBK does not support the End to End latency for file system stream benchmarking.
 
+## Live filesystem read graphs with WebLogger
+
+WebLogger provides local live graphs without Docker, Prometheus, or Grafana. A read benchmark requires an existing
+file, and its record size must match the size used to create that file:
+
+```bash
+# Prepare a 1 GiB input file.
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -writers 1 -size 1024 -records 1048576
+
+# Benchmark reads for 60 seconds with live graphs at http://127.0.0.1:9720.
+./build/install/sbk/bin/sbk \
+  -class file -file /tmp/sbk-weblogger.dat \
+  -readers 1 -size 1024 -seconds 60 \
+  -out WebLogger
+```
+
+See the [WebLogger guide](../../docs/WEB_LOGGER.md) for dashboard options, lifecycle, distributed usage, and
+security guidance.
+
 ## File write Benchmarking with SBK and FIO
 The FIO (Flexible I/O tester) supports multiple files writing at a time. whereas SBK uses single file for write/read operation.
 Both FIO And SBK can be used with Write operations with buffering and writes can be with in sync (Sync to file system).
@@ -412,5 +433,4 @@ Total : File Reading     0 Writers,     1 Readers,      0 Max Writers,     1 Max
 
 
 ```
-
 

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import tools.jackson.databind.ObjectMapper;
+import io.sbk.system.Printer;
+
+import java.awt.Desktop;
+import java.awt.GraphicsEnvironment;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Non-blocking dashboard publisher used by SBK loggers.
+ */
+public final class DashboardClient implements AutoCloseable {
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(1);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration START_TIMEOUT = Duration.ofSeconds(10);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final HttpClient httpClient;
+    private final URI baseUri;
+    private final String runId;
+    private final ArrayBlockingQueue<DashboardSnapshot> pending;
+    private final AtomicBoolean closing;
+    private final Thread publisherThread;
+
+    private DashboardClient(HttpClient httpClient, URI baseUri, DashboardRun run) throws IOException,
+            InterruptedException {
+        this.httpClient = httpClient;
+        this.baseUri = baseUri;
+        this.runId = run.runId();
+        this.pending = new ArrayBlockingQueue<>(1);
+        this.closing = new AtomicBoolean(false);
+        postJson("/api/v1/runs", run, 201);
+        this.publisherThread = Thread.ofVirtual().name("sbk-dashboard-publisher-" + runId).start(this::publishLoop);
+    }
+
+    /**
+     * Connects to a compatible dashboard server, starting one when configured and necessary.
+     *
+     * @param config dashboard configuration
+     * @param run    benchmark run metadata
+     * @return connected asynchronous client
+     * @throws IOException if no compatible dashboard can be reached
+     * @throws InterruptedException if server startup is interrupted
+     */
+    public static DashboardClient connect(DashboardConfig config, DashboardRun run)
+            throws IOException, InterruptedException {
+        final URI baseUri = URI.create("http://" + config.host + ":" + config.port);
+        final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+        final Health health = health(httpClient, baseUri);
+        if (health == Health.INCOMPATIBLE) {
+            throw new IOException("Port " + config.port + " is not a compatible SBK dashboard server");
+        }
+        if (health == Health.UNAVAILABLE) {
+            if (!config.start) {
+                throw new IOException("SBK dashboard is unavailable and automatic startup is disabled");
+            }
+            startServer(config);
+            waitUntilHealthy(httpClient, baseUri);
+        }
+        final DashboardClient client = new DashboardClient(httpClient, baseUri, run);
+        if (config.open) {
+            client.openBrowser();
+        }
+        return client;
+    }
+
+    /**
+     * Returns the browser URL for this benchmark run.
+     *
+     * @return dashboard URL
+     */
+    public URI getRunUri() {
+        return URI.create(baseUri + "/?run=" + runId);
+    }
+
+    /**
+     * Offers a snapshot without waiting for network I/O. If publication is behind, the newest snapshot replaces the
+     * stale pending snapshot.
+     *
+     * @param snapshot latest benchmark summary
+     */
+    public void publish(DashboardSnapshot snapshot) {
+        if (closing.get() || pending.offer(snapshot)) {
+            return;
+        }
+        pending.poll();
+        pending.offer(snapshot);
+    }
+
+    @Override
+    public void close() {
+        if (!closing.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            publisherThread.join(REQUEST_TIMEOUT.toMillis() * 2);
+            postJson("/api/v1/runs/" + runId + "/complete", Map.of(), 204);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        } catch (IOException ex) {
+            Printer.log.warn("SBK dashboard completion notification failed: {}",
+                    Objects.toString(ex.getMessage(), ex.getClass().getSimpleName()));
+        }
+    }
+
+    private void publishLoop() {
+        while (!closing.get() || !pending.isEmpty()) {
+            try {
+                final DashboardSnapshot snapshot = pending.poll(250, TimeUnit.MILLISECONDS);
+                if (snapshot != null) {
+                    postJson("/api/v1/runs/" + runId + "/snapshots", snapshot, 204);
+                }
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (IOException ex) {
+                Printer.log.warn("SBK dashboard snapshot publication failed: {}",
+                        Objects.toString(ex.getMessage(), ex.getClass().getSimpleName()));
+            }
+        }
+    }
+
+    private void postJson(String path, Object body, int expectedStatus) throws IOException, InterruptedException {
+        final HttpRequest request = HttpRequest.newBuilder(baseUri.resolve(path))
+                .timeout(REQUEST_TIMEOUT)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofByteArray(MAPPER.writeValueAsBytes(body)))
+                .build();
+        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != expectedStatus) {
+            throw new IOException("Dashboard returned HTTP " + response.statusCode() + ": " + response.body());
+        }
+    }
+
+    private void openBrowser() {
+        if (GraphicsEnvironment.isHeadless() || !Desktop.isDesktopSupported()
+                || !Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            return;
+        }
+        Thread.ofVirtual().start(() -> {
+            try {
+                Desktop.getDesktop().browse(getRunUri());
+            } catch (IOException | UnsupportedOperationException ex) {
+                Printer.log.info("Open the SBK dashboard at {}", getRunUri());
+            }
+        });
+    }
+
+    private static Health health(HttpClient client, URI baseUri) {
+        final HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/api/v1/health"))
+                .timeout(CONNECT_TIMEOUT).GET().build();
+        try {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                return Health.INCOMPATIBLE;
+            }
+            final Map<?, ?> values = MAPPER.readValue(response.body(), Map.class);
+            return "sbk-dashboard".equals(values.get("service"))
+                    && Objects.equals(DashboardServer.API_VERSION, values.get("apiVersion"))
+                    ? Health.AVAILABLE : Health.INCOMPATIBLE;
+        } catch (IOException ex) {
+            return Health.UNAVAILABLE;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return Health.UNAVAILABLE;
+        }
+    }
+
+    private static void waitUntilHealthy(HttpClient client, URI baseUri) throws IOException, InterruptedException {
+        final long deadline = System.nanoTime() + START_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            final Health health = health(client, baseUri);
+            if (health == Health.AVAILABLE) {
+                return;
+            }
+            if (health == Health.INCOMPATIBLE) {
+                throw new IOException("Another application is using the configured dashboard port");
+            }
+            Thread.sleep(100);
+        }
+        throw new IOException("SBK dashboard did not become ready within " + START_TIMEOUT.toSeconds() + " seconds");
+    }
+
+    private static void startServer(DashboardConfig config) throws IOException {
+        final String javaExecutable = resolveJavaExecutable();
+        final ProcessBuilder builder = new ProcessBuilder(javaExecutable, "-XX:+UseCompactObjectHeaders", "-cp",
+                System.getProperty("java.class.path"), DashboardServerMain.class.getName(),
+                "-host", config.host, "-port", Integer.toString(config.port),
+                "-retention", Integer.toString(config.retention));
+        builder.redirectInput(ProcessBuilder.Redirect.PIPE);
+        builder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        builder.start();
+    }
+
+    @SuppressFBWarnings(value = "ENV_USE_PROPERTY_INSTEAD_OF_ENV",
+            justification = "SBK_JAVA_HOME and JAVA_HOME are documented SBK launcher overrides")
+    private static String resolveJavaExecutable() {
+        String javaHome = System.getenv("SBK_JAVA_HOME");
+        if (javaHome == null || javaHome.isBlank()) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+        if (javaHome == null || javaHome.isBlank()) {
+            javaHome = System.getProperty("java.home");
+        }
+        final String executable = System.getProperty("os.name", "").toLowerCase().contains("win")
+                ? "java.exe" : "java";
+        return Path.of(javaHome).toAbsolutePath().normalize().resolve("bin").resolve(executable).toString();
+    }
+
+    private enum Health {
+        AVAILABLE,
+        UNAVAILABLE,
+        INCOMPATIBLE
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
@@ -148,6 +148,9 @@ public final class DashboardClient implements AutoCloseable {
                 .POST(HttpRequest.BodyPublishers.ofByteArray(MAPPER.writeValueAsBytes(body)))
                 .build();
         final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 409) {
+            throw new DashboardBusyException(response.body());
+        }
         if (response.statusCode() != expectedStatus) {
             throw new IOException("Dashboard returned HTTP " + response.statusCode() + ": " + response.body());
         }
@@ -210,7 +213,7 @@ public final class DashboardClient implements AutoCloseable {
                 "-retention", Integer.toString(config.retention));
         builder.redirectInput(ProcessBuilder.Redirect.PIPE);
         builder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-        builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        builder.redirectError(ProcessBuilder.Redirect.DISCARD);
         builder.start();
     }
 
@@ -233,5 +236,17 @@ public final class DashboardClient implements AutoCloseable {
         AVAILABLE,
         UNAVAILABLE,
         INCOMPATIBLE
+    }
+
+    /** Indicates that another benchmark owns the dashboard's single active-run lease. */
+    public static final class DashboardBusyException extends IOException {
+        /**
+         * Creates a dashboard ownership exception.
+         *
+         * @param message ownership conflict details returned by the dashboard server
+         */
+        private DashboardBusyException(String message) {
+            super(message);
+        }
     }
 }

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardConfig.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardConfig.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+/**
+ * Configuration for the local SBK browser dashboard.
+ */
+public final class DashboardConfig {
+    /** Address on which the dashboard server listens. */
+    public String host;
+    /** TCP port used by the dashboard server. */
+    public int port;
+    /** Whether SBK may start the dashboard server when it is unavailable. */
+    public boolean start;
+    /** Whether SBK should open the dashboard in the default browser. */
+    public boolean open;
+    /** Maximum number of snapshots retained for each benchmark run. */
+    public int retention;
+    /** Optional human-readable benchmark name. */
+    public String name;
+
+    /**
+     * Creates an empty dashboard configuration for property binding.
+     */
+    public DashboardConfig() {
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.javaprop.JavaPropsFactory;
+import io.sbk.action.Action;
+import io.sbk.api.impl.Sbk;
+import io.sbk.params.InputOptions;
+import io.sbk.params.ParsedOptions;
+import io.sbk.system.Printer;
+import io.time.TimeUnit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Shared dashboard configuration, lifecycle, and snapshot construction for SBK, SBM, and GEM loggers.
+ */
+public final class DashboardLoggerSupport implements AutoCloseable {
+    /** Dashboard host CLI option. */
+    public static final String HOST_OPTION = "dashboardhost";
+    /** Dashboard port CLI option. */
+    public static final String PORT_OPTION = "dashboardport";
+    /** Dashboard automatic-start CLI option. */
+    public static final String START_OPTION = "dashboardstart";
+    /** Dashboard browser-open CLI option. */
+    public static final String OPEN_OPTION = "dashboardopen";
+    /** Dashboard retention CLI option. */
+    public static final String RETENTION_OPTION = "dashboardretention";
+    /** Dashboard run-name CLI option. */
+    public static final String NAME_OPTION = "dashboardname";
+    private static final String CONFIG_FILE = "dashboard.properties";
+    private DashboardConfig config;
+    private DashboardClient client;
+    private String runId;
+    private double[] percentiles;
+
+    /**
+     * Creates dashboard support with configuration loaded when arguments are added.
+     */
+    public DashboardLoggerSupport() {
+    }
+
+    /**
+     * Adds dashboard-specific command-line options.
+     *
+     * @param params input option registry
+     */
+    public void addArgs(InputOptions params) {
+        config = loadConfig();
+        params.addOption(HOST_OPTION, true, "Local dashboard host; default: " + config.host);
+        params.addOption(PORT_OPTION, true, "Local dashboard port; default: " + config.port);
+        params.addOption(START_OPTION, true, "Start dashboard server when unavailable; default: " + config.start);
+        params.addOption(OPEN_OPTION, true, "Open dashboard in the local browser; default: " + config.open);
+        params.addOption(RETENTION_OPTION, true, "Snapshots retained per run; default: " + config.retention);
+        params.addOption(NAME_OPTION, true, "Optional dashboard run name; default: empty");
+    }
+
+    /**
+     * Parses dashboard-specific options.
+     *
+     * @param params parsed command-line options
+     * @throws IllegalArgumentException if a dashboard option is invalid
+     */
+    public void parseArgs(ParsedOptions params) {
+        ensureConfig();
+        config.host = params.getOptionValue(HOST_OPTION, config.host);
+        config.port = Integer.parseInt(params.getOptionValue(PORT_OPTION, Integer.toString(config.port)));
+        config.start = Boolean.parseBoolean(params.getOptionValue(START_OPTION, Boolean.toString(config.start)));
+        config.open = Boolean.parseBoolean(params.getOptionValue(OPEN_OPTION, Boolean.toString(config.open)));
+        config.retention = Integer.parseInt(params.getOptionValue(RETENTION_OPTION,
+                Integer.toString(config.retention)));
+        config.name = params.getOptionValue(NAME_OPTION, Objects.requireNonNullElse(config.name, ""));
+        if (config.port < 1 || config.port > 65535) {
+            throw new IllegalArgumentException("Dashboard port must be between 1 and 65535");
+        }
+        if (config.retention < 1) {
+            throw new IllegalArgumentException("Dashboard retention must be greater than zero");
+        }
+    }
+
+    /**
+     * Starts or reuses the local dashboard and registers a benchmark run.
+     *
+     * @param source      source application name
+     * @param storage     storage driver name
+     * @param action      benchmark action
+     * @param timeUnit    latency time unit
+     * @param percentiles configured percentile labels
+     */
+    public void open(String source, String storage, Action action, TimeUnit timeUnit, double[] percentiles) {
+        ensureConfig();
+        this.percentiles = percentiles.clone();
+        this.runId = UUID.randomUUID().toString();
+        final String version = Objects.requireNonNullElse(Sbk.class.getPackage().getImplementationVersion(), "dev");
+        final DashboardRun run = new DashboardRun(runId, config.name, source, storage, action.name(),
+                timeUnit.name(), version, System.getProperty("java.runtime.version"), System.currentTimeMillis());
+        try {
+            client = DashboardClient.connect(config, run);
+            Printer.log.info("SBK Dashboard: {}", client.getRunUri());
+        } catch (IOException ex) {
+            client = null;
+            Printer.log.warn("SBK dashboard is unavailable; benchmark will continue without live graphs: {}",
+                    ex.getMessage());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            client = null;
+            Printer.log.warn("SBK dashboard startup was interrupted; benchmark will continue without live graphs");
+        }
+    }
+
+    /**
+     * Publishes one periodic or total snapshot without blocking the caller on HTTP I/O.
+     *
+     * @param total                           whether this is the final total
+     * @param connections                     active connections
+     * @param maxConnections                  maximum connections
+     * @param writers                         active writers
+     * @param maxWriters                      maximum writers
+     * @param readers                         active readers
+     * @param maxReaders                      maximum readers
+     * @param writeRequestBytes               write request bytes
+     * @param writeRequestMbPerSec            write request throughput
+     * @param writeRequestRecords             write request records
+     * @param writeRequestRecordsPerSec       write request rate
+     * @param readRequestBytes                read request bytes
+     * @param readRequestMbPerSec             read request throughput
+     * @param readRequestRecords              read request records
+     * @param readRequestRecordsPerSec        read request rate
+     * @param writeResponsePendingRecords     pending write records
+     * @param writeResponsePendingBytes       pending write bytes
+     * @param readResponsePendingRecords      pending read records
+     * @param readResponsePendingBytes        pending read bytes
+     * @param writeReadRequestPendingRecords  pending combined records
+     * @param writeReadRequestPendingBytes    pending combined bytes
+     * @param writeTimeoutEvents              write timeout events
+     * @param writeTimeoutEventsPerSec        write timeout rate
+     * @param readTimeoutEvents               read timeout events
+     * @param readTimeoutEventsPerSec         read timeout rate
+     * @param seconds                         elapsed seconds
+     * @param bytes                           completed bytes
+     * @param records                         completed records
+     * @param recordsPerSec                   completed record rate
+     * @param mbPerSec                        completed throughput
+     * @param averageLatency                  average latency
+     * @param minimumLatency                  minimum latency
+     * @param maximumLatency                  maximum latency
+     * @param invalid                         invalid latencies
+     * @param lowerDiscard                    low discarded latencies
+     * @param higherDiscard                   high discarded latencies
+     * @param slc1                            first SLC count
+     * @param slc2                            second SLC count
+     * @param percentileLatencies             percentile values
+     * @param percentileLatencyCounts         percentile counts
+     */
+    public void publish(boolean total, int connections, int maxConnections, int writers, int maxWriters,
+                        int readers, int maxReaders, long writeRequestBytes, double writeRequestMbPerSec,
+                        long writeRequestRecords, double writeRequestRecordsPerSec, long readRequestBytes,
+                        double readRequestMbPerSec, long readRequestRecords, double readRequestRecordsPerSec,
+                        long writeResponsePendingRecords, long writeResponsePendingBytes,
+                        long readResponsePendingRecords, long readResponsePendingBytes,
+                        long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                        long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                        double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                        double recordsPerSec, double mbPerSec, double averageLatency, long minimumLatency,
+                        long maximumLatency, long invalid, long lowerDiscard, long higherDiscard,
+                        long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
+        if (client == null) {
+            return;
+        }
+        final DashboardSnapshot.WorkerMetrics workers = new DashboardSnapshot.WorkerMetrics(writers, maxWriters,
+                readers, maxReaders, connections, maxConnections);
+        final DashboardSnapshot.RequestMetrics requests = new DashboardSnapshot.RequestMetrics(writeRequestBytes,
+                writeRequestRecords, writeRequestMbPerSec, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestRecords, readRequestMbPerSec, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec);
+        final DashboardSnapshot.PerformanceMetrics performance = new DashboardSnapshot.PerformanceMetrics(seconds,
+                bytes, records, recordsPerSec, mbPerSec);
+        final DashboardSnapshot.LatencyMetrics latency = new DashboardSnapshot.LatencyMetrics(averageLatency,
+                minimumLatency, maximumLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentiles,
+                percentileLatencies, percentileLatencyCounts);
+        client.publish(new DashboardSnapshot(runId, System.currentTimeMillis(), total, workers, requests,
+                performance, latency));
+    }
+
+    /**
+     * Returns dashboard option names, including the command-line prefix.
+     *
+     * @return dashboard options
+     */
+    public String[] getOptionsArgs() {
+        return new String[]{"-" + HOST_OPTION, "-" + PORT_OPTION, "-" + START_OPTION, "-" + OPEN_OPTION,
+                "-" + RETENTION_OPTION, "-" + NAME_OPTION};
+    }
+
+    /**
+     * Returns the current dashboard option/value pairs for forwarding to SBM.
+     *
+     * @return parsed dashboard arguments
+     */
+    public String[] getParsedArgs() {
+        ensureConfig();
+        return new String[]{"-" + HOST_OPTION, config.host, "-" + PORT_OPTION, Integer.toString(config.port),
+                "-" + START_OPTION, Boolean.toString(config.start), "-" + OPEN_OPTION,
+                Boolean.toString(config.open), "-" + RETENTION_OPTION, Integer.toString(config.retention),
+                "-" + NAME_OPTION, Objects.requireNonNullElse(config.name, "")};
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    private static DashboardConfig loadConfig() {
+        try (InputStream input = DashboardLoggerSupport.class.getClassLoader().getResourceAsStream(CONFIG_FILE)) {
+            return new ObjectMapper(new JavaPropsFactory()).readValue(input, DashboardConfig.class);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to load " + CONFIG_FILE, ex);
+        }
+    }
+
+    private void ensureConfig() {
+        if (config == null) {
+            config = loadConfig();
+        }
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
@@ -97,8 +97,10 @@ public final class DashboardLoggerSupport implements AutoCloseable {
      * @param action      benchmark action
      * @param timeUnit    latency time unit
      * @param percentiles configured percentile labels
+     * @throws IOException if another benchmark is already using the dashboard
      */
-    public void open(String source, String storage, Action action, TimeUnit timeUnit, double[] percentiles) {
+    public void open(String source, String storage, Action action, TimeUnit timeUnit, double[] percentiles)
+            throws IOException {
         ensureConfig();
         this.percentiles = percentiles.clone();
         this.runId = UUID.randomUUID().toString();
@@ -108,6 +110,10 @@ public final class DashboardLoggerSupport implements AutoCloseable {
         try {
             client = DashboardClient.connect(config, run);
             Printer.log.info("SBK Dashboard: {}", client.getRunUri());
+        } catch (DashboardClient.DashboardBusyException ex) {
+            client = null;
+            Printer.log.error("{} WebLogger cannot start: {}", source, ex.getMessage());
+            throw ex;
         } catch (IOException ex) {
             client = null;
             Printer.log.warn("SBK dashboard is unavailable; benchmark will continue without live graphs: {}",

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardRun.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardRun.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+/**
+ * Describes one SBK benchmark displayed by the dashboard.
+ *
+ * @param runId       unique run identifier
+ * @param name        optional user-provided run name
+ * @param source      source application, such as SBK or SBM
+ * @param storage     storage driver name
+ * @param action      benchmark action
+ * @param timeUnit    latency time unit
+ * @param sbkVersion  SBK implementation version
+ * @param javaVersion Java runtime version
+ * @param startedAt   run start time in epoch milliseconds
+ */
+public record DashboardRun(String runId, String name, String source, String storage, String action,
+                           String timeUnit, String sbkVersion, String javaVersion, long startedAt) {
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,24 +26,42 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Lightweight local HTTP server that stores bounded SBK histories and serves the browser dashboard.
  */
 public final class DashboardServer implements AutoCloseable {
     /** Dashboard HTTP API version. */
-    public static final int API_VERSION = 1;
+    public static final int API_VERSION = 2;
+    /** Time an unused dashboard remains available after its benchmark exits. */
+    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(1);
+    private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(5);
     private static final String API_PREFIX = "/api/v1/";
     private static final String RESOURCE_PREFIX = "/dashboard/";
     private static final String SSE_OWNED_ATTRIBUTE = "sbk.dashboard.sseOwned";
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private final HttpServer server;
     private final ExecutorService executor;
+    private final ScheduledExecutorService scheduler;
     private final int retention;
     private final ConcurrentHashMap<String, RunState> runs;
+    private final Duration idleTimeout;
+    private final Duration heartbeatInterval;
+    private final Object lifecycleLock;
+    private final AtomicBoolean closed;
+    private final CountDownLatch termination;
+    private final Map<String, Long> browsers;
+    private String activeRunId;
+    private ScheduledFuture<?> idleShutdown;
+    private boolean shuttingDown;
 
     /**
      * Creates a dashboard server bound to the supplied address.
@@ -54,13 +73,43 @@ public final class DashboardServer implements AutoCloseable {
      * @throws IllegalArgumentException if retention is not positive
      */
     public DashboardServer(String host, int port, int retention) throws IOException {
+        this(host, port, retention, DEFAULT_IDLE_TIMEOUT, DEFAULT_HEARTBEAT_INTERVAL);
+    }
+
+    /**
+     * Creates a dashboard server with configurable lifecycle timings.
+     *
+     * @param host              local address on which to listen
+     * @param port              TCP port
+     * @param retention         maximum snapshots retained per run
+     * @param idleTimeout       delay before an inactive dashboard without browsers stops
+     * @param heartbeatInterval interval used to detect disconnected browser event streams
+     * @throws IOException if the server cannot bind
+     * @throws IllegalArgumentException if a size or duration is not positive
+     */
+    DashboardServer(String host, int port, int retention, Duration idleTimeout, Duration heartbeatInterval)
+            throws IOException {
         if (retention < 1) {
             throw new IllegalArgumentException("Dashboard retention must be greater than zero");
         }
+        if (idleTimeout.isZero() || idleTimeout.isNegative()) {
+            throw new IllegalArgumentException("Dashboard idle timeout must be greater than zero");
+        }
+        if (heartbeatInterval.isZero() || heartbeatInterval.isNegative()) {
+            throw new IllegalArgumentException("Dashboard heartbeat interval must be greater than zero");
+        }
         this.retention = retention;
+        this.idleTimeout = idleTimeout;
+        this.heartbeatInterval = heartbeatInterval;
         this.runs = new ConcurrentHashMap<>();
+        this.lifecycleLock = new Object();
+        this.closed = new AtomicBoolean();
+        this.termination = new CountDownLatch(1);
+        this.browsers = new ConcurrentHashMap<>();
         this.server = HttpServer.create(new InetSocketAddress(host, port), 32);
         this.executor = Executors.newVirtualThreadPerTaskExecutor();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(Thread.ofPlatform()
+                .name("sbk-dashboard-idle-monitor").daemon().factory());
         server.setExecutor(executor);
         server.createContext(API_PREFIX, this::handleApi);
         server.createContext("/", this::handleResource);
@@ -82,11 +131,29 @@ public final class DashboardServer implements AutoCloseable {
         return server.getAddress();
     }
 
+    /**
+     * Waits until this server is closed explicitly or by its idle lifecycle policy.
+     *
+     * @throws InterruptedException if the waiting thread is interrupted
+     */
+    public void awaitTermination() throws InterruptedException {
+        termination.await();
+    }
+
     @Override
     public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        synchronized (lifecycleLock) {
+            shuttingDown = true;
+            cancelIdleShutdown();
+        }
         runs.values().forEach(RunState::close);
         server.stop(0);
+        scheduler.shutdown();
         executor.close();
+        termination.countDown();
     }
 
     private void handleApi(HttpExchange exchange) throws IOException {
@@ -108,9 +175,30 @@ public final class DashboardServer implements AutoCloseable {
                         sendText(exchange, 400, "runId is required", "text/plain; charset=utf-8");
                         return;
                     }
-                    runs.computeIfAbsent(run.runId(), ignored -> new RunState(run, retention));
-                    sendJson(exchange, 201, run);
+                    final String conflict = register(run);
+                    if (conflict != null) {
+                        sendText(exchange, 409, conflict, "text/plain; charset=utf-8");
+                    } else {
+                        sendJson(exchange, 201, run);
+                    }
                 }
+                return;
+            }
+            if ((API_PREFIX + "browser/connect").equals(path)
+                    || (API_PREFIX + "browser/disconnect").equals(path)) {
+                requireMethod(exchange, "POST");
+                final Map<?, ?> request = MAPPER.readValue(exchange.getRequestBody(), Map.class);
+                final String browserId = Objects.toString(request.get("browserId"), "");
+                if (browserId.isBlank()) {
+                    sendText(exchange, 400, "browserId is required", "text/plain; charset=utf-8");
+                    return;
+                }
+                if (path.endsWith("/connect")) {
+                    browserSeen(browserId);
+                } else {
+                    browserGone(browserId);
+                }
+                exchange.sendResponseHeaders(204, -1);
                 return;
             }
             handleRunApi(exchange, path);
@@ -154,6 +242,7 @@ public final class DashboardServer implements AutoCloseable {
             case "complete" -> {
                 requireMethod(exchange, "POST");
                 state.complete();
+                benchmarkCompleted(state.run.runId());
                 exchange.sendResponseHeaders(204, -1);
             }
             case "history" -> {
@@ -233,7 +322,90 @@ public final class DashboardServer implements AutoCloseable {
         }
     }
 
-    private static final class RunState {
+    private String register(DashboardRun run) {
+        synchronized (lifecycleLock) {
+            if (shuttingDown) {
+                return "SBK dashboard is shutting down; retry the benchmark";
+            }
+            if (activeRunId != null) {
+                final RunState active = runs.get(activeRunId);
+                final String owner = active == null ? activeRunId
+                        : active.run.source() + " run " + active.run.runId();
+                return "SBK dashboard is already in use by active " + owner
+                        + "; only one SBK, SBM, or SBK-GEM WebLogger benchmark may run at a time";
+            }
+            if (runs.putIfAbsent(run.runId(), new RunState(run, retention)) != null) {
+                return "Dashboard runId already exists: " + run.runId();
+            }
+            cancelIdleShutdown();
+            activeRunId = run.runId();
+            return null;
+        }
+    }
+
+    private void benchmarkCompleted(String runId) {
+        synchronized (lifecycleLock) {
+            if (runId.equals(activeRunId)) {
+                activeRunId = null;
+                scheduleIdleShutdownIfUnused();
+            }
+        }
+    }
+
+    private void browserSeen(String browserId) {
+        synchronized (lifecycleLock) {
+            browsers.put(browserId, System.currentTimeMillis());
+            if (activeRunId == null) {
+                scheduleIdleShutdownIfUnused();
+            }
+        }
+    }
+
+    private void browserGone(String browserId) {
+        synchronized (lifecycleLock) {
+            browsers.remove(browserId);
+            if (activeRunId == null) {
+                scheduleIdleShutdownIfUnused();
+            }
+        }
+    }
+
+    private void scheduleIdleShutdownIfUnused() {
+        if (activeRunId != null || shuttingDown) {
+            return;
+        }
+        cancelIdleShutdown();
+        final long now = System.currentTimeMillis();
+        final long lastBrowserSeen = browsers.values().stream().mapToLong(Long::longValue).max().orElse(now);
+        final long delay = Math.max(1, lastBrowserSeen + idleTimeout.toMillis() - now);
+        idleShutdown = scheduler.schedule(this::closeIfUnused, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void closeIfUnused() {
+        synchronized (lifecycleLock) {
+            idleShutdown = null;
+            if (activeRunId != null || shuttingDown) {
+                return;
+            }
+            final long expiry = System.currentTimeMillis() - idleTimeout.toMillis();
+            browsers.entrySet().removeIf(entry -> entry.getValue() <= expiry);
+            if (!browsers.isEmpty()) {
+                scheduleIdleShutdownIfUnused();
+                return;
+            }
+            shuttingDown = true;
+        }
+        close();
+    }
+
+    private void cancelIdleShutdown() {
+        if (idleShutdown != null) {
+            idleShutdown.cancel(false);
+            idleShutdown = null;
+        }
+    }
+
+    private final class RunState {
         private final DashboardRun run;
         private final int retention;
         private final ArrayDeque<DashboardSnapshot> history;
@@ -275,7 +447,7 @@ public final class DashboardServer implements AutoCloseable {
             exchange.getResponseHeaders().set("Cache-Control", "no-cache");
             exchange.getResponseHeaders().set("Connection", "keep-alive");
             exchange.sendResponseHeaders(200, 0);
-            final SseClient client = new SseClient(exchange.getResponseBody());
+            final SseClient client = new SseClient(exchange.getResponseBody(), heartbeatInterval);
             clients.add(client);
             try {
                 client.run();
@@ -299,11 +471,13 @@ public final class DashboardServer implements AutoCloseable {
         private static final String WAKE_EVENT = "";
         private final OutputStream output;
         private final ArrayBlockingQueue<String> events;
+        private final Duration heartbeatInterval;
         private volatile boolean open;
 
-        private SseClient(OutputStream output) {
+        private SseClient(OutputStream output, Duration heartbeatInterval) {
             this.output = output;
             this.events = new ArrayBlockingQueue<>(1);
+            this.heartbeatInterval = heartbeatInterval;
             this.open = true;
         }
 
@@ -319,11 +493,11 @@ public final class DashboardServer implements AutoCloseable {
             output.flush();
             while (open) {
                 try {
-                    final String event = events.take();
+                    final String event = events.poll(heartbeatInterval.toMillis(), TimeUnit.MILLISECONDS);
                     if (!open) {
                         return;
                     }
-                    output.write(event.getBytes(StandardCharsets.UTF_8));
+                    output.write((event == null ? ": heartbeat\n\n" : event).getBytes(StandardCharsets.UTF_8));
                     output.flush();
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Lightweight local HTTP server that stores bounded SBK histories and serves the browser dashboard.
+ */
+public final class DashboardServer implements AutoCloseable {
+    /** Dashboard HTTP API version. */
+    public static final int API_VERSION = 1;
+    private static final String API_PREFIX = "/api/v1/";
+    private static final String RESOURCE_PREFIX = "/dashboard/";
+    private static final String SSE_OWNED_ATTRIBUTE = "sbk.dashboard.sseOwned";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final HttpServer server;
+    private final ExecutorService executor;
+    private final int retention;
+    private final ConcurrentHashMap<String, RunState> runs;
+
+    /**
+     * Creates a dashboard server bound to the supplied address.
+     *
+     * @param host      local address on which to listen
+     * @param port      TCP port
+     * @param retention maximum snapshots retained per run
+     * @throws IOException if the server cannot bind
+     * @throws IllegalArgumentException if retention is not positive
+     */
+    public DashboardServer(String host, int port, int retention) throws IOException {
+        if (retention < 1) {
+            throw new IllegalArgumentException("Dashboard retention must be greater than zero");
+        }
+        this.retention = retention;
+        this.runs = new ConcurrentHashMap<>();
+        this.server = HttpServer.create(new InetSocketAddress(host, port), 32);
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
+        server.setExecutor(executor);
+        server.createContext(API_PREFIX, this::handleApi);
+        server.createContext("/", this::handleResource);
+    }
+
+    /**
+     * Starts accepting dashboard connections.
+     */
+    public void start() {
+        server.start();
+    }
+
+    /**
+     * Returns the actual bound address.
+     *
+     * @return server address
+     */
+    public InetSocketAddress getAddress() {
+        return server.getAddress();
+    }
+
+    @Override
+    public void close() {
+        runs.values().forEach(RunState::close);
+        server.stop(0);
+        executor.close();
+    }
+
+    private void handleApi(HttpExchange exchange) throws IOException {
+        try {
+            final String path = exchange.getRequestURI().getPath();
+            if ((API_PREFIX + "health").equals(path)) {
+                requireMethod(exchange, "GET");
+                sendJson(exchange, 200, Map.of("service", "sbk-dashboard", "apiVersion", API_VERSION,
+                        "status", "ready"));
+                return;
+            }
+            if ((API_PREFIX + "runs").equals(path)) {
+                if ("GET".equals(exchange.getRequestMethod())) {
+                    sendJson(exchange, 200, runs.values().stream().map(RunState::view).toList());
+                } else {
+                    requireMethod(exchange, "POST");
+                    final DashboardRun run = MAPPER.readValue(exchange.getRequestBody(), DashboardRun.class);
+                    if (run.runId() == null || run.runId().isBlank()) {
+                        sendText(exchange, 400, "runId is required", "text/plain; charset=utf-8");
+                        return;
+                    }
+                    runs.computeIfAbsent(run.runId(), ignored -> new RunState(run, retention));
+                    sendJson(exchange, 201, run);
+                }
+                return;
+            }
+            handleRunApi(exchange, path);
+        } catch (MethodNotAllowedException ex) {
+            sendText(exchange, 405, ex.getMessage(), "text/plain; charset=utf-8");
+        } catch (IllegalArgumentException ex) {
+            sendText(exchange, 400, ex.getMessage(), "text/plain; charset=utf-8");
+        } catch (Exception ex) {
+            sendText(exchange, 500, Objects.toString(ex.getMessage(), ex.getClass().getSimpleName()),
+                    "text/plain; charset=utf-8");
+        } finally {
+            if (!Boolean.TRUE.equals(exchange.getAttribute(SSE_OWNED_ATTRIBUTE))) {
+                exchange.close();
+            }
+        }
+    }
+
+    private void handleRunApi(HttpExchange exchange, String path) throws IOException {
+        final String relative = path.substring(API_PREFIX.length());
+        final String[] elements = relative.split("/");
+        if (elements.length != 3 || !"runs".equals(elements[0])) {
+            sendText(exchange, 404, "Not found", "text/plain; charset=utf-8");
+            return;
+        }
+        final RunState state = runs.get(elements[1]);
+        if (state == null) {
+            sendText(exchange, 404, "Unknown dashboard run", "text/plain; charset=utf-8");
+            return;
+        }
+        switch (elements[2]) {
+            case "snapshots" -> {
+                requireMethod(exchange, "POST");
+                final DashboardSnapshot snapshot = MAPPER.readValue(exchange.getRequestBody(),
+                        DashboardSnapshot.class);
+                if (!state.run.runId().equals(snapshot.runId())) {
+                    throw new IllegalArgumentException("Snapshot runId does not match URL");
+                }
+                state.add(snapshot);
+                exchange.sendResponseHeaders(204, -1);
+            }
+            case "complete" -> {
+                requireMethod(exchange, "POST");
+                state.complete();
+                exchange.sendResponseHeaders(204, -1);
+            }
+            case "history" -> {
+                requireMethod(exchange, "GET");
+                sendJson(exchange, 200, state.history());
+            }
+            case "events" -> {
+                requireMethod(exchange, "GET");
+                state.events(exchange);
+            }
+            default -> sendText(exchange, 404, "Not found", "text/plain; charset=utf-8");
+        }
+    }
+
+    private void handleResource(HttpExchange exchange) throws IOException {
+        try {
+            requireMethod(exchange, "GET");
+            final String path = exchange.getRequestURI().getPath();
+            final String resource;
+            final String contentType;
+            if ("/".equals(path) || "/index.html".equals(path)) {
+                resource = RESOURCE_PREFIX + "index.html";
+                contentType = "text/html; charset=utf-8";
+            } else if ("/app.js".equals(path)) {
+                resource = RESOURCE_PREFIX + "app.js";
+                contentType = "text/javascript; charset=utf-8";
+            } else if ("/style.css".equals(path)) {
+                resource = RESOURCE_PREFIX + "style.css";
+                contentType = "text/css; charset=utf-8";
+            } else {
+                sendText(exchange, 404, "Not found", "text/plain; charset=utf-8");
+                return;
+            }
+            try (InputStream input = DashboardServer.class.getResourceAsStream(resource)) {
+                if (input == null) {
+                    sendText(exchange, 404, "Dashboard resource not found", "text/plain; charset=utf-8");
+                    return;
+                }
+                final byte[] body = input.readAllBytes();
+                exchange.getResponseHeaders().set("Content-Type", contentType);
+                exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream output = exchange.getResponseBody()) {
+                    output.write(body);
+                }
+            }
+        } catch (MethodNotAllowedException ex) {
+            sendText(exchange, 405, ex.getMessage(), "text/plain; charset=utf-8");
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private static void requireMethod(HttpExchange exchange, String method) {
+        if (!method.equals(exchange.getRequestMethod())) {
+            throw new MethodNotAllowedException("Expected " + method);
+        }
+    }
+
+    private static void sendJson(HttpExchange exchange, int status, Object body) throws IOException {
+        final byte[] bytes = MAPPER.writeValueAsBytes(body);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.getResponseHeaders().set("Cache-Control", "no-store");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(bytes);
+        }
+    }
+
+    private static void sendText(HttpExchange exchange, int status, String body, String contentType)
+            throws IOException {
+        final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", contentType);
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(bytes);
+        }
+    }
+
+    private static final class RunState {
+        private final DashboardRun run;
+        private final int retention;
+        private final ArrayDeque<DashboardSnapshot> history;
+        private final CopyOnWriteArrayList<SseClient> clients;
+        private volatile boolean completed;
+
+        private RunState(DashboardRun run, int retention) {
+            this.run = run;
+            this.retention = retention;
+            this.history = new ArrayDeque<>(retention);
+            this.clients = new CopyOnWriteArrayList<>();
+        }
+
+        private synchronized void add(DashboardSnapshot snapshot) throws IOException {
+            if (history.size() == retention) {
+                history.removeFirst();
+            }
+            history.addLast(snapshot);
+            final String event = "event: snapshot\ndata: " + MAPPER.writeValueAsString(snapshot) + "\n\n";
+            clients.forEach(client -> client.offer(event));
+        }
+
+        private synchronized List<DashboardSnapshot> history() {
+            return new ArrayList<>(history);
+        }
+
+        private void complete() {
+            completed = true;
+            clients.forEach(client -> client.offer("event: complete\ndata: {}\n\n"));
+        }
+
+        private DashboardRunView view() {
+            return new DashboardRunView(run, completed);
+        }
+
+        private void events(HttpExchange exchange) throws IOException {
+            exchange.setAttribute(SSE_OWNED_ATTRIBUTE, Boolean.TRUE);
+            exchange.getResponseHeaders().set("Content-Type", "text/event-stream; charset=utf-8");
+            exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+            exchange.getResponseHeaders().set("Connection", "keep-alive");
+            exchange.sendResponseHeaders(200, 0);
+            final SseClient client = new SseClient(exchange.getResponseBody());
+            clients.add(client);
+            try {
+                client.run();
+            } finally {
+                clients.remove(client);
+                client.close();
+                exchange.close();
+            }
+        }
+
+        private void close() {
+            clients.forEach(SseClient::close);
+            clients.clear();
+        }
+    }
+
+    private record DashboardRunView(DashboardRun run, boolean completed) {
+    }
+
+    private static final class SseClient implements AutoCloseable {
+        private static final String WAKE_EVENT = "";
+        private final OutputStream output;
+        private final ArrayBlockingQueue<String> events;
+        private volatile boolean open;
+
+        private SseClient(OutputStream output) {
+            this.output = output;
+            this.events = new ArrayBlockingQueue<>(1);
+            this.open = true;
+        }
+
+        private void offer(String event) {
+            if (!events.offer(event)) {
+                events.poll();
+                events.offer(event);
+            }
+        }
+
+        private void run() throws IOException {
+            output.write("retry: 2000\n\n".getBytes(StandardCharsets.UTF_8));
+            output.flush();
+            while (open) {
+                try {
+                    final String event = events.take();
+                    if (!open) {
+                        return;
+                    }
+                    output.write(event.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            open = false;
+            offer(WAKE_EVENT);
+            try {
+                output.close();
+            } catch (IOException ignored) {
+                // The browser may have already closed the connection.
+            }
+        }
+    }
+
+    private static final class MethodNotAllowedException extends IllegalArgumentException {
+        private MethodNotAllowedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
@@ -10,7 +10,6 @@
 package io.sbk.dashboard;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Standalone entry point for the reusable local SBK dashboard server.
@@ -49,6 +48,6 @@ public abstract class DashboardServerMain {
         final DashboardServer dashboardServer = new DashboardServer(host, port, retention);
         Runtime.getRuntime().addShutdownHook(new Thread(dashboardServer::close));
         dashboardServer.start();
-        new CountDownLatch(1).await();
+        dashboardServer.awaitTermination();
     }
 }

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Standalone entry point for the reusable local SBK dashboard server.
+ */
+public abstract class DashboardServerMain {
+
+    /**
+     * Creates a dashboard server entry point.
+     */
+    public DashboardServerMain() {
+    }
+
+    /**
+     * Starts the dashboard server and waits until the process is terminated.
+     *
+     * @param args {@code -host}, {@code -port}, and {@code -retention} options
+     * @throws IOException if the server cannot start
+     * @throws InterruptedException if the process is interrupted
+     * @throws IllegalArgumentException if an option or value is invalid
+     */
+    public static void main(String[] args) throws IOException, InterruptedException {
+        String host = "127.0.0.1";
+        int port = 9720;
+        int retention = 3600;
+        for (int index = 0; index < args.length; index += 2) {
+            if (index + 1 >= args.length) {
+                throw new IllegalArgumentException("Missing dashboard option value for " + args[index]);
+            }
+            switch (args[index]) {
+                case "-host" -> host = args[index + 1];
+                case "-port" -> port = Integer.parseInt(args[index + 1]);
+                case "-retention" -> retention = Integer.parseInt(args[index + 1]);
+                default -> throw new IllegalArgumentException("Unknown dashboard option " + args[index]);
+            }
+        }
+        final DashboardServer dashboardServer = new DashboardServer(host, port, retention);
+        Runtime.getRuntime().addShutdownHook(new Thread(dashboardServer::close));
+        dashboardServer.start();
+        new CountDownLatch(1).await();
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardSnapshot.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardSnapshot.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+/**
+ * Immutable benchmark summary sent from an SBK logger to the dashboard.
+ *
+ * @param runId       benchmark run identifier
+ * @param timestamp   snapshot time in epoch milliseconds
+ * @param total       whether this is the final cumulative snapshot
+ * @param workers     active and maximum worker/connection counts
+ * @param requests    request, pending-operation, and timeout statistics
+ * @param performance completed data and throughput statistics
+ * @param latency     latency distribution summary
+ */
+public record DashboardSnapshot(String runId, long timestamp, boolean total, WorkerMetrics workers,
+                                RequestMetrics requests, PerformanceMetrics performance,
+                                LatencyMetrics latency) {
+
+    /**
+     * Worker and distributed-connection counts.
+     *
+     * @param writers        active writers
+     * @param maxWriters     maximum writers
+     * @param readers        active readers
+     * @param maxReaders     maximum readers
+     * @param connections    active SBM connections
+     * @param maxConnections maximum SBM connections
+     */
+    public record WorkerMetrics(int writers, int maxWriters, int readers, int maxReaders,
+                                int connections, int maxConnections) {
+    }
+
+    /**
+     * Request-side statistics for a reporting window.
+     *
+     * @param writeBytes              write-request bytes
+     * @param writeRecords            write-request records
+     * @param writeMbPerSec           write-request throughput
+     * @param writeRecordsPerSec      write-request rate
+     * @param readBytes               read-request bytes
+     * @param readRecords             read-request records
+     * @param readMbPerSec            read-request throughput
+     * @param readRecordsPerSec       read-request rate
+     * @param pendingWriteRecords     pending write-response records
+     * @param pendingWriteBytes       pending write-response bytes
+     * @param pendingReadRecords      pending read-response records
+     * @param pendingReadBytes        pending read-response bytes
+     * @param pendingCombinedRecords  pending combined request records
+     * @param pendingCombinedBytes    pending combined request bytes
+     * @param writeTimeouts           write timeout events
+     * @param writeTimeoutsPerSec     write timeout event rate
+     * @param readTimeouts            read timeout events
+     * @param readTimeoutsPerSec      read timeout event rate
+     */
+    public record RequestMetrics(long writeBytes, long writeRecords, double writeMbPerSec,
+                                 double writeRecordsPerSec, long readBytes, long readRecords,
+                                 double readMbPerSec, double readRecordsPerSec,
+                                 long pendingWriteRecords, long pendingWriteBytes,
+                                 long pendingReadRecords, long pendingReadBytes,
+                                 long pendingCombinedRecords, long pendingCombinedBytes,
+                                 long writeTimeouts, double writeTimeoutsPerSec,
+                                 long readTimeouts, double readTimeoutsPerSec) {
+    }
+
+    /**
+     * Completed-operation statistics.
+     *
+     * @param seconds       elapsed seconds represented by this snapshot
+     * @param bytes         completed bytes
+     * @param records       completed records
+     * @param recordsPerSec completed record rate
+     * @param mbPerSec      completed throughput
+     */
+    public record PerformanceMetrics(double seconds, long bytes, long records,
+                                     double recordsPerSec, double mbPerSec) {
+    }
+
+    /**
+     * Latency distribution summary.
+     *
+     * @param average          average latency
+     * @param minimum          minimum latency
+     * @param maximum          maximum latency
+     * @param invalid          invalid latency count
+     * @param lowerDiscard     samples below the configured range
+     * @param higherDiscard    samples above the configured range
+     * @param slc1             first SLC count
+     * @param slc2             second SLC count
+     * @param percentileLabels configured percentile labels
+     * @param percentiles      corresponding percentile latency values
+     * @param percentileCounts corresponding percentile sample counts
+     */
+    public record LatencyMetrics(double average, long minimum, long maximum, long invalid,
+                                 long lowerDiscard, long higherDiscard, long slc1, long slc2,
+                                 double[] percentileLabels, long[] percentiles,
+                                 long[] percentileCounts) {
+        /**
+         * Protects the immutable snapshot from later mutation of source arrays.
+         */
+        public LatencyMetrics {
+            percentileLabels = percentileLabels.clone();
+            percentiles = percentiles.clone();
+            percentileCounts = percentileCounts.clone();
+        }
+
+        /**
+         * Returns a defensive copy of the configured percentile labels.
+         *
+         * @return percentile labels
+         */
+        @Override
+        public double[] percentileLabels() {
+            return percentileLabels.clone();
+        }
+
+        /**
+         * Returns a defensive copy of the measured percentile latencies.
+         *
+         * @return percentile latency values
+         */
+        @Override
+        public long[] percentiles() {
+            return percentiles.clone();
+        }
+
+        /**
+         * Returns a defensive copy of the percentile sample counts.
+         *
+         * @return percentile sample counts
+         */
+        @Override
+        public long[] percentileCounts() {
+            return percentileCounts.clone();
+        }
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/logger/impl/WebLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/WebLogger.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.sbk.action.Action;
+import io.sbk.dashboard.DashboardLoggerSupport;
+import io.sbk.params.InputOptions;
+import io.sbk.params.ParsedOptions;
+import io.sbk.system.Printer;
+import io.time.Time;
+
+import java.io.IOException;
+
+/**
+ * SBK logger that preserves console/CSV reporting and publishes live summaries to the local browser dashboard.
+ */
+public class WebLogger extends CSVLogger {
+    private final DashboardLoggerSupport dashboard;
+
+    /**
+     * Creates a web logger with no dashboard process started.
+     */
+    public WebLogger() {
+        dashboard = new DashboardLoggerSupport();
+    }
+
+    @Override
+    public void addArgs(InputOptions params) throws IllegalArgumentException {
+        super.addArgs(params);
+        dashboard.addArgs(params);
+    }
+
+    @Override
+    public void parseArgs(ParsedOptions params) throws IllegalArgumentException {
+        super.parseArgs(params);
+        dashboard.parseArgs(params);
+    }
+
+    @Override
+    public void open(ParsedOptions params, String storageName, Action action, Time time) throws IOException {
+        super.open(params, storageName, action, time);
+        dashboard.open("SBK", storageName, action, getTimeUnit(), getPercentiles());
+        Printer.log.info("SBK WebLogger Started");
+    }
+
+    @Override
+    public void close(ParsedOptions params) throws IOException {
+        dashboard.close();
+        super.close(params);
+        Printer.log.info("SBK WebLogger Shutdown");
+    }
+
+    @Override
+    public void print(long reportTime, int writers, int maxWriters, int readers, int maxReaders,
+                      long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
+                      double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
+                      long readRequestRecords, double readRequestRecordsPerSec, long writeResponsePendingRecords,
+                      long writeResponsePendingBytes, long readResponsePendingRecords, long readResponsePendingBytes,
+                      long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                      long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                      double readTimeoutEventsPerSec, double seconds, long bytes, long records, double recsPerSec,
+                      double mbPerSec, double avgLatency, long minLatency, long maxLatency, long invalid,
+                      long lowerDiscard, long higherDiscard, long slc1, long slc2, long[] percentileLatencies,
+                      long[] percentileLatencyCounts) {
+        super.print(reportTime, writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
+                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords, writeResponsePendingBytes,
+                readResponsePendingRecords, readResponsePendingBytes, writeReadRequestPendingRecords,
+                writeReadRequestPendingBytes, writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents,
+                readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency,
+                maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
+                percentileLatencyCounts);
+        publish(false, writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
+                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords, writeResponsePendingBytes,
+                readResponsePendingRecords, readResponsePendingBytes, writeReadRequestPendingRecords,
+                writeReadRequestPendingBytes, writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents,
+                readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency,
+                maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
+                percentileLatencyCounts);
+    }
+
+    @Override
+    public void printTotal(long reportTime, int writers, int maxWriters, int readers, int maxReaders,
+                           long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
+                           double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
+                           long readRequestRecords, double readRequestRecordsPerSec,
+                           long writeResponsePendingRecords, long writeResponsePendingBytes,
+                           long readResponsePendingRecords, long readResponsePendingBytes,
+                           long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                           long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                           double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                           double recsPerSec, double mbPerSec, double avgLatency, long minLatency, long maxLatency,
+                           long invalid, long lowerDiscard, long higherDiscard, long slc1, long slc2,
+                           long[] percentileLatencies, long[] percentileLatencyCounts) {
+        super.printTotal(reportTime, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+        publish(true, writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
+                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords, writeResponsePendingBytes,
+                readResponsePendingRecords, readResponsePendingBytes, writeReadRequestPendingRecords,
+                writeReadRequestPendingBytes, writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents,
+                readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency,
+                maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
+                percentileLatencyCounts);
+    }
+
+    private void publish(boolean total, int writers, int maxWriters, int readers, int maxReaders,
+                         long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
+                         double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
+                         long readRequestRecords, double readRequestRecordsPerSec,
+                         long writeResponsePendingRecords, long writeResponsePendingBytes,
+                         long readResponsePendingRecords, long readResponsePendingBytes,
+                         long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                         long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                         double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                         double recsPerSec, double mbPerSec, double avgLatency, long minLatency, long maxLatency,
+                         long invalid, long lowerDiscard, long higherDiscard, long slc1, long slc2,
+                         long[] percentileLatencies, long[] percentileLatencyCounts) {
+        dashboard.publish(total, 0, 0, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+    }
+}

--- a/sbk-api/src/main/resources/dashboard.properties
+++ b/sbk-api/src/main/resources/dashboard.properties
@@ -1,0 +1,14 @@
+# Copyright (c) KMG. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+host=127.0.0.1
+port=9720
+start=true
+open=true
+retention=3600
+name=

--- a/sbk-api/src/main/resources/dashboard/app.js
+++ b/sbk-api/src/main/resources/dashboard/app.js
@@ -12,6 +12,26 @@
 const colors = ['#39d5ff', '#46e6a7', '#9b8cff', '#ffb454'];
 const state = {run: null, completed: false, snapshots: [], events: null};
 const elements = Object.fromEntries([...document.querySelectorAll('[id]')].map(item => [item.id, item]));
+const browserId = sessionStorage.getItem('sbkDashboardBrowserId') || crypto.randomUUID();
+sessionStorage.setItem('sbkDashboardBrowserId', browserId);
+
+function updateBrowserLease() {
+    fetch('/api/v1/browser/connect', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({browserId}),
+        keepalive: true
+    }).catch(() => {});
+}
+
+function releaseBrowserLease() {
+    navigator.sendBeacon('/api/v1/browser/disconnect', JSON.stringify({browserId}));
+}
+
+updateBrowserLease();
+setInterval(updateBrowserLease, 15000);
+window.addEventListener('pagehide', releaseBrowserLease);
+window.addEventListener('pageshow', updateBrowserLease);
 
 function compact(value) {
     return Intl.NumberFormat(undefined, {notation: 'compact', maximumFractionDigits: 2}).format(value || 0);

--- a/sbk-api/src/main/resources/dashboard/app.js
+++ b/sbk-api/src/main/resources/dashboard/app.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+'use strict';
+
+const colors = ['#39d5ff', '#46e6a7', '#9b8cff', '#ffb454'];
+const state = {run: null, completed: false, snapshots: [], events: null};
+const elements = Object.fromEntries([...document.querySelectorAll('[id]')].map(item => [item.id, item]));
+
+function compact(value) {
+    return Intl.NumberFormat(undefined, {notation: 'compact', maximumFractionDigits: 2}).format(value || 0);
+}
+
+function bytes(value) {
+    const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+    let number = Math.max(0, value || 0);
+    let unit = 0;
+    while (number >= 1024 && unit < units.length - 1) { number /= 1024; unit++; }
+    return `${number.toFixed(unit ? 1 : 0)} ${units[unit]}`;
+}
+
+function duration(seconds) {
+    const value = Math.max(0, Math.floor(seconds || 0));
+    return `${String(Math.floor(value / 60)).padStart(2, '0')}:${String(value % 60).padStart(2, '0')}`;
+}
+
+function percentile(snapshot, target) {
+    const labels = snapshot.latency.percentileLabels;
+    if (!labels.length) return 0;
+    let index = labels.findIndex(value => value >= target);
+    if (index < 0) index = labels.length - 1;
+    return snapshot.latency.percentiles[index] || 0;
+}
+
+function update() {
+    const snapshot = state.snapshots.at(-1);
+    if (!snapshot || !state.run) return;
+    const run = state.run;
+    elements.status.textContent = state.completed || snapshot.total ? 'COMPLETE' : 'RUNNING';
+    elements.status.className = `status ${state.completed || snapshot.total ? 'complete' : 'running'}`;
+    elements.title.textContent = run.name || `${run.storage} ${run.action.replaceAll('_', ' ')}`;
+    elements.subtitle.textContent = `${run.source} ${run.sbkVersion}  •  ${run.storage}  •  Java ${run.javaVersion}`;
+    elements.elapsed.textContent = duration(snapshot.performance.seconds);
+    elements.recordsRate.textContent = compact(snapshot.performance.recordsPerSec);
+    elements.throughput.textContent = `${snapshot.performance.mbPerSec.toFixed(2)} MB/s`;
+    elements.p99.textContent = `${compact(percentile(snapshot, 99))} ${run.timeUnit}`;
+    elements.workers.textContent = snapshot.workers.writers + snapshot.workers.readers;
+    elements.connections.textContent = snapshot.workers.connections;
+    elements.latencyUnit.textContent = run.timeUnit;
+    elements.pending.textContent = compact(snapshot.requests.pendingWriteRecords
+        + snapshot.requests.pendingReadRecords + snapshot.requests.pendingCombinedRecords);
+    elements.timeouts.textContent = compact(snapshot.requests.writeTimeouts + snapshot.requests.readTimeouts);
+    elements.invalid.textContent = compact(snapshot.latency.invalid);
+    elements.discarded.textContent = compact(snapshot.latency.lowerDiscard + snapshot.latency.higherDiscard);
+    elements.totalRecords.textContent = compact(snapshot.performance.records);
+    elements.totalBytes.textContent = bytes(snapshot.performance.bytes);
+    drawAll();
+}
+
+function drawChart(canvas, series) {
+    const ratio = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, rect.width * ratio);
+    canvas.height = Math.max(1, rect.height * ratio);
+    const ctx = canvas.getContext('2d');
+    ctx.scale(ratio, ratio);
+    const width = rect.width;
+    const height = rect.height;
+    const pad = {left: 54, right: 14, top: 18, bottom: 28};
+    const plotWidth = width - pad.left - pad.right;
+    const plotHeight = height - pad.top - pad.bottom;
+    const values = series.flatMap(item => item.values);
+    const maximum = Math.max(1, ...values);
+    ctx.clearRect(0, 0, width, height);
+    ctx.strokeStyle = 'rgba(140,164,186,.14)';
+    ctx.fillStyle = '#7891a8';
+    ctx.font = '11px system-ui';
+    for (let line = 0; line <= 4; line++) {
+        const y = pad.top + plotHeight * line / 4;
+        ctx.beginPath(); ctx.moveTo(pad.left, y); ctx.lineTo(width - pad.right, y); ctx.stroke();
+        ctx.fillText(compact(maximum * (1 - line / 4)), 4, y + 4);
+    }
+    series.forEach((item, seriesIndex) => {
+        ctx.strokeStyle = colors[seriesIndex % colors.length];
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        item.values.forEach((value, index) => {
+            const x = pad.left + plotWidth * index / Math.max(1, item.values.length - 1);
+            const y = pad.top + plotHeight * (1 - value / maximum);
+            if (index === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+        ctx.fillStyle = colors[seriesIndex % colors.length];
+        ctx.fillRect(pad.left + seriesIndex * 125, height - 12, 10, 3);
+        ctx.fillText(item.name, pad.left + 15 + seriesIndex * 125, height - 7);
+    });
+}
+
+function drawAll() {
+    const data = state.snapshots.slice(-600);
+    drawChart(elements.rateChart, [
+        {name: 'Completed', values: data.map(item => item.performance.recordsPerSec)},
+        {name: 'Write requests', values: data.map(item => item.requests.writeRecordsPerSec)},
+        {name: 'Read requests', values: data.map(item => item.requests.readRecordsPerSec)}
+    ]);
+    drawChart(elements.throughputChart, [
+        {name: 'Completed', values: data.map(item => item.performance.mbPerSec)},
+        {name: 'Write', values: data.map(item => item.requests.writeMbPerSec)},
+        {name: 'Read', values: data.map(item => item.requests.readMbPerSec)}
+    ]);
+    drawChart(elements.latencyChart, [
+        {name: 'p50', values: data.map(item => percentile(item, 50))},
+        {name: 'p95', values: data.map(item => percentile(item, 95))},
+        {name: 'p99', values: data.map(item => percentile(item, 99))},
+        {name: 'p99.9', values: data.map(item => percentile(item, 99.9))}
+    ]);
+    drawChart(elements.workerChart, [
+        {name: 'Writers', values: data.map(item => item.workers.writers)},
+        {name: 'Readers', values: data.map(item => item.workers.readers)},
+        {name: 'Connections', values: data.map(item => item.workers.connections)}
+    ]);
+}
+
+async function selectRun(runView) {
+    if (state.events) state.events.close();
+    state.run = runView.run;
+    state.completed = runView.completed;
+    const response = await fetch(`/api/v1/runs/${state.run.runId}/history`);
+    state.snapshots = await response.json();
+    history.replaceState(null, '', `/?run=${state.run.runId}`);
+    update();
+    state.events = new EventSource(`/api/v1/runs/${state.run.runId}/events`);
+    state.events.addEventListener('snapshot', event => {
+        state.snapshots.push(JSON.parse(event.data));
+        if (state.snapshots.length > 3600) state.snapshots.shift();
+        update();
+    });
+    state.events.addEventListener('complete', () => { state.completed = true; update(); });
+}
+
+async function loadRuns() {
+    const response = await fetch('/api/v1/runs');
+    const runs = await response.json();
+    runs.sort((a, b) => b.run.startedAt - a.run.startedAt);
+    elements.runs.innerHTML = '';
+    runs.forEach(view => {
+        const option = document.createElement('option');
+        option.value = view.run.runId;
+        option.textContent = `${view.run.name || view.run.storage + ' ' + view.run.action} — ${new Date(view.run.startedAt).toLocaleTimeString()}`;
+        elements.runs.append(option);
+    });
+    if (!runs.length) return;
+    const requested = new URLSearchParams(location.search).get('run');
+    const selected = runs.find(item => item.run.runId === requested) || runs[0];
+    elements.runs.value = selected.run.runId;
+    elements.runs.onchange = () => selectRun(runs.find(item => item.run.runId === elements.runs.value));
+    await selectRun(selected);
+}
+
+window.addEventListener('resize', drawAll);
+loadRuns().catch(error => { elements.subtitle.textContent = `Dashboard error: ${error.message}`; });

--- a/sbk-api/src/main/resources/dashboard/index.html
+++ b/sbk-api/src/main/resources/dashboard/index.html
@@ -1,0 +1,80 @@
+<!--
+Copyright (c) KMG. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+-->
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SBK Live Dashboard</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<header>
+    <div>
+        <div class="eyebrow">STORAGE BENCHMARK KIT</div>
+        <h1>Live Performance Dashboard</h1>
+    </div>
+    <div class="run-picker">
+        <label for="runs">Benchmark run</label>
+        <select id="runs"></select>
+    </div>
+</header>
+
+<main>
+    <section class="identity">
+        <div>
+            <span id="status" class="status waiting">WAITING</span>
+            <h2 id="title">Waiting for an SBK benchmark</h2>
+            <p id="subtitle">Start SBK with <code>-out WebLogger</code></p>
+        </div>
+        <div id="elapsed" class="elapsed">00:00</div>
+    </section>
+
+    <section class="cards">
+        <article><span>Records / sec</span><strong id="recordsRate">0</strong></article>
+        <article><span>Throughput</span><strong id="throughput">0 MB/s</strong></article>
+        <article><span>p99 latency</span><strong id="p99">0</strong></article>
+        <article><span>Workers</span><strong id="workers">0</strong></article>
+        <article><span>Connections</span><strong id="connections">0</strong></article>
+    </section>
+
+    <section class="grid">
+        <article class="panel wide">
+            <div class="panel-title"><h3>Operation rate</h3><span>records / second</span></div>
+            <canvas id="rateChart"></canvas>
+        </article>
+        <article class="panel">
+            <div class="panel-title"><h3>Throughput</h3><span>MB / second</span></div>
+            <canvas id="throughputChart"></canvas>
+        </article>
+        <article class="panel">
+            <div class="panel-title"><h3>Latency percentiles</h3><span id="latencyUnit">configured unit</span></div>
+            <canvas id="latencyChart"></canvas>
+        </article>
+        <article class="panel">
+            <div class="panel-title"><h3>Workers and connections</h3><span>active</span></div>
+            <canvas id="workerChart"></canvas>
+        </article>
+        <article class="panel">
+            <div class="panel-title"><h3>Pressure and errors</h3><span>current window</span></div>
+            <div class="metrics-table">
+                <div><span>Pending records</span><strong id="pending">0</strong></div>
+                <div><span>Timeout events</span><strong id="timeouts">0</strong></div>
+                <div><span>Invalid latencies</span><strong id="invalid">0</strong></div>
+                <div><span>Discarded latencies</span><strong id="discarded">0</strong></div>
+                <div><span>Total records</span><strong id="totalRecords">0</strong></div>
+                <div><span>Total bytes</span><strong id="totalBytes">0 B</strong></div>
+            </div>
+        </article>
+    </section>
+</main>
+<script src="/app.js"></script>
+</body>
+</html>

--- a/sbk-api/src/main/resources/dashboard/style.css
+++ b/sbk-api/src/main/resources/dashboard/style.css
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+:root {
+    color-scheme: dark;
+    --bg: #07111f;
+    --panel: rgba(15, 30, 50, .88);
+    --panel-border: rgba(137, 180, 220, .16);
+    --text: #edf7ff;
+    --muted: #8ca4ba;
+    --cyan: #39d5ff;
+    --green: #46e6a7;
+    --violet: #9b8cff;
+    --orange: #ffb454;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    color: var(--text);
+    background:
+        radial-gradient(circle at 15% -10%, rgba(57, 213, 255, .18), transparent 32rem),
+        radial-gradient(circle at 95% 10%, rgba(155, 140, 255, .14), transparent 28rem),
+        var(--bg);
+}
+
+header, main { width: min(1500px, calc(100% - 40px)); margin: auto; }
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: end;
+    padding: 30px 0 22px;
+}
+
+h1, h2, h3, p { margin: 0; }
+h1 { font-size: clamp(1.5rem, 3vw, 2.4rem); letter-spacing: -.04em; }
+.eyebrow { color: var(--cyan); font-size: .72rem; font-weight: 800; letter-spacing: .2em; margin-bottom: 7px; }
+.run-picker { display: grid; gap: 6px; min-width: 270px; }
+.run-picker label, .panel-title span { color: var(--muted); font-size: .74rem; text-transform: uppercase; letter-spacing: .08em; }
+select {
+    width: 100%; padding: 10px 12px; color: var(--text); background: #10233a;
+    border: 1px solid var(--panel-border); border-radius: 9px;
+}
+
+.identity {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 20px 24px; border: 1px solid var(--panel-border); border-radius: 16px;
+    background: linear-gradient(110deg, rgba(17, 42, 67, .95), rgba(18, 27, 48, .86));
+    box-shadow: 0 18px 60px rgba(0, 0, 0, .22);
+}
+.identity h2 { margin: 8px 0 5px; }
+.identity p { color: var(--muted); }
+.status { display: inline-block; padding: 4px 9px; border-radius: 999px; font-size: .68rem; font-weight: 900; letter-spacing: .1em; }
+.status.running { color: #042518; background: var(--green); box-shadow: 0 0 24px rgba(70, 230, 167, .35); }
+.status.complete { color: #061a2a; background: var(--cyan); }
+.status.waiting { color: #392408; background: var(--orange); }
+.elapsed { font: 700 clamp(1.8rem, 4vw, 3.3rem)/1 ui-monospace, SFMono-Regular, monospace; color: #d8f7ff; }
+
+.cards { display: grid; grid-template-columns: repeat(5, 1fr); gap: 13px; margin: 15px 0; }
+.cards article, .panel {
+    border: 1px solid var(--panel-border); border-radius: 14px; background: var(--panel);
+    box-shadow: 0 14px 45px rgba(0, 0, 0, .17); backdrop-filter: blur(12px);
+}
+.cards article { padding: 15px 17px; }
+.cards span { display: block; color: var(--muted); font-size: .76rem; margin-bottom: 7px; }
+.cards strong { font-size: clamp(1.15rem, 2vw, 1.7rem); font-variant-numeric: tabular-nums; }
+
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 15px; padding-bottom: 35px; }
+.panel { min-height: 310px; padding: 17px; overflow: hidden; }
+.panel.wide { grid-column: span 2; }
+.panel-title { display: flex; justify-content: space-between; align-items: center; margin-bottom: 9px; }
+.panel h3 { font-size: 1rem; }
+canvas { display: block; width: 100%; height: 250px; }
+.wide canvas { height: 280px; }
+.metrics-table { display: grid; gap: 1px; margin-top: 16px; border-radius: 10px; overflow: hidden; background: var(--panel-border); }
+.metrics-table div { display: flex; justify-content: space-between; padding: 12px 13px; background: #0c1c2e; }
+.metrics-table span { color: var(--muted); }
+.metrics-table strong { font-variant-numeric: tabular-nums; }
+code { color: var(--cyan); }
+
+@media (max-width: 900px) {
+    header { align-items: start; gap: 20px; flex-direction: column; }
+    .run-picker { width: 100%; }
+    .cards { grid-template-columns: repeat(2, 1fr); }
+    .grid { grid-template-columns: 1fr; }
+    .panel.wide { grid-column: auto; }
+}
+
+@media (max-width: 520px) {
+    header, main { width: min(100% - 22px, 1500px); }
+    .identity { align-items: start; gap: 18px; flex-direction: column; }
+    .cards { grid-template-columns: 1fr; }
+}

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -19,6 +19,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,13 +39,14 @@ final class DashboardServerTest {
             final DashboardRun secondRun = run("run-two");
             final URI baseUri = URI.create("http://127.0.0.1:" + port);
 
-            try (DashboardClient first = DashboardClient.connect(config, firstRun);
-                 DashboardClient second = DashboardClient.connect(config, secondRun)) {
+            try (DashboardClient first = DashboardClient.connect(config, firstRun)) {
                 first.publish(snapshot("run-one", 1));
                 waitForHistory(baseUri, "run-one", 1);
                 first.publish(snapshot("run-one", 2));
                 waitForHistory(baseUri, "run-one", 2);
                 first.publish(snapshot("run-one", 3));
+            }
+            try (DashboardClient second = DashboardClient.connect(config, secondRun)) {
                 second.publish(snapshot("run-two", 4));
             }
 
@@ -56,6 +58,93 @@ final class DashboardServerTest {
             assertTrue(get(baseUri.resolve("/api/v1/health")).body().contains("sbk-dashboard"));
             assertTrue(get(baseUri.resolve("/")).body().contains("SBK Live Dashboard"));
         }
+    }
+
+    @Test
+    void rejectsASecondActiveBenchmarkWithOwnershipDetails() throws Exception {
+        try (DashboardServer server = new DashboardServer("127.0.0.1", 0, 2)) {
+            server.start();
+            final DashboardConfig config = config(server.getAddress().getPort());
+            try (DashboardClient ignored = DashboardClient.connect(config, run("active-run"))) {
+                final DashboardClient.DashboardBusyException exception = assertThrows(
+                        DashboardClient.DashboardBusyException.class,
+                        () -> DashboardClient.connect(config, run("competing-run")));
+                assertTrue(exception.getMessage().contains("already in use by active SBK run active-run"));
+                assertTrue(exception.getMessage().contains("only one SBK, SBM, or SBK-GEM"));
+            }
+        }
+    }
+
+    @Test
+    void retainsCompletedLogsForBrowserThenStopsAfterBrowserDisconnects() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(500);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        final DashboardClient client = DashboardClient.connect(config(server.getAddress().getPort()),
+                run("retained-run"));
+        post(baseUri.resolve("/api/v1/browser/connect"), "{\"browserId\":\"test-browser\"}");
+        final HttpResponse<java.io.InputStream> events = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(baseUri.resolve("/api/v1/runs/retained-run/events")).GET().build(),
+                HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, events.statusCode());
+
+        client.close();
+        for (int refresh = 0; refresh < 10; refresh++) {
+            Thread.sleep(100);
+            post(baseUri.resolve("/api/v1/browser/connect"), "{\"browserId\":\"test-browser\"}");
+        }
+        assertEquals(200, get(baseUri.resolve("/api/v1/health")).statusCode());
+
+        post(baseUri.resolve("/api/v1/browser/disconnect"), "{\"browserId\":\"test-browser\"}");
+        events.body().close();
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void browserConnectingDuringIdleGraceCancelsOriginalShutdown() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(500);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        try (DashboardClient client = DashboardClient.connect(config(server.getAddress().getPort()),
+                run("browser-grace-run"))) {
+            client.publish(snapshot("browser-grace-run", 1));
+        }
+
+        Thread.sleep(250);
+        for (int refresh = 0; refresh < 6; refresh++) {
+            post(baseUri.resolve("/api/v1/browser/connect"), "{\"browserId\":\"late-browser\"}");
+            Thread.sleep(100);
+        }
+        assertEquals(200, get(baseUri.resolve("/api/v1/health")).statusCode());
+
+        post(baseUri.resolve("/api/v1/browser/disconnect"), "{\"browserId\":\"late-browser\"}");
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void benchmarkConnectingDuringIdleGraceCancelsOriginalShutdown() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(500);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final int port = server.getAddress().getPort();
+        final URI baseUri = URI.create("http://127.0.0.1:" + port);
+        try (DashboardClient first = DashboardClient.connect(config(port), run("first-grace-run"))) {
+            first.publish(snapshot("first-grace-run", 1));
+        }
+
+        Thread.sleep(250);
+        try (DashboardClient second = DashboardClient.connect(config(port), run("second-grace-run"))) {
+            Thread.sleep(400);
+            assertEquals(200, get(baseUri.resolve("/api/v1/health")).statusCode());
+            second.publish(snapshot("second-grace-run", 2));
+            assertEquals(1, waitForHistory(baseUri, "second-grace-run", 1).length);
+        }
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
     }
 
     @Test
@@ -89,6 +178,13 @@ final class DashboardServerTest {
 
     private static HttpResponse<String> get(URI uri) throws Exception {
         return HttpClient.newHttpClient().send(HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> post(URI uri, String body) throws Exception {
+        return HttpClient.newHttpClient().send(HttpRequest.newBuilder(uri)
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(body)).build(),
                 HttpResponse.BodyHandlers.ofString());
     }
 

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.dashboard;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the local dashboard HTTP API and reusable client connection.
+ */
+final class DashboardServerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void reusesRunningServerAndRetainsOnlyConfiguredHistory() throws Exception {
+        try (DashboardServer server = new DashboardServer("127.0.0.1", 0, 2)) {
+            server.start();
+            final int port = server.getAddress().getPort();
+            final DashboardConfig config = config(port);
+            final DashboardRun firstRun = run("run-one");
+            final DashboardRun secondRun = run("run-two");
+            final URI baseUri = URI.create("http://127.0.0.1:" + port);
+
+            try (DashboardClient first = DashboardClient.connect(config, firstRun);
+                 DashboardClient second = DashboardClient.connect(config, secondRun)) {
+                first.publish(snapshot("run-one", 1));
+                waitForHistory(baseUri, "run-one", 1);
+                first.publish(snapshot("run-one", 2));
+                waitForHistory(baseUri, "run-one", 2);
+                first.publish(snapshot("run-one", 3));
+                second.publish(snapshot("run-two", 4));
+            }
+
+            final DashboardSnapshot[] firstHistory = waitForHistory(baseUri, "run-one", 2);
+            final DashboardSnapshot[] secondHistory = waitForHistory(baseUri, "run-two", 1);
+            assertEquals(2, firstHistory.length);
+            assertEquals(1, secondHistory.length);
+            assertEquals(3, firstHistory[1].performance().records());
+            assertTrue(get(baseUri.resolve("/api/v1/health")).body().contains("sbk-dashboard"));
+            assertTrue(get(baseUri.resolve("/")).body().contains("SBK Live Dashboard"));
+        }
+    }
+
+    @Test
+    void closesPromptlyWhileBrowserEventStreamIsConnected() throws Exception {
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2);
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        try (DashboardClient client = DashboardClient.connect(config(server.getAddress().getPort()),
+                run("stream-run"))) {
+            final HttpResponse<java.io.InputStream> events = HttpClient.newHttpClient().send(
+                    HttpRequest.newBuilder(baseUri.resolve("/api/v1/runs/stream-run/events")).GET().build(),
+                    HttpResponse.BodyHandlers.ofInputStream());
+            assertEquals(200, events.statusCode());
+            assertTimeoutPreemptively(Duration.ofSeconds(2), server::close);
+            events.body().close();
+        }
+    }
+
+    private static DashboardSnapshot[] waitForHistory(URI baseUri, String runId, int expected) throws Exception {
+        final long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
+        DashboardSnapshot[] snapshots = new DashboardSnapshot[0];
+        while (snapshots.length < expected && System.nanoTime() < deadline) {
+            snapshots = MAPPER.readValue(get(baseUri.resolve("/api/v1/runs/" + runId + "/history")).body(),
+                    DashboardSnapshot[].class);
+            if (snapshots.length < expected) {
+                Thread.sleep(25);
+            }
+        }
+        return snapshots;
+    }
+
+    private static HttpResponse<String> get(URI uri) throws Exception {
+        return HttpClient.newHttpClient().send(HttpRequest.newBuilder(uri).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static DashboardConfig config(int port) {
+        final DashboardConfig config = new DashboardConfig();
+        config.host = "127.0.0.1";
+        config.port = port;
+        config.start = false;
+        config.open = false;
+        config.retention = 2;
+        config.name = "test";
+        return config;
+    }
+
+    private static DashboardRun run(String runId) {
+        return new DashboardRun(runId, "test", "SBK", "File", "Writing", "ns", "test", "25", 1);
+    }
+
+    private static DashboardSnapshot snapshot(String runId, long records) {
+        return new DashboardSnapshot(runId, records, false,
+                new DashboardSnapshot.WorkerMetrics(1, 1, 0, 0, 0, 0),
+                new DashboardSnapshot.RequestMetrics(100, records, 1, 1, 0, 0, 0, 0,
+                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+                new DashboardSnapshot.PerformanceMetrics(records, records * 100, records, records, 1),
+                new DashboardSnapshot.LatencyMetrics(10, 1, 20, 0, 0, 0, 0, 0,
+                        new double[]{50, 99}, new long[]{10, 20}, new long[]{1, 1}));
+    }
+}

--- a/sbk-gem/README.md
+++ b/sbk-gem/README.md
@@ -134,6 +134,11 @@ Before a multi-host run:
 | `SshUtils` | SSH and file-transfer helpers |
 | `ConnectionConfig` | Remote connection model |
 | `GemPrometheusLogger` | GEM/SBM aggregate metrics output |
+| `GemWebLogger` | GEM adapter for the embedded SBM local live dashboard |
+
+Select `-out GemWebLogger` for dependency-free aggregate graphs at `http://127.0.0.1:9720`. Remote SBK processes
+still use `GrpcLogger`; the embedded SBM publishes the combined cluster result to the local dashboard. Dashboard
+options are listed by `sbk-gem -out GemWebLogger -help` and are forwarded only to the local SBM logger.
 
 ## Failure domains
 

--- a/sbk-gem/README.md
+++ b/sbk-gem/README.md
@@ -138,7 +138,13 @@ Before a multi-host run:
 
 Select `-out GemWebLogger` for dependency-free aggregate graphs at `http://127.0.0.1:9720`. Remote SBK processes
 still use `GrpcLogger`; the embedded SBM publishes the combined cluster result to the local dashboard. Dashboard
-options are listed by `sbk-gem -out GemWebLogger -help` and are forwarded only to the local SBM logger.
+options are listed by `sbk-gem -out GemWebLogger -help` and are forwarded only to the local SBM logger. A running
+idle dashboard is reused, but an active SBK, SBM, or SBK-GEM WebLogger owner causes SBK-GEM to exit with a clear
+ownership error. After a run, graphs remain available while a browser is connected; the unused dashboard exits
+after one minute.
+
+See the [WebLogger guide](../docs/WEB_LOGGER.md) for dashboard options, ownership and shutdown behavior, network
+security, and complete SBK, SBM, and SBK-GEM examples.
 
 ## Failure domains
 

--- a/sbk-gem/src/main/java/io/gem/logger/impl/GemWebLogger.java
+++ b/sbk-gem/src/main/java/io/gem/logger/impl/GemWebLogger.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.gem.logger.impl;
+
+import io.gem.logger.GemLogger;
+import io.sbm.logger.impl.SbmWebLogger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * GEM adapter for {@link SbmWebLogger}; dashboard rendering and publication remain in the SBM logger.
+ */
+public final class GemWebLogger extends SbmWebLogger implements GemLogger {
+
+    /**
+     * Creates a GEM web logger without starting the dashboard.
+     */
+    public GemWebLogger() {
+    }
+
+    @Override
+    protected String getDashboardSource() {
+        return "SBK-GEM";
+    }
+
+    @Override
+    public String[] getOptionsArgs() {
+        final List<String> options = new ArrayList<>();
+        Collections.addAll(options, "-time", "-minlatency", "-maxlatency", "-csvfile");
+        Collections.addAll(options, getDashboardOptionsArgs());
+        return options.toArray(String[]::new);
+    }
+
+    @Override
+    public String[] getParsedArgs() {
+        final List<String> arguments = new ArrayList<>();
+        if (isCsvEnable()) {
+            Collections.addAll(arguments, "-csvfile", getCsvFile());
+        }
+        Collections.addAll(arguments, "-time", getTimeUnit().name(), "-minlatency",
+                Long.toString(getMinLatency()), "-maxlatency", Long.toString(getMaxLatency()));
+        Collections.addAll(arguments, getDashboardParsedArgs());
+        return arguments.toArray(String[]::new);
+    }
+}

--- a/sbk-gem/src/test/java/io/gem/logger/impl/GemWebLoggerTest.java
+++ b/sbk-gem/src/test/java/io/gem/logger/impl/GemWebLoggerTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.gem.logger.impl;
+
+import io.gem.api.GemLoggerPackage;
+import io.sbm.params.impl.SbmParameters;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests GEM dashboard logger discovery and local-SBM argument forwarding.
+ */
+final class GemWebLoggerTest {
+
+    @Test
+    void discoversWebLoggerAndForwardsDashboardOptions() throws Exception {
+        final GemWebLogger logger = new GemWebLogger();
+        final SbmParameters parameters = new SbmParameters("test", 9717, 1, 0,
+                new String[]{GemWebLogger.class.getSimpleName()});
+        logger.addArgs(parameters);
+        parameters.parseArgs(new String[]{"-class", "file", "-action", "r", "-dashboardhost", "127.0.0.1",
+                "-dashboardport", "9876", "-dashboardstart", "false", "-dashboardopen", "false",
+                "-dashboardretention", "42", "-dashboardname", "gem-test", "-time", "ns"});
+        logger.parseArgs(parameters);
+
+        final String[] options = logger.getOptionsArgs();
+        final String[] parsed = logger.getParsedArgs();
+        assertTrue(Arrays.asList(options).contains("-dashboardport"));
+        assertEquals("9876", valueOf(parsed, "-dashboardport"));
+        assertEquals("false", valueOf(parsed, "-dashboardstart"));
+        assertEquals("gem-test", valueOf(parsed, "-dashboardname"));
+        assertTrue(Arrays.asList(new GemLoggerPackage("io.gem.logger").getClassNames())
+                .contains(GemWebLogger.class.getSimpleName()));
+    }
+
+    private static String valueOf(String[] arguments, String option) {
+        for (int index = 0; index + 1 < arguments.length; index += 2) {
+            if (option.equals(arguments[index])) {
+                return arguments[index + 1];
+            }
+        }
+        throw new AssertionError("Missing option " + option);
+    }
+}

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -63,7 +63,13 @@ Start a dependency-free local live dashboard instead of Prometheus:
 ```
 
 The browser dashboard defaults to `http://127.0.0.1:9720` and displays aggregate SBM connection, workload,
-throughput, request-pressure, timeout, and latency-percentile data.
+throughput, request-pressure, timeout, and latency-percentile data. It permits one active WebLogger benchmark,
+keeps completed graphs while a browser remains connected, and exits after one minute without a connected browser.
+An existing idle dashboard is reused; an active SBK, SBM, or SBK-GEM dashboard owner causes SBM to exit with an
+ownership error.
+
+See the [WebLogger guide](../docs/WEB_LOGGER.md) for dashboard options, lifecycle, browser leases, security, and a
+complete distributed example.
 
 Then point one or more installed SBK clients at it:
 

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -28,7 +28,7 @@ flowchart LR
     B[SBK client B / GrpcLogger] --> G
     G --> Q[Concurrent ingestion queues]
     Q --> R[Aggregate recorder]
-    R --> O[Prometheus and result output]
+    R --> O[Prometheus, local web dashboard, or result output]
 ```
 
 The default gRPC port is `9717`. Container configuration also exposes the configured metrics port. Keep the gRPC service on a trusted benchmark network unless an external security layer is provided.
@@ -56,6 +56,15 @@ Start with defaults:
 ./sbm/build/install/sbm/bin/sbm
 ```
 
+Start a dependency-free local live dashboard instead of Prometheus:
+
+```bash
+./sbm/build/install/sbm/bin/sbm -out SbmWebLogger -class file -action r
+```
+
+The browser dashboard defaults to `http://127.0.0.1:9720` and displays aggregate SBM connection, workload,
+throughput, request-pressure, timeout, and latency-percentile data.
+
 Then point one or more installed SBK clients at it:
 
 ```bash
@@ -78,6 +87,7 @@ Use a hostname or address reachable from every SBK client. Firewalls, containers
 | `SbmLatencyBenchmark` | Concurrent queue ingestion and window dispatch |
 | `SbmTotalWindowLatencyPeriodicRecorder` | Periodic and total aggregate windows |
 | `SbmPrometheusLogger` | Aggregated output and metrics |
+| `SbmWebLogger` | Aggregated output and local live dashboard publication |
 
 Protocol sources are under `sbk-api/src/main/proto`; generated Java/gRPC sources are build products.
 

--- a/sbm/src/main/java/io/sbm/logger/impl/AbstractRamLogger.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/AbstractRamLogger.java
@@ -10,69 +10,35 @@
 
 package io.sbm.logger.impl;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.perl.api.LatencyRecord;
 import io.sbk.action.Action;
-import io.sbk.config.Config;
-import io.sbk.logger.impl.PrometheusLogger;
-import io.sbk.logger.impl.SbkPrometheusServer;
+import io.sbk.logger.impl.CSVLogger;
 import io.sbk.params.ParsedOptions;
 import io.sbk.system.Printer;
 import io.sbm.logger.RamLogger;
 import io.time.Time;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Base Prometheus-backed logger for SBM.
+ * Exporter-neutral base logger for SBM.
  *
- * <p>Extends SBK's {@link io.sbk.logger.impl.PrometheusLogger} to add SBM-specific
- * connection gauges and request metrics aggregation. Manages a {@link SbmPrometheusServer}
- * that exposes metrics and provides helper methods shared by concrete SBM loggers.
+ * <p>Adds SBM connection counts and request aggregation to SBK's console/CSV logger. Concrete implementations decide
+ * whether summaries are exported to Prometheus, the local web dashboard, or another destination.
  */
-public abstract class AbstractRamLogger extends PrometheusLogger implements RamLogger {
-    final static String CONFIG_FILE = "sbm-metrics.properties";
+public abstract class AbstractRamLogger extends CSVLogger implements RamLogger {
     final static String SBM_PREFIX = "SBM";
     final static int MAX_REQUEST_RW_IDS = 10;
     private AtomicInteger connections;
     private AtomicInteger maxConnections;
-    private SbmPrometheusServer prometheusServer;
 
     /**
-     * Constructor RamPrometheusLogger calling its super calls and initializing {@link #prometheusServer} = null.
+     * Creates an SBM logger with empty connection counters.
      */
     public AbstractRamLogger() {
         super();
-        prometheusServer = null;
-    }
-
-    /**
-     * Load SBM metrics configuration from classpath.
-     *
-     * @return input stream for {@code sbm-metrics.properties}
-     */
-    public InputStream getMetricsConfigStream() {
-        return SbmPrometheusLogger.class.getClassLoader().getResourceAsStream(CONFIG_FILE);
-    }
-
-    /**
-     * Create or return the {@link SbmPrometheusServer} exposing SBM metrics.
-     *
-     * @return initialized Prometheus server instance
-     * @throws IOException if metrics server initialization fails
-     */
-    @Override
-    @SuppressFBWarnings("EI_EXPOSE_REP")
-    public @Nonnull SbkPrometheusServer getPrometheusRWMetricsServer() throws IOException {
-        if (prometheusServer == null) {
-            prometheusServer = new SbmPrometheusServer(Config.NAME, getAction().name(), getStorageName(),
-                    getPercentiles(), getTime(), getMetricsConfig());
-        }
-        return prometheusServer;
     }
 
     /**
@@ -103,31 +69,25 @@ public abstract class AbstractRamLogger extends PrometheusLogger implements RamL
         super.open(params, storageName, action, time);
         this.connections = new AtomicInteger(0);
         this.maxConnections = new AtomicInteger(0);
-        Printer.log.info("SBK Connections PrometheusLogger Started");
+        Printer.log.info("SBM connection tracking started");
     }
 
 
     /**
-     * Increment current and maximum connection counters and update metrics.
+     * Increment current and maximum connection counters.
      */
     @Override
     public void incrementConnections() {
         connections.incrementAndGet();
         maxConnections.incrementAndGet();
-        if (prometheusServer != null) {
-            prometheusServer.incrementConnections();
-        }
     }
 
     /**
-     * Decrement current connection counter and update metrics.
+     * Decrement current connection counter.
      */
     @Override
     public void decrementConnections() {
         connections.decrementAndGet();
-        if (prometheusServer != null) {
-            prometheusServer.decrementConnections();
-        }
     }
 
     @Override
@@ -199,16 +159,6 @@ public abstract class AbstractRamLogger extends PrometheusLogger implements RamL
                       long records, double recsPerSec, double mbPerSec,
                       double avgLatency, long minLatency, long maxLatency, long invalid, long lowerDiscard,
                       long higherDiscard, long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
-        if (prometheusServer != null) {
-            prometheusServer.print(writers, maxWriters, readers, maxReaders,
-                    writeRequestBytes, writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec,
-                    readRequestBytes, readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec,
-                    writeResponsePendingRecords, writeResponsePendingBytes, readResponsePendingRecords,
-                    readResponsePendingBytes, writeReadRequestPendingRecords, writeReadRequestPendingBytes,
-                    writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec,
-                    seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency,
-                    invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies, percentileLatencyCounts);
-        }
         if (isCsvEnable()) {
             writeToCSV(SBM_PREFIX, REGULAR_PRINT, reportTime, connections.get(), maxConnections.get(),
                     writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,

--- a/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusLogger.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusLogger.java
@@ -9,6 +9,19 @@
  */
 package io.sbm.logger.impl;
 
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.javaprop.JavaPropsFactory;
+import io.sbk.action.Action;
+import io.sbk.config.Config;
+import io.sbk.logger.MetricsConfig;
+import io.sbk.params.InputOptions;
+import io.sbk.params.ParsedOptions;
+import io.sbk.system.Printer;
+import io.time.Time;
+
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * Concrete SBM logger that prints to stdout and exports metrics via Prometheus.
  *
@@ -16,11 +29,98 @@ package io.sbm.logger.impl;
  * connection counts, request/response stats, throughput, and latency percentiles.
  */
 public class SbmPrometheusLogger extends AbstractRamLogger {
+    private static final String CONFIG_FILE = "sbm-metrics.properties";
+    private MetricsConfig metricsConfig;
+    private boolean contextDisabled;
+    private SbmPrometheusServer prometheusServer;
 
     /**
      * Creates a Prometheus logger for aggregated SBM results.
      */
     public SbmPrometheusLogger() {
+    }
+
+    /**
+     * Opens the bundled SBM metrics configuration.
+     *
+     * @return metrics configuration stream
+     */
+    public InputStream getMetricsConfigStream() {
+        return SbmPrometheusLogger.class.getClassLoader().getResourceAsStream(CONFIG_FILE);
+    }
+
+    /**
+     * Returns the parsed metrics configuration for GEM argument forwarding.
+     *
+     * @return active metrics configuration
+     */
+    protected final MetricsConfig getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    @Override
+    public void addArgs(InputOptions params) throws IllegalArgumentException {
+        super.addArgs(params);
+        try {
+            metricsConfig = new ObjectMapper(new JavaPropsFactory()).readValue(getMetricsConfigStream(),
+                    MetricsConfig.class);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Unable to load " + CONFIG_FILE, ex);
+        }
+        params.addOption("context", true, "Prometheus metric context; 'no' disables this option; default: "
+                + metricsConfig.port + metricsConfig.context);
+    }
+
+    @Override
+    public void parseArgs(ParsedOptions params) throws IllegalArgumentException {
+        super.parseArgs(params);
+        final String parsedContext = params.getOptionValue("context",
+                metricsConfig.port + metricsConfig.context);
+        contextDisabled = parsedContext.equalsIgnoreCase(DISABLE_STRING);
+        if (!contextDisabled) {
+            final String[] values = parsedContext.split("/", 2);
+            metricsConfig.port = Integer.parseInt(values[0]);
+            if (values.length == 2 && values[1] != null) {
+                metricsConfig.context = "/" + values[1];
+            }
+        }
+    }
+
+    @Override
+    public void open(ParsedOptions params, String storageName, Action action, Time time) throws IOException {
+        super.open(params, storageName, action, time);
+        if (!contextDisabled) {
+            prometheusServer = new SbmPrometheusServer(Config.NAME, action.name(), storageName,
+                    getPercentiles(), time, metricsConfig);
+            prometheusServer.start();
+        }
+        Printer.log.info("SBM PrometheusLogger Started");
+    }
+
+    @Override
+    public void close(ParsedOptions params) throws IOException {
+        if (prometheusServer != null) {
+            prometheusServer.stop();
+            prometheusServer = null;
+        }
+        super.close(params);
+        Printer.log.info("SBM PrometheusLogger Shutdown");
+    }
+
+    @Override
+    public void incrementConnections() {
+        super.incrementConnections();
+        if (prometheusServer != null) {
+            prometheusServer.incrementConnections();
+        }
+    }
+
+    @Override
+    public void decrementConnections() {
+        super.decrementConnections();
+        if (prometheusServer != null) {
+            prometheusServer.decrementConnections();
+        }
     }
 
     @Override
@@ -34,6 +134,14 @@ public class SbmPrometheusLogger extends AbstractRamLogger {
                       double seconds, long bytes, long records, double recsPerSec, double mbPerSec, double avgLatency,
                       long minLatency, long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
                       long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
+        publishMetrics(writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
+                readRequestRecords, readRequestsRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
         String timestamp = getTimeStamp(reportTime);
         StringBuilder out = new StringBuilder(timestamp+", "+SBM_PREFIX);
         appendConnections(out, connections, maxConnections);
@@ -62,6 +170,14 @@ public class SbmPrometheusLogger extends AbstractRamLogger {
                            double recsPerSec, double mbPerSec, double avgLatency, long minLatency,
                            long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
                            long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
+        publishMetrics(writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
+                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
         String timestamp = getTimeStamp(reportTime);
         StringBuilder out = new StringBuilder(timestamp+" Total : " + SBM_PREFIX);
         appendConnections(out, connections, maxConnections);
@@ -75,5 +191,30 @@ public class SbmPrometheusLogger extends AbstractRamLogger {
                 seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency,
                 invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies, percentileLatencyCounts);
         System.out.println(out);
+    }
+
+    private void publishMetrics(int writers, int maxWriters, int readers, int maxReaders,
+                                long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
+                                double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
+                                long readRequestRecords, double readRequestRecordsPerSec,
+                                long writeResponsePendingRecords, long writeResponsePendingBytes,
+                                long readResponsePendingRecords, long readResponsePendingBytes,
+                                long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                                long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                                double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                                double recsPerSec, double mbPerSec, double avgLatency, long minLatency,
+                                long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
+                                long slc1, long slc2, long[] percentileLatencies,
+                                long[] percentileLatencyCounts) {
+        if (prometheusServer != null) {
+            prometheusServer.print(writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                    writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                    readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec,
+                    writeResponsePendingRecords, writeResponsePendingBytes, readResponsePendingRecords,
+                    readResponsePendingBytes, writeReadRequestPendingRecords, writeReadRequestPendingBytes,
+                    writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec,
+                    seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid,
+                    lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies, percentileLatencyCounts);
+        }
     }
 }

--- a/sbm/src/main/java/io/sbm/logger/impl/SbmWebLogger.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/SbmWebLogger.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbm.logger.impl;
+
+import io.sbk.action.Action;
+import io.sbk.dashboard.DashboardLoggerSupport;
+import io.sbk.params.InputOptions;
+import io.sbk.params.ParsedOptions;
+import io.sbk.system.Printer;
+import io.time.Time;
+
+import java.io.IOException;
+
+/**
+ * SBM logger that publishes aggregated distributed benchmark summaries to the local browser dashboard.
+ */
+public class SbmWebLogger extends AbstractRamLogger {
+    private final DashboardLoggerSupport dashboard;
+
+    /**
+     * Creates an SBM web logger without starting the dashboard.
+     */
+    public SbmWebLogger() {
+        dashboard = new DashboardLoggerSupport();
+    }
+
+    @Override
+    public void addArgs(InputOptions params) throws IllegalArgumentException {
+        super.addArgs(params);
+        dashboard.addArgs(params);
+    }
+
+    @Override
+    public void parseArgs(ParsedOptions params) throws IllegalArgumentException {
+        super.parseArgs(params);
+        dashboard.parseArgs(params);
+    }
+
+    @Override
+    public void open(ParsedOptions params, String storageName, Action action, Time time) throws IOException {
+        super.open(params, storageName, action, time);
+        dashboard.open(getDashboardSource(), storageName, action, getTimeUnit(), getPercentiles());
+        Printer.log.info("SBM WebLogger Started");
+    }
+
+    @Override
+    public void close(ParsedOptions params) throws IOException {
+        dashboard.close();
+        super.close(params);
+        Printer.log.info("SBM WebLogger Shutdown");
+    }
+
+    /**
+     * Returns the application label included in dashboard run metadata.
+     *
+     * @return source application label
+     */
+    protected String getDashboardSource() {
+        return "SBM";
+    }
+
+    /**
+     * Returns dashboard option names for GEM argument segregation.
+     *
+     * @return dashboard option names
+     */
+    protected final String[] getDashboardOptionsArgs() {
+        return dashboard.getOptionsArgs();
+    }
+
+    /**
+     * Returns parsed dashboard arguments for forwarding to local SBM.
+     *
+     * @return dashboard option/value pairs
+     */
+    protected final String[] getDashboardParsedArgs() {
+        return dashboard.getParsedArgs();
+    }
+
+    @Override
+    public void print(long reportTime, int connections, int maxConnections, int writers, int maxWriters, int readers,
+                      int maxReaders, long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
+                      double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
+                      long readRequestRecords, double readRequestRecordsPerSec, long writeResponsePendingRecords,
+                      long writeResponsePendingBytes, long readResponsePendingRecords, long readResponsePendingBytes,
+                      long writeReadRequestPendingRecords, long writeReadRequestPendingBytes, long writeTimeoutEvents,
+                      double writeTimeoutEventsPerSec, long readTimeoutEvents, double readTimeoutEventsPerSec,
+                      double seconds, long bytes, long records, double recsPerSec, double mbPerSec, double avgLatency,
+                      long minLatency, long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
+                      long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
+        final StringBuilder output = new StringBuilder(getTimeStamp(reportTime) + ", " + SBM_PREFIX);
+        appendConnections(output, connections, maxConnections);
+        output.append(getPrefix());
+        appendResultString(output, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+        System.out.println(output);
+        publish(false, connections, maxConnections, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+    }
+
+    @Override
+    public void printTotal(long reportTime, int connections, int maxConnections, int writers, int maxWriters,
+                           int readers, int maxReaders, long writeRequestBytes, double writeRequestMbPerSec,
+                           long writeRequestRecords, double writeRequestRecordsPerSec, long readRequestBytes,
+                           double readRequestMbPerSec, long readRequestRecords, double readRequestRecordsPerSec,
+                           long writeResponsePendingRecords, long writeResponsePendingBytes,
+                           long readResponsePendingRecords, long readResponsePendingBytes,
+                           long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                           long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                           double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                           double recsPerSec, double mbPerSec, double avgLatency, long minLatency,
+                           long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
+                           long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
+        final StringBuilder output = new StringBuilder(getTimeStamp(reportTime) + " Total : " + SBM_PREFIX);
+        appendConnections(output, connections, maxConnections);
+        output.append(getPrefix());
+        appendResultString(output, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+        System.out.println(output);
+        publish(true, connections, maxConnections, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
+                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
+                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
+                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
+                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
+                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
+                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+    }
+
+    private void publish(boolean total, int connections, int maxConnections, int writers, int maxWriters,
+                         int readers, int maxReaders, long writeRequestBytes, double writeRequestMbPerSec,
+                         long writeRequestRecords, double writeRequestRecordsPerSec, long readRequestBytes,
+                         double readRequestMbPerSec, long readRequestRecords, double readRequestRecordsPerSec,
+                         long writeResponsePendingRecords, long writeResponsePendingBytes,
+                         long readResponsePendingRecords, long readResponsePendingBytes,
+                         long writeReadRequestPendingRecords, long writeReadRequestPendingBytes,
+                         long writeTimeoutEvents, double writeTimeoutEventsPerSec, long readTimeoutEvents,
+                         double readTimeoutEventsPerSec, double seconds, long bytes, long records,
+                         double recsPerSec, double mbPerSec, double avgLatency, long minLatency, long maxLatency,
+                         long invalid, long lowerDiscard, long higherDiscard, long slc1, long slc2,
+                         long[] percentileLatencies, long[] percentileLatencyCounts) {
+        dashboard.publish(total, connections, maxConnections, writers, maxWriters, readers, maxReaders,
+                writeRequestBytes, writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec,
+                readRequestBytes, readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec,
+                writeResponsePendingRecords, writeResponsePendingBytes, readResponsePendingRecords,
+                readResponsePendingBytes, writeReadRequestPendingRecords, writeReadRequestPendingBytes,
+                writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec,
+                seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid,
+                lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies, percentileLatencyCounts);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dependency-free local live dashboard with bounded history and server-sent events
- add WebLogger, SbmWebLogger, and GemWebLogger for single-node and distributed benchmarks
- automatically start or reuse a compatible local dashboard server
- preserve Prometheus behavior through exporter-neutral SBM aggregation
- document dashboard usage and configuration

## Validation
- ./gradlew check
- ./gradlew installDist
- strict Javadocs for sbk-api, sbm, and sbk-gem
- installed SBK WebLogger filesystem benchmark
- live health, HTML, history, snapshot, and server-reuse checks
- installed SbmWebLogger aggregate publication check
- SBK-GEM logger discovery and argument-forwarding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dependency-free local live web dashboard for monitoring benchmark runs via new WebLogger output.
  * Included real-time charts/metrics (throughput, latency percentiles, workers/connections, pending operations, timeouts) with configurable host/port, retention, run name, and optional browser auto-open.
  * Added dashboard server lifecycle/ownership handling (reuse across runs, idle auto-shutdown, browser lease behavior).
  * Extended web dashboard support to SBM and GEM with GemWebLogger.
* **Documentation**
  * Updated guides and README sections with WebLogger setup, URLs/commands, distributed monitoring notes, and security/networking guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->