### PR TITLE
Enable direct HTTP dashboard access by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ match between preparation and reading:
 SBK opens `http://127.0.0.1:9720` in the default browser. By default, the lightweight Java server accepts plain HTTP
 on all network interfaces at port 9720, retains bounded history in
 memory and streams new summaries with server-sent events. A later SBK process reuses a compatible server already on
-that port. The server accepts one active SBK, SBM, or SBK-GEM benchmark at a time and reports an error if another
+that port. Startup prints copy-paste dashboard links for loopback, hostname, and available public/private host IPv4
+addresses. The server accepts one active SBK, SBM, or SBK-GEM benchmark at a time and reports an error if another
 WebLogger benchmark already owns it. Completed graphs remain available while a browser is connected; after the
 benchmark has finished and no browser has been connected for one minute, the server exits automatically. Snapshots
 and 15-second logger heartbeats renew the active-run lease. If a benchmark is killed without completing, one minute

--- a/README.md
+++ b/README.md
@@ -229,7 +229,10 @@ on all network interfaces at port 9720, retains bounded history in
 memory and streams new summaries with server-sent events. A later SBK process reuses a compatible server already on
 that port. The server accepts one active SBK, SBM, or SBK-GEM benchmark at a time and reports an error if another
 WebLogger benchmark already owns it. Completed graphs remain available while a browser is connected; after the
-benchmark has finished and no browser has been connected for one minute, the server exits automatically. Use
+benchmark has finished and no browser has been connected for one minute, the server exits automatically. Snapshots
+and 15-second logger heartbeats renew the active-run lease. If a benchmark is killed without completing, one minute
+without either signal marks that run abandoned and releases dashboard ownership; an attached browser may continue
+viewing its graphs without preventing a new run. Use
 `-dashboardopen false` on headless hosts, `-dashboardstart false` to require a pre-existing server, and
 `-dashboardport PORT` to select another port. No SSH tunnel, TLS certificate, or HTTPS setup is enabled or required
 by default. From another system, open `http://<benchmark-host>:9720`; use this only on a trusted benchmark network.

--- a/README.md
+++ b/README.md
@@ -224,13 +224,16 @@ match between preparation and reading:
   -out WebLogger
 ```
 
-SBK opens `http://127.0.0.1:9720` in the default browser. The lightweight Java server retains bounded history in
+SBK opens `http://127.0.0.1:9720` in the default browser. By default, the lightweight Java server accepts plain HTTP
+on all network interfaces at port 9720, retains bounded history in
 memory and streams new summaries with server-sent events. A later SBK process reuses a compatible server already on
 that port. The server accepts one active SBK, SBM, or SBK-GEM benchmark at a time and reports an error if another
 WebLogger benchmark already owns it. Completed graphs remain available while a browser is connected; after the
 benchmark has finished and no browser has been connected for one minute, the server exits automatically. Use
 `-dashboardopen false` on headless hosts, `-dashboardstart false` to require a pre-existing server, and
-`-dashboardport PORT` to select another port. Run `sbk -out WebLogger -help` for the complete option set.
+`-dashboardport PORT` to select another port. No SSH tunnel, TLS certificate, or HTTPS setup is enabled or required
+by default. From another system, open `http://<benchmark-host>:9720`; use this only on a trusted benchmark network.
+Run `sbk -out WebLogger -help` for the complete option set.
 See the [WebLogger guide](docs/WEB_LOGGER.md) for every option, dashboard lifecycle, distributed usage, security,
 and troubleshooting.
 
@@ -244,7 +247,8 @@ sbm -out SbmWebLogger -class file -action r
 sbk-gem -out GemWebLogger -class file -nodes host1,host2 -writers 2 -size 4096 -seconds 60
 ```
 
-The default listener is loopback-only. Bind it to a non-loopback address only on a trusted benchmark network.
+The dashboard listener defaults to `0.0.0.0` for direct HTTP access. Restrict it with
+`-dashboardhost 127.0.0.1` when remote browser access is not required.
 
 ## Distributed execution
 

--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -20,6 +20,8 @@ WebLogger displays SBK measurements in a local browser without Docker, Prometheu
 periodic and total measurements printed by SBK, so enabling it does not add measurement sampling or storage-driver
 work. The dashboard server is implemented with the JDK HTTP server, retains a bounded in-memory history, and sends
 new summaries to browsers with server-sent events (SSE).
+The browser also synchronizes bounded history every two seconds, so graphs recover automatically if an SSE stream
+is delayed, interrupted, or unavailable through an HTTP intermediary.
 
 Use the logger matching the application:
 
@@ -169,6 +171,7 @@ Then open <http://127.0.0.1:9720> locally.
 | Browser does not open | Copy the printed URL manually, or use `-dashboardopen false` on headless systems |
 | Dashboard unavailable | Check `-dashboardhost`, `-dashboardport`, local firewall rules, and whether startup is disabled |
 | Port is incompatible | Stop the unrelated/older service or select another `-dashboardport` |
+| Dashboard remains on an older UI after upgrading SBK | Close every dashboard browser tab, wait one idle minute for the old server to exit, and retry |
 | Dashboard already in use | Wait for the named active benchmark to finish; do not combine independent experiments |
 | Read benchmark reports no useful data | Create and verify the input file first; use the same record size for preparation and reading |
 | Graph disappears after completion | Keep a browser page connected; otherwise the server intentionally exits after one idle minute |

--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -31,8 +31,9 @@ Use the logger matching the application:
 | `sbm` | `SbmWebLogger` | Aggregated results received from distributed SBK clients |
 | `sbk-gem` or `sbk-gem-yal` | `GemWebLogger` | Cluster aggregate produced by GEM's embedded SBM |
 
-The local dashboard URL is <http://127.0.0.1:9720>. The server listens on `0.0.0.0` by default, so a browser on
-another system can use `http://<benchmark-host>:9720`. The exact local run URL is printed when the logger starts.
+The local dashboard URL is <http://127.0.0.1:9720>. The server listens on `0.0.0.0` by default and prints separate
+copy-paste run links for loopback, the machine hostname, and its available public/private IPv4 addresses. A browser
+on another system can use one of those hostname or IP links when network and firewall policy allow the connection.
 The default transport is unsecured HTTP; WebLogger does not start SSH and does not enable TLS or HTTPS.
 
 ## Quick start: filesystem read benchmark

--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -102,16 +102,24 @@ The server lifecycle is:
 
 1. The first WebLogger application starts a server when one is not already reachable.
 2. A compatible idle server is reused; another server process is not started.
-3. When the benchmark finishes, its bounded history and final snapshot remain in server memory.
-4. An open browser renews a lightweight lease every 15 seconds, keeping the completed graphs available.
-5. If a browser connects during the one-minute idle grace period, the pending shutdown is cancelled while that
+3. The active logger renews its run lease every 15 seconds. Publishing a measurement snapshot also renews the same
+   lease, so normal reporting traffic needs no separate heartbeat.
+4. When the benchmark finishes normally, its bounded history and final snapshot remain in server memory.
+5. If the benchmark process disappears without completing its run, one minute without a snapshot or logger
+   heartbeat marks the run as abandoned and releases dashboard ownership. A new benchmark can then register.
+6. An open browser renews a separate lightweight lease every 15 seconds, keeping completed or abandoned graphs
+   available.
+7. If a browser connects during the one-minute idle grace period, the pending shutdown is cancelled while that
    browser remains connected.
-6. If SBK, SBM, or SBK-GEM connects during the grace period, it becomes the active run and cancels the pending
+8. If SBK, SBM, or SBK-GEM connects during the grace period, it becomes the active run and cancels the pending
    shutdown.
-7. When no benchmark is active and no browser lease is present for one minute, the server exits gracefully.
+9. When an abandoned run has no attached browser, the server exits as soon as the one-minute run lease expires.
+   In every other idle state, the server exits after one minute with neither benchmark nor browser activity.
 
 Closing a browser releases its lease. If a browser or network disappears without a clean close, the lease expires
-from its last renewal, so a dead TCP connection cannot keep the process alive indefinitely.
+from its last renewal, so a dead TCP connection cannot keep the process alive indefinitely. The logger and browser
+leases are independent: an attached browser preserves old graphs, but it cannot retain ownership for a dead
+benchmark.
 
 ## Distributed WebLogger modes
 
@@ -173,6 +181,7 @@ Then open <http://127.0.0.1:9720> locally.
 | Port is incompatible | Stop the unrelated/older service or select another `-dashboardport` |
 | Dashboard remains on an older UI after upgrading SBK | Close every dashboard browser tab, wait one idle minute for the old server to exit, and retry |
 | Dashboard already in use | Wait for the named active benchmark to finish; do not combine independent experiments |
+| Dashboard reports an abandoned run | The logger stopped publishing snapshots and heartbeats for one minute, usually because its SBK, SBM, or SBK-GEM process was killed or lost connectivity; correct the failure and start a new benchmark |
 | Read benchmark reports no useful data | Create and verify the input file first; use the same record size for preparation and reading |
 | Graph disappears after completion | Keep a browser page connected; otherwise the server intentionally exits after one idle minute |
 | Remote browser cannot connect | Verify port 9720 is allowed by the benchmark host firewall and use `http://<benchmark-host>:9720` |

--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -29,7 +29,9 @@ Use the logger matching the application:
 | `sbm` | `SbmWebLogger` | Aggregated results received from distributed SBK clients |
 | `sbk-gem` or `sbk-gem-yal` | `GemWebLogger` | Cluster aggregate produced by GEM's embedded SBM |
 
-The default dashboard URL is <http://127.0.0.1:9720>. The exact run URL is printed when the logger starts.
+The local dashboard URL is <http://127.0.0.1:9720>. The server listens on `0.0.0.0` by default, so a browser on
+another system can use `http://<benchmark-host>:9720`. The exact local run URL is printed when the logger starts.
+The default transport is unsecured HTTP; WebLogger does not start SSH and does not enable TLS or HTTPS.
 
 ## Quick start: filesystem read benchmark
 
@@ -77,7 +79,7 @@ Logger options appear only after selecting the WebLogger class. Treat generated 
 
 | Option | Default | Meaning |
 |---|---:|---|
-| `-dashboardhost HOST` | `127.0.0.1` | Address on which the local HTTP server listens |
+| `-dashboardhost HOST` | `0.0.0.0` | Address on which the plain HTTP server listens |
 | `-dashboardport PORT` | `9720` | Dashboard HTTP port |
 | `-dashboardstart true\|false` | `true` | Start a compatible server when none is reachable |
 | `-dashboardopen true\|false` | `true` | Ask the local desktop to open the run URL |
@@ -141,15 +143,24 @@ GEM starts an embedded SBM. Remote SBK processes send SBP/gRPC measurements to t
 
 ## Network and security
 
-The default loopback binding restricts access to the benchmark host. To view a remote loopback dashboard, prefer an
-SSH tunnel rather than exposing the port:
+The default `0.0.0.0` binding accepts unsecured HTTP connections on every network interface. WebLogger neither
+starts SSH nor enables TLS/HTTPS. A remote browser can therefore connect directly:
+
+```text
+http://<benchmark-host>:9720
+```
+
+The dashboard has no authentication or encryption. Use the default only on an isolated, trusted benchmark network
+protected by host and network firewall rules. To restrict access to the benchmark host, set
+`-dashboardhost 127.0.0.1`.
+
+An SSH tunnel remains an optional security measure when the dashboard is bound to loopback:
 
 ```bash
 ssh -L 9720:127.0.0.1:9720 user@benchmark-host
 ```
 
-Then open <http://127.0.0.1:9720> locally. The dashboard has no authentication or TLS. Bind
-`-dashboardhost 0.0.0.0` only on an isolated, trusted benchmark network protected by host and network controls.
+Then open <http://127.0.0.1:9720> locally.
 
 ## Troubleshooting
 
@@ -161,7 +172,7 @@ Then open <http://127.0.0.1:9720> locally. The dashboard has no authentication o
 | Dashboard already in use | Wait for the named active benchmark to finish; do not combine independent experiments |
 | Read benchmark reports no useful data | Create and verify the input file first; use the same record size for preparation and reading |
 | Graph disappears after completion | Keep a browser page connected; otherwise the server intentionally exits after one idle minute |
-| Remote browser cannot connect | Keep loopback binding and use an SSH tunnel, or review trusted-network routing explicitly |
+| Remote browser cannot connect | Verify port 9720 is allowed by the benchmark host firewall and use `http://<benchmark-host>:9720` |
 
 The implementation is under `sbk-api/src/main/java/io/sbk/dashboard`. `DashboardLoggerSupport` is shared by SBK,
 SBM, and SBK-GEM; `DashboardServer` owns run registration, bounded histories, browser leases, SSE, and idle shutdown.

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -2280,24 +2280,53 @@ flowchart LR
     HOT["Writer and reader hot paths"] --> PERL["PerL measurement pipeline"]
     PERL --> SUMMARY["Periodic and total summaries"]
     SUMMARY --> LOGGER["WebLogger family"]
-    LOGGER -->|HTTP publish| SERVER["Reusable dashboard server"]
+    LOGGER -->|Snapshot or 15-second heartbeat| LEASE["Active-run lease"]
+    LEASE --> SERVER["Reusable dashboard server"]
     SERVER --> HISTORY["Bounded run history"]
     SERVER -->|SSE| BROWSER["Browser graphs"]
+    BROWSER -->|15-second heartbeat| BLEASE["Browser lease"]
+    BLEASE --> SERVER
 
     classDef hot fill:#fee2e2,stroke:#b91c1c,color:#000
     classDef control fill:#e0f2fe,stroke:#0369a1,color:#000
     classDef view fill:#dcfce7,stroke:#15803d,color:#000
     class HOT,PERL hot
-    class SUMMARY,LOGGER,SERVER,HISTORY control
-    class BROWSER view
+    class SUMMARY,LOGGER,LEASE,SERVER,HISTORY control
+    class BROWSER,BLEASE view
 ```
 
-Only one benchmark owns a dashboard server at a time. A completed run remains
-available while a browser renews its lease. With no active SBK, SBM, or SBK-GEM
-publisher and no browser lease, the server exits after a one-minute idle grace
-period. A browser or new benchmark connecting during that grace period cancels
-the pending shutdown. See the [WebLogger guide](WEB_LOGGER.md) for commands,
-options, distributed modes, security, and troubleshooting.
+Only one benchmark owns a dashboard server at a time. Registration starts an
+active-run lease. Each snapshot renews it, and a 15-second client heartbeat
+renews it during quiet reporting intervals. If neither arrives for one minute,
+the server marks the run abandoned and releases `activeRunId`; this prevents a
+crashed SBK, SBM, or SBK-GEM process from permanently blocking later runs.
+
+The browser has an independent 15-second lease. A fresh browser lease preserves
+the abandoned or completed run's graphs, but does not preserve benchmark
+ownership. If the run lease expires with no browser attached, the server exits
+immediately. Otherwise it remains available until there has been neither an
+active publisher nor a browser lease for one minute.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: Server starts
+    Idle --> Active: Logger registers run
+    Active --> Active: Snapshot or logger heartbeat
+    Active --> Completed: Logger completes normally
+    Active --> Abandoned: No logger activity for one minute
+    Abandoned --> Active: New logger registers
+    Completed --> Active: New logger registers
+    Completed --> Retained: Browser lease is active
+    Abandoned --> Retained: Browser lease is active
+    Completed --> Stopped: No browser for one minute
+    Abandoned --> Stopped: No browser at lease expiry
+    Retained --> Retained: Browser heartbeat
+    Retained --> Stopped: No publisher or browser for one minute
+    Stopped --> [*]
+```
+
+See the [WebLogger guide](WEB_LOGGER.md) for commands, options, distributed
+modes, security, and troubleshooting.
 
 ---
 

--- a/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
@@ -26,6 +26,7 @@ import io.sbk.logger.RWLogger;
 import io.sbk.params.impl.SbkDriversParameters;
 import io.sbk.params.impl.SbkParameters;
 import io.sbk.system.Printer;
+import io.sbk.utils.ApplicationShutdownHook;
 import io.sbk.utils.SbkUtils;
 import io.sbp.api.Sbp;
 import io.sbp.config.SbpVersion;
@@ -109,12 +110,13 @@ final public class Sbk {
             return;
         }
 
-        final CompletableFuture<Void> ret = benchmark.start();
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println();
-            benchmark.stop();
-        }));
-        ret.get();
+        final Thread shutdownHook = ApplicationShutdownHook.register(Config.NAME.toUpperCase(), benchmark::stop);
+        try {
+            final CompletableFuture<Void> ret = benchmark.start();
+            ret.get();
+        } finally {
+            ApplicationShutdownHook.remove(shutdownHook);
+        }
     }
 
 

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
@@ -75,6 +75,7 @@ final public class SbkBenchmark implements Benchmark {
     final private RWLogger rwLogger;
     final private ExecutorService executor;
     final private ExecutorService perlExecutor;
+    final private ExecutorService lifecycleExecutor;
     final private ParameterOptions params;
     final private Perl writePerl;
     final private Perl readPerl;
@@ -114,6 +115,8 @@ final public class SbkBenchmark implements Benchmark {
         };
 
         this.perlExecutor = new ForkJoinPool(5);
+        this.lifecycleExecutor = Executors.newSingleThreadExecutor(Thread.ofPlatform()
+                .name("sbk-benchmark-lifecycle").factory());
 
         if (params.getWritersCount() > 0 && params.getAction() == Action.Writing) {
             PerlConfig wConfig = PerlConfig.build(SbkBenchmark.class.getClassLoader().getResourceAsStream(CONFIGFILE));
@@ -359,27 +362,44 @@ final public class SbkBenchmark implements Benchmark {
         }
 
         if (params.getTotalSecondsToRun() > 0) {
-            timeoutExecutor.schedule(this::stop, params.getTotalSecondsToRun() + 1, TimeUnit.SECONDS);
+            timeoutExecutor.schedule(() -> requestShutdown(null),
+                    params.getTotalSecondsToRun() + 1, TimeUnit.SECONDS);
         }
 
         if (wStatFuture != null && !wStatFuture.isDone()) {
             wStatFuture.exceptionally(ex -> {
-                shutdown(ex);
+                requestShutdown(ex);
                 return null;
             });
         }
 
         if (rStatFuture != null && !rStatFuture.isDone()) {
             rStatFuture.exceptionally(ex -> {
-                shutdown(ex);
+                requestShutdown(ex);
                 return null;
             });
         }
-        rwLogger.setExceptionHandler(this::shutdown);
+        rwLogger.setExceptionHandler(this::requestShutdown);
         assert chainFuture != null;
-        chainFuture.thenRunAsync(this::stop, executor);
+        chainFuture.whenComplete((ignored, ex) -> requestShutdown(ex));
 
         return retFuture.toCompletableFuture();
+    }
+
+    /**
+     * Schedules automatic benchmark shutdown away from worker, timeout, PerL, and logger threads.
+     *
+     * <p>The shutdown path interrupts and awaits the worker executor. Running that path on a worker
+     * would interrupt the shutdown thread itself and produce a false shutdown warning.
+     *
+     * @param ex failure that initiated shutdown, or {@code null} for normal completion
+     */
+    @Synchronized
+    private void requestShutdown(Throwable ex) {
+        if (state == State.END || lifecycleExecutor.isShutdown()) {
+            return;
+        }
+        lifecycleExecutor.execute(() -> shutdown(ex));
     }
 
     /**
@@ -438,6 +458,7 @@ final public class SbkBenchmark implements Benchmark {
             Printer.log.info("SBK Benchmark Shutdown");
             retFuture.complete(null);
         }
+        lifecycleExecutor.shutdown();
 
     }
 

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
@@ -281,7 +281,10 @@ final public class SbkBenchmark implements Benchmark {
             }, executor).thenAccept(d -> {
                 try {
                     CompletableFuture.allOf(writeFutures.toArray(new CompletableFuture[0])).get();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    Printer.log.info("Writer coordination interrupted during shutdown");
+                } catch (ExecutionException e) {
                     e.printStackTrace();
                 }
             });
@@ -333,7 +336,10 @@ final public class SbkBenchmark implements Benchmark {
             }, executor).thenAccept(d -> {
                         try {
                             CompletableFuture.allOf(readFutures.toArray(new CompletableFuture[0])).get();
-                        } catch (InterruptedException | ExecutionException e) {
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            Printer.log.info("Reader coordination interrupted during shutdown");
+                        } catch (ExecutionException e) {
                             e.printStackTrace();
                         }
                     }
@@ -390,37 +396,39 @@ final public class SbkBenchmark implements Benchmark {
             return;
         }
         state = State.END;
-        if (writePerl != null) {
-            writePerl.stop();
-        }
-        if (readPerl != null) {
-            readPerl.stop();
-        }
+        timeoutExecutor.shutdownNow();
+        executor.shutdownNow();
         readers.forEach(c -> {
             try {
                 c.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                Printer.log.warn("Unable to close an SBK reader during shutdown", e);
             }
         });
         writers.forEach(c -> {
             try {
                 c.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                Printer.log.warn("Unable to close an SBK writer during shutdown", e);
             }
         });
+        if (writePerl != null) {
+            writePerl.stop();
+        }
+        if (readPerl != null) {
+            readPerl.stop();
+        }
         try {
             storage.closeStorage(params);
             rwLogger.close(params);
         } catch (IOException e) {
-            e.printStackTrace();
+            Printer.log.warn("Unable to close SBK storage or logger during shutdown", e);
         }
-        executor.shutdown();
         try {
             executor.awaitTermination(1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            ex.printStackTrace();
+            Thread.currentThread().interrupt();
+            Printer.log.warn("Interrupted while waiting for SBK workers to stop", e);
         }
 
         if (ex != null) {

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkReader.java
@@ -111,7 +111,11 @@ final public class SbkReader extends Worker implements RunBenchmark {
             } catch (EOFException ex) {
                 Printer.log.info("Reader " + id + " exited with EOF");
             } catch (IOException ex) {
-                ex.printStackTrace();
+                if (Thread.currentThread().isInterrupted()) {
+                    Printer.log.info("Reader " + id + " interrupted during shutdown");
+                } else {
+                    ex.printStackTrace();
+                }
             }
             rCount.decrementReaders();
         }, executor);

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkWriter.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkWriter.java
@@ -105,7 +105,11 @@ final public class SbkWriter extends Worker implements RunBenchmark {
                 perf.apply(secondsToRun, recordsCount);
                 Printer.log.info("Writer " + id + " exited");
             } catch (IOException ex) {
-                ex.printStackTrace();
+                if (Thread.currentThread().isInterrupted()) {
+                    Printer.log.info("Writer " + id + " interrupted during shutdown");
+                } else {
+                    ex.printStackTrace();
+                }
             }
             wCount.decrementWriters();
         }, executor);

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
@@ -35,6 +35,7 @@ public final class DashboardClient implements AutoCloseable {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(1);
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(2);
     private static final Duration START_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration LEASE_HEARTBEAT_INTERVAL = Duration.ofSeconds(15);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private final HttpClient httpClient;
     private final URI baseUri;
@@ -42,14 +43,16 @@ public final class DashboardClient implements AutoCloseable {
     private final ArrayBlockingQueue<DashboardSnapshot> pending;
     private final AtomicBoolean closing;
     private final Thread publisherThread;
+    private final Duration leaseHeartbeatInterval;
 
-    private DashboardClient(HttpClient httpClient, URI baseUri, DashboardRun run) throws IOException,
-            InterruptedException {
+    private DashboardClient(HttpClient httpClient, URI baseUri, DashboardRun run, Duration leaseHeartbeatInterval)
+            throws IOException, InterruptedException {
         this.httpClient = httpClient;
         this.baseUri = baseUri;
         this.runId = run.runId();
         this.pending = new ArrayBlockingQueue<>(1);
         this.closing = new AtomicBoolean(false);
+        this.leaseHeartbeatInterval = leaseHeartbeatInterval;
         postJson("/api/v1/runs", run, 201);
         this.publisherThread = Thread.ofVirtual().name("sbk-dashboard-publisher-" + runId).start(this::publishLoop);
     }
@@ -65,6 +68,14 @@ public final class DashboardClient implements AutoCloseable {
      */
     public static DashboardClient connect(DashboardConfig config, DashboardRun run)
             throws IOException, InterruptedException {
+        return connect(config, run, LEASE_HEARTBEAT_INTERVAL);
+    }
+
+    static DashboardClient connect(DashboardConfig config, DashboardRun run, Duration leaseHeartbeatInterval)
+            throws IOException, InterruptedException {
+        if (leaseHeartbeatInterval.isZero() || leaseHeartbeatInterval.isNegative()) {
+            throw new IllegalArgumentException("Dashboard lease heartbeat interval must be greater than zero");
+        }
         final URI baseUri = URI.create("http://" + connectionHost(config.host) + ":" + config.port);
         final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
         final Health health = health(httpClient, baseUri);
@@ -78,7 +89,7 @@ public final class DashboardClient implements AutoCloseable {
             startServer(config);
             waitUntilHealthy(httpClient, baseUri);
         }
-        final DashboardClient client = new DashboardClient(httpClient, baseUri, run);
+        final DashboardClient client = new DashboardClient(httpClient, baseUri, run, leaseHeartbeatInterval);
         if (config.open) {
             client.openBrowser();
         }
@@ -136,18 +147,26 @@ public final class DashboardClient implements AutoCloseable {
     }
 
     private void publishLoop() {
+        long nextHeartbeat = System.nanoTime() + leaseHeartbeatInterval.toNanos();
         while (!closing.get() || !pending.isEmpty()) {
             try {
-                final DashboardSnapshot snapshot = pending.poll(250, TimeUnit.MILLISECONDS);
+                final long heartbeatWait = Math.max(1,
+                        TimeUnit.NANOSECONDS.toMillis(nextHeartbeat - System.nanoTime()));
+                final DashboardSnapshot snapshot = pending.poll(Math.min(250, heartbeatWait), TimeUnit.MILLISECONDS);
                 if (snapshot != null) {
                     postJson("/api/v1/runs/" + runId + "/snapshots", snapshot, 204);
+                    nextHeartbeat = System.nanoTime() + leaseHeartbeatInterval.toNanos();
+                } else if (!closing.get() && System.nanoTime() >= nextHeartbeat) {
+                    postJson("/api/v1/runs/" + runId + "/heartbeat", Map.of(), 204);
+                    nextHeartbeat = System.nanoTime() + leaseHeartbeatInterval.toNanos();
                 }
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 return;
             } catch (IOException ex) {
-                Printer.log.warn("SBK dashboard snapshot publication failed: {}",
+                Printer.log.warn("SBK dashboard publication failed: {}",
                         Objects.toString(ex.getMessage(), ex.getClass().getSimpleName()));
+                nextHeartbeat = System.nanoTime() + leaseHeartbeatInterval.toNanos();
             }
         }
     }

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
@@ -16,12 +16,22 @@ import io.sbk.system.Printer;
 import java.awt.Desktop;
 import java.awt.GraphicsEnvironment;
 import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -44,15 +54,17 @@ public final class DashboardClient implements AutoCloseable {
     private final AtomicBoolean closing;
     private final Thread publisherThread;
     private final Duration leaseHeartbeatInterval;
+    private final List<DashboardLink> runLinks;
 
-    private DashboardClient(HttpClient httpClient, URI baseUri, DashboardRun run, Duration leaseHeartbeatInterval)
-            throws IOException, InterruptedException {
+    private DashboardClient(HttpClient httpClient, URI baseUri, DashboardConfig config, DashboardRun run,
+            Duration leaseHeartbeatInterval) throws IOException, InterruptedException {
         this.httpClient = httpClient;
         this.baseUri = baseUri;
         this.runId = run.runId();
         this.pending = new ArrayBlockingQueue<>(1);
         this.closing = new AtomicBoolean(false);
         this.leaseHeartbeatInterval = leaseHeartbeatInterval;
+        this.runLinks = dashboardLinks(config.host, config.port, runId, localHostname(), localAddresses());
         postJson("/api/v1/runs", run, 201);
         this.publisherThread = Thread.ofVirtual().name("sbk-dashboard-publisher-" + runId).start(this::publishLoop);
     }
@@ -89,7 +101,8 @@ public final class DashboardClient implements AutoCloseable {
             startServer(config);
             waitUntilHealthy(httpClient, baseUri);
         }
-        final DashboardClient client = new DashboardClient(httpClient, baseUri, run, leaseHeartbeatInterval);
+        final DashboardClient client = new DashboardClient(httpClient, baseUri, config, run,
+                leaseHeartbeatInterval);
         if (config.open) {
             client.openBrowser();
         }
@@ -114,6 +127,38 @@ public final class DashboardClient implements AutoCloseable {
      */
     public URI getRunUri() {
         return URI.create(baseUri + "/?run=" + runId);
+    }
+
+    /**
+     * Returns copy-paste dashboard links reachable through the configured bind address.
+     *
+     * @return local link followed by hostname and available host-address links
+     */
+    public List<DashboardLink> getRunLinks() {
+        return new ArrayList<>(runLinks);
+    }
+
+    static List<DashboardLink> dashboardLinks(String bindHost, int port, String runId, String hostname,
+            List<InetAddress> addresses) {
+        final boolean wildcard = "0.0.0.0".equals(bindHost);
+        final Map<String, String> hosts = new LinkedHashMap<>();
+        hosts.put(connectionHost(bindHost), wildcard ? "Local" : "Configured");
+        if (wildcard) {
+            if (hostname != null && !hostname.isBlank()) {
+                hosts.putIfAbsent(hostname, "Hostname");
+            }
+            addresses.stream()
+                    .filter(Inet4Address.class::isInstance)
+                    .filter(address -> !address.isAnyLocalAddress() && !address.isLoopbackAddress()
+                            && !address.isLinkLocalAddress() && !address.isMulticastAddress())
+                    .sorted(Comparator.comparing(InetAddress::isSiteLocalAddress)
+                            .thenComparing(InetAddress::getHostAddress))
+                    .forEach(address -> hosts.putIfAbsent(address.getHostAddress(),
+                            address.isSiteLocalAddress() ? "Private IP" : "Public IP"));
+        }
+        final List<DashboardLink> links = new ArrayList<>(hosts.size());
+        hosts.forEach((host, label) -> links.add(new DashboardLink(label, runUri(host, port, runId))));
+        return List.copyOf(links);
     }
 
     /**
@@ -247,6 +292,50 @@ public final class DashboardClient implements AutoCloseable {
         builder.start();
     }
 
+    private static String localHostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (IOException ex) {
+            return "";
+        }
+    }
+
+    private static List<InetAddress> localAddresses() {
+        final List<InetAddress> addresses = new ArrayList<>();
+        try {
+            final InetAddress primaryAddress = InetAddress.getLocalHost();
+            if (!primaryAddress.isAnyLocalAddress() && !primaryAddress.isLoopbackAddress()
+                    && !primaryAddress.isLinkLocalAddress()) {
+                return List.of(primaryAddress);
+            }
+        } catch (IOException ex) {
+            // Fall back to interface enumeration when the local hostname cannot be resolved.
+        }
+        try {
+            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces == null) {
+                return addresses;
+            }
+            while (interfaces.hasMoreElements()) {
+                final Enumeration<InetAddress> interfaceAddresses = interfaces.nextElement().getInetAddresses();
+                while (interfaceAddresses.hasMoreElements()) {
+                    addresses.add(interfaceAddresses.nextElement());
+                }
+            }
+        } catch (SocketException ex) {
+            return List.of();
+        }
+        return addresses;
+    }
+
+    private static URI runUri(String host, int port, String runId) {
+        try {
+            return new URI("http", null, host, port, "/", "run=" + runId, null);
+        } catch (URISyntaxException ex) {
+            throw new IllegalArgumentException("Invalid dashboard address: " + host, ex);
+        }
+    }
+
     @SuppressFBWarnings(value = "ENV_USE_PROPERTY_INSTEAD_OF_ENV",
             justification = "SBK_JAVA_HOME and JAVA_HOME are documented SBK launcher overrides")
     private static String resolveJavaExecutable() {
@@ -266,6 +355,15 @@ public final class DashboardClient implements AutoCloseable {
         AVAILABLE,
         UNAVAILABLE,
         INCOMPATIBLE
+    }
+
+    /**
+     * A labeled, copy-paste URL for one dashboard network address.
+     *
+     * @param label address type, such as hostname or public IP
+     * @param uri   complete dashboard run URL
+     */
+    public record DashboardLink(String label, URI uri) {
     }
 
     /** Indicates that another benchmark owns the dashboard's single active-run lease. */

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardClient.java
@@ -65,7 +65,7 @@ public final class DashboardClient implements AutoCloseable {
      */
     public static DashboardClient connect(DashboardConfig config, DashboardRun run)
             throws IOException, InterruptedException {
-        final URI baseUri = URI.create("http://" + config.host + ":" + config.port);
+        final URI baseUri = URI.create("http://" + connectionHost(config.host) + ":" + config.port);
         final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
         final Health health = health(httpClient, baseUri);
         if (health == Health.INCOMPATIBLE) {
@@ -83,6 +83,17 @@ public final class DashboardClient implements AutoCloseable {
             client.openBrowser();
         }
         return client;
+    }
+
+    /**
+     * Selects a reachable local address when the server is configured to listen on every network interface.
+     * Wildcard addresses are valid bind addresses but are not suitable dashboard destinations for HTTP clients.
+     *
+     * @param host configured dashboard host or bind address
+     * @return host used by the local dashboard publisher and browser URL
+     */
+    static String connectionHost(String host) {
+        return "0.0.0.0".equals(host) ? "127.0.0.1" : host;
     }
 
     /**

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
@@ -109,7 +109,8 @@ public final class DashboardLoggerSupport implements AutoCloseable {
                 timeUnit.name(), version, System.getProperty("java.runtime.version"), System.currentTimeMillis());
         try {
             client = DashboardClient.connect(config, run);
-            Printer.log.info("SBK Dashboard: {}", client.getRunUri());
+            client.getRunLinks().forEach(link -> Printer.log.info("SBK Dashboard ({}): {}",
+                    link.label(), link.uri()));
         } catch (DashboardClient.DashboardBusyException ex) {
             client = null;
             Printer.log.error("{} WebLogger cannot start: {}", source, ex.getMessage());

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class DashboardServer implements AutoCloseable {
     /** Dashboard HTTP API version. */
-    public static final int API_VERSION = 2;
+    public static final int API_VERSION = 3;
     /** Time an unused dashboard remains available after its benchmark exits. */
     public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(5);

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class DashboardServer implements AutoCloseable {
     /** Dashboard HTTP API version. */
-    public static final int API_VERSION = 3;
+    public static final int API_VERSION = 4;
     /** Time an unused dashboard remains available after its benchmark exits. */
     public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(5);
@@ -120,6 +120,9 @@ public final class DashboardServer implements AutoCloseable {
      */
     public void start() {
         server.start();
+        synchronized (lifecycleLock) {
+            scheduleIdleShutdownIfUnused();
+        }
     }
 
     /**
@@ -236,7 +239,19 @@ public final class DashboardServer implements AutoCloseable {
                 if (!state.run.runId().equals(snapshot.runId())) {
                     throw new IllegalArgumentException("Snapshot runId does not match URL");
                 }
+                if (!benchmarkSeen(state.run.runId())) {
+                    sendText(exchange, 409, "Dashboard run lease has expired", "text/plain; charset=utf-8");
+                    return;
+                }
                 state.add(snapshot);
+                exchange.sendResponseHeaders(204, -1);
+            }
+            case "heartbeat" -> {
+                requireMethod(exchange, "POST");
+                if (!benchmarkSeen(state.run.runId())) {
+                    sendText(exchange, 409, "Dashboard run lease has expired", "text/plain; charset=utf-8");
+                    return;
+                }
                 exchange.sendResponseHeaders(204, -1);
             }
             case "complete" -> {
@@ -339,7 +354,23 @@ public final class DashboardServer implements AutoCloseable {
             }
             cancelIdleShutdown();
             activeRunId = run.runId();
+            scheduleActiveRunExpiry(runs.get(activeRunId));
             return null;
+        }
+    }
+
+    private boolean benchmarkSeen(String runId) {
+        synchronized (lifecycleLock) {
+            if (!runId.equals(activeRunId) || shuttingDown) {
+                return false;
+            }
+            final RunState state = runs.get(runId);
+            if (state == null || state.completed) {
+                return false;
+            }
+            state.touch();
+            scheduleActiveRunExpiry(state);
+            return true;
         }
     }
 
@@ -367,6 +398,42 @@ public final class DashboardServer implements AutoCloseable {
             if (activeRunId == null) {
                 scheduleIdleShutdownIfUnused();
             }
+        }
+    }
+
+    private void scheduleActiveRunExpiry(RunState state) {
+        cancelIdleShutdown();
+        final long delay = Math.max(1, state.lastActivity + idleTimeout.toMillis() - System.currentTimeMillis());
+        idleShutdown = scheduler.schedule(() -> expireActiveRun(state.run.runId()), delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void expireActiveRun(String runId) {
+        boolean closeNow = false;
+        synchronized (lifecycleLock) {
+            idleShutdown = null;
+            if (!runId.equals(activeRunId) || shuttingDown) {
+                return;
+            }
+            final RunState state = runs.get(runId);
+            final long expiry = System.currentTimeMillis() - idleTimeout.toMillis();
+            if (state != null && state.lastActivity > expiry) {
+                scheduleActiveRunExpiry(state);
+                return;
+            }
+            if (state != null) {
+                state.abandon();
+            }
+            activeRunId = null;
+            browsers.entrySet().removeIf(entry -> entry.getValue() <= expiry);
+            if (browsers.isEmpty()) {
+                shuttingDown = true;
+                closeNow = true;
+            } else {
+                scheduleIdleShutdownIfUnused();
+            }
+        }
+        if (closeNow) {
+            close();
         }
     }
 
@@ -411,12 +478,15 @@ public final class DashboardServer implements AutoCloseable {
         private final ArrayDeque<DashboardSnapshot> history;
         private final CopyOnWriteArrayList<SseClient> clients;
         private volatile boolean completed;
+        private volatile boolean abandoned;
+        private volatile long lastActivity;
 
         private RunState(DashboardRun run, int retention) {
             this.run = run;
             this.retention = retention;
             this.history = new ArrayDeque<>(retention);
             this.clients = new CopyOnWriteArrayList<>();
+            this.lastActivity = System.currentTimeMillis();
         }
 
         private synchronized void add(DashboardSnapshot snapshot) throws IOException {
@@ -434,11 +504,22 @@ public final class DashboardServer implements AutoCloseable {
 
         private void complete() {
             completed = true;
-            clients.forEach(client -> client.offer("event: complete\ndata: {}\n\n"));
+            clients.forEach(client -> client.offer("event: complete\ndata: {\"abandoned\":" + abandoned
+                    + "}\n\n"));
+        }
+
+        private void abandon() {
+            completed = true;
+            abandoned = true;
+            clients.forEach(client -> client.offer("event: complete\ndata: {\"abandoned\":true}\n\n"));
+        }
+
+        private void touch() {
+            lastActivity = System.currentTimeMillis();
         }
 
         private DashboardRunView view() {
-            return new DashboardRunView(run, completed);
+            return new DashboardRunView(run, completed, abandoned);
         }
 
         private void events(HttpExchange exchange) throws IOException {
@@ -464,7 +545,7 @@ public final class DashboardServer implements AutoCloseable {
         }
     }
 
-    private record DashboardRunView(DashboardRun run, boolean completed) {
+    private record DashboardRunView(DashboardRun run, boolean completed, boolean abandoned) {
     }
 
     private static final class SseClient implements AutoCloseable {

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServerMain.java
@@ -31,7 +31,7 @@ public abstract class DashboardServerMain {
      * @throws IllegalArgumentException if an option or value is invalid
      */
     public static void main(String[] args) throws IOException, InterruptedException {
-        String host = "127.0.0.1";
+        String host = "0.0.0.0";
         int port = 9720;
         int retention = 3600;
         for (int index = 0; index < args.length; index += 2) {

--- a/sbk-api/src/main/java/io/sbk/utils/ApplicationShutdownHook.java
+++ b/sbk-api/src/main/java/io/sbk/utils/ApplicationShutdownHook.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.utils;
+
+import io.sbk.system.Printer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Registers a bounded JVM shutdown hook for an SBK application.
+ *
+ * <p>The actual application cleanup runs on a separate daemon thread. The JVM
+ * hook waits for it only for a bounded interval, ensuring that a blocked
+ * storage driver, SSH operation, logger, or network server cannot prevent the
+ * process from terminating after {@code SIGINT} or {@code SIGTERM}.
+ */
+public final class ApplicationShutdownHook {
+    private static final long SHUTDOWN_TIMEOUT_SECONDS = 3;
+
+    private ApplicationShutdownHook() {
+    }
+
+    /**
+     * Registers a shutdown hook for an application benchmark.
+     *
+     * @param applicationName application name used in lifecycle messages
+     * @param cleanup cleanup operation, normally {@code benchmark.stop()}
+     * @return the registered hook, which can be removed after normal completion
+     */
+    public static Thread register(String applicationName, Runnable cleanup) {
+        final Thread hook = new Thread(
+                () -> runBounded(applicationName, cleanup, SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                applicationName + "-shutdown-hook");
+        Runtime.getRuntime().addShutdownHook(hook);
+        return hook;
+    }
+
+    /**
+     * Removes a previously registered hook after normal application shutdown.
+     *
+     * <p>If JVM shutdown has already started, hook removal is no longer legal;
+     * this method deliberately ignores that race because the hook is already
+     * performing the requested cleanup.
+     *
+     * @param hook hook returned by {@link #register(String, Runnable)}
+     */
+    public static void remove(Thread hook) {
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook);
+        } catch (IllegalStateException ignored) {
+            // JVM shutdown is already in progress.
+        }
+    }
+
+    static void runBounded(String applicationName, Runnable cleanup, long timeout, TimeUnit unit) {
+        System.out.println();
+        Printer.log.info("{}: Shutdown signal received", applicationName);
+        final Thread cleanupThread = Thread.ofPlatform()
+                .daemon(true)
+                .name(applicationName + "-shutdown-cleanup")
+                .unstarted(cleanup);
+        cleanupThread.start();
+        try {
+            cleanupThread.join(unit.toMillis(timeout));
+            if (cleanupThread.isAlive()) {
+                Printer.log.warn("{}: Graceful shutdown exceeded {} {}; forcing process exit",
+                        applicationName, timeout, unit.toString().toLowerCase());
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            Printer.log.warn("{}: Shutdown hook interrupted; forcing process exit", applicationName);
+        }
+    }
+}

--- a/sbk-api/src/main/resources/dashboard.properties
+++ b/sbk-api/src/main/resources/dashboard.properties
@@ -6,7 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-host=127.0.0.1
+host=0.0.0.0
 port=9720
 start=true
 open=true

--- a/sbk-api/src/main/resources/dashboard/app.js
+++ b/sbk-api/src/main/resources/dashboard/app.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const colors = ['#39d5ff', '#46e6a7', '#9b8cff', '#ffb454'];
-const state = {run: null, completed: false, snapshots: [], events: null, historyTimer: null};
+const state = {run: null, completed: false, abandoned: false, snapshots: [], events: null, historyTimer: null};
 const elements = Object.fromEntries([...document.querySelectorAll('[id]')].map(item => [item.id, item]));
 const generatedBrowserId = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
     ? globalThis.crypto.randomUUID()
@@ -68,12 +68,13 @@ function update() {
     elements.title.textContent = run.name || `${run.storage} ${run.action.replace(/_/g, ' ')}`;
     elements.subtitle.textContent = `${run.source} ${run.sbkVersion}  •  ${run.storage}  •  Java ${run.javaVersion}`;
     if (!snapshot) {
-        elements.status.textContent = 'WAITING';
-        elements.status.className = 'status waiting';
+        elements.status.textContent = state.abandoned ? 'ABANDONED' : 'WAITING';
+        elements.status.className = `status ${state.abandoned ? 'abandoned' : 'waiting'}`;
         return;
     }
-    elements.status.textContent = state.completed || snapshot.total ? 'COMPLETE' : 'RUNNING';
-    elements.status.className = `status ${state.completed || snapshot.total ? 'complete' : 'running'}`;
+    const status = state.abandoned ? 'ABANDONED' : state.completed || snapshot.total ? 'COMPLETE' : 'RUNNING';
+    elements.status.textContent = status;
+    elements.status.className = `status ${status.toLowerCase()}`;
     elements.elapsed.textContent = duration(snapshot.performance.seconds);
     elements.recordsRate.textContent = compact(snapshot.performance.recordsPerSec);
     elements.throughput.textContent = `${snapshot.performance.mbPerSec.toFixed(2)} MB/s`;
@@ -182,6 +183,7 @@ async function selectRun(runView) {
     if (state.historyTimer) clearInterval(state.historyTimer);
     state.run = runView.run;
     state.completed = runView.completed;
+    state.abandoned = runView.abandoned;
     state.snapshots = [];
     history.replaceState(null, '', `/?run=${state.run.runId}`);
     update();
@@ -197,7 +199,11 @@ async function selectRun(runView) {
         mergeSnapshot(JSON.parse(event.data));
         update();
     });
-    state.events.addEventListener('complete', () => { state.completed = true; update(); });
+    state.events.addEventListener('complete', event => {
+        state.completed = true;
+        state.abandoned = JSON.parse(event.data).abandoned === true;
+        update();
+    });
 }
 
 async function loadRuns() {

--- a/sbk-api/src/main/resources/dashboard/app.js
+++ b/sbk-api/src/main/resources/dashboard/app.js
@@ -10,9 +10,12 @@
 'use strict';
 
 const colors = ['#39d5ff', '#46e6a7', '#9b8cff', '#ffb454'];
-const state = {run: null, completed: false, snapshots: [], events: null};
+const state = {run: null, completed: false, snapshots: [], events: null, historyTimer: null};
 const elements = Object.fromEntries([...document.querySelectorAll('[id]')].map(item => [item.id, item]));
-const browserId = sessionStorage.getItem('sbkDashboardBrowserId') || crypto.randomUUID();
+const generatedBrowserId = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
+    ? globalThis.crypto.randomUUID()
+    : `sbk-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const browserId = sessionStorage.getItem('sbkDashboardBrowserId') || generatedBrowserId;
 sessionStorage.setItem('sbkDashboardBrowserId', browserId);
 
 function updateBrowserLease() {
@@ -59,13 +62,18 @@ function percentile(snapshot, target) {
 }
 
 function update() {
-    const snapshot = state.snapshots.at(-1);
-    if (!snapshot || !state.run) return;
+    const snapshot = state.snapshots[state.snapshots.length - 1];
+    if (!state.run) return;
     const run = state.run;
+    elements.title.textContent = run.name || `${run.storage} ${run.action.replace(/_/g, ' ')}`;
+    elements.subtitle.textContent = `${run.source} ${run.sbkVersion}  •  ${run.storage}  •  Java ${run.javaVersion}`;
+    if (!snapshot) {
+        elements.status.textContent = 'WAITING';
+        elements.status.className = 'status waiting';
+        return;
+    }
     elements.status.textContent = state.completed || snapshot.total ? 'COMPLETE' : 'RUNNING';
     elements.status.className = `status ${state.completed || snapshot.total ? 'complete' : 'running'}`;
-    elements.title.textContent = run.name || `${run.storage} ${run.action.replaceAll('_', ' ')}`;
-    elements.subtitle.textContent = `${run.source} ${run.sbkVersion}  •  ${run.storage}  •  Java ${run.javaVersion}`;
     elements.elapsed.textContent = duration(snapshot.performance.seconds);
     elements.recordsRate.textContent = compact(snapshot.performance.recordsPerSec);
     elements.throughput.textContent = `${snapshot.performance.mbPerSec.toFixed(2)} MB/s`;
@@ -81,6 +89,28 @@ function update() {
     elements.totalRecords.textContent = compact(snapshot.performance.records);
     elements.totalBytes.textContent = bytes(snapshot.performance.bytes);
     drawAll();
+}
+
+function mergeSnapshot(snapshot) {
+    const existing = state.snapshots.findIndex(item => item.timestamp === snapshot.timestamp
+        && item.total === snapshot.total);
+    if (existing >= 0) {
+        state.snapshots[existing] = snapshot;
+    } else {
+        state.snapshots.push(snapshot);
+    }
+    state.snapshots.sort((left, right) => left.timestamp - right.timestamp);
+    if (state.snapshots.length > 3600) state.snapshots.splice(0, state.snapshots.length - 3600);
+}
+
+async function refreshHistory(runId) {
+    const response = await fetch(`/api/v1/runs/${runId}/history`, {cache: 'no-store'});
+    if (!response.ok) throw new Error(`History request returned HTTP ${response.status}`);
+    const snapshots = await response.json();
+    if (!state.run || state.run.runId !== runId) return;
+    snapshots.forEach(mergeSnapshot);
+    if (snapshots.some(snapshot => snapshot.total)) state.completed = true;
+    update();
 }
 
 function drawChart(canvas, series) {
@@ -149,23 +179,30 @@ function drawAll() {
 
 async function selectRun(runView) {
     if (state.events) state.events.close();
+    if (state.historyTimer) clearInterval(state.historyTimer);
     state.run = runView.run;
     state.completed = runView.completed;
-    const response = await fetch(`/api/v1/runs/${state.run.runId}/history`);
-    state.snapshots = await response.json();
+    state.snapshots = [];
     history.replaceState(null, '', `/?run=${state.run.runId}`);
     update();
-    state.events = new EventSource(`/api/v1/runs/${state.run.runId}/events`);
+    const runId = state.run.runId;
+    await refreshHistory(runId);
+    state.historyTimer = setInterval(() => {
+        refreshHistory(runId).catch(error => {
+            elements.subtitle.textContent = `Dashboard refresh error: ${error.message}`;
+        });
+    }, 2000);
+    state.events = new EventSource(`/api/v1/runs/${runId}/events`);
     state.events.addEventListener('snapshot', event => {
-        state.snapshots.push(JSON.parse(event.data));
-        if (state.snapshots.length > 3600) state.snapshots.shift();
+        mergeSnapshot(JSON.parse(event.data));
         update();
     });
     state.events.addEventListener('complete', () => { state.completed = true; update(); });
 }
 
 async function loadRuns() {
-    const response = await fetch('/api/v1/runs');
+    const response = await fetch('/api/v1/runs', {cache: 'no-store'});
+    if (!response.ok) throw new Error(`Runs request returned HTTP ${response.status}`);
     const runs = await response.json();
     runs.sort((a, b) => b.run.startedAt - a.run.startedAt);
     elements.runs.innerHTML = '';

--- a/sbk-api/src/main/resources/dashboard/style.css
+++ b/sbk-api/src/main/resources/dashboard/style.css
@@ -63,6 +63,7 @@ select {
 .status { display: inline-block; padding: 4px 9px; border-radius: 999px; font-size: .68rem; font-weight: 900; letter-spacing: .1em; }
 .status.running { color: #042518; background: var(--green); box-shadow: 0 0 24px rgba(70, 230, 167, .35); }
 .status.complete { color: #061a2a; background: var(--cyan); }
+.status.abandoned { color: #2b0710; background: #ff6b88; }
 .status.waiting { color: #392408; background: var(--orange); }
 .elapsed { font: 700 clamp(1.8rem, 4vw, 3.3rem)/1 ui-monospace, SFMono-Regular, monospace; color: #d8f7ff; }
 

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -178,6 +178,93 @@ final class DashboardServerTest {
         }
     }
 
+    @Test
+    void abandonedRunWithoutBrowserStopsDashboard() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(300);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+
+        assertEquals(201, post(baseUri.resolve("/api/v1/runs"),
+                MAPPER.writeValueAsString(run("abandoned-run"))).statusCode());
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void abandonedRunRemainsForAttachedBrowserAndReleasesOwnership() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(300);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        assertEquals(201, post(baseUri.resolve("/api/v1/runs"),
+                MAPPER.writeValueAsString(run("browser-retained-abandoned-run"))).statusCode());
+
+        String runs = "";
+        for (int refresh = 0; refresh < 10 && !runs.contains("\"abandoned\":true"); refresh++) {
+            post(baseUri.resolve("/api/v1/browser/connect"), "{\"browserId\":\"lease-browser\"}");
+            Thread.sleep(100);
+            runs = get(baseUri.resolve("/api/v1/runs")).body();
+        }
+        assertTrue(runs.contains("\"abandoned\":true"));
+        assertEquals(201, post(baseUri.resolve("/api/v1/runs"),
+                MAPPER.writeValueAsString(run("replacement-run"))).statusCode());
+        assertEquals(204, post(baseUri.resolve("/api/v1/runs/replacement-run/complete"), "{}").statusCode());
+        post(baseUri.resolve("/api/v1/browser/disconnect"), "{\"browserId\":\"lease-browser\"}");
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void clientHeartbeatRenewsActiveRunLease() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(300);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+
+        try (DashboardClient ignored = DashboardClient.connect(config(server.getAddress().getPort()),
+                run("heartbeat-run"), Duration.ofMillis(75))) {
+            Thread.sleep(800);
+            assertEquals(200, get(baseUri.resolve("/api/v1/health")).statusCode());
+            assertTrue(get(baseUri.resolve("/api/v1/runs")).body().contains("\"completed\":false"));
+        }
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void snapshotsRenewActiveRunLease() throws Exception {
+        final Duration idleTimeout = Duration.ofMillis(300);
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2, idleTimeout,
+                Duration.ofMillis(20));
+        server.start();
+        final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        assertEquals(201, post(baseUri.resolve("/api/v1/runs"),
+                MAPPER.writeValueAsString(run("snapshot-lease-run"))).statusCode());
+
+        for (int sequence = 1; sequence <= 6; sequence++) {
+            Thread.sleep(100);
+            assertEquals(204, post(baseUri.resolve("/api/v1/runs/snapshot-lease-run/snapshots"),
+                    MAPPER.writeValueAsString(snapshot("snapshot-lease-run", sequence))).statusCode());
+        }
+        assertEquals(200, get(baseUri.resolve("/api/v1/health")).statusCode());
+        assertTrue(get(baseUri.resolve("/api/v1/runs")).body().contains("\"completed\":false"));
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
+    @Test
+    void dashboardWithoutBenchmarkOrBrowserStopsAfterIdleTimeout() throws Exception {
+        final DashboardServer server = new DashboardServer("127.0.0.1", 0, 2,
+                Duration.ofMillis(200), Duration.ofMillis(20));
+        server.start();
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), server::awaitTermination);
+    }
+
     private static DashboardSnapshot[] waitForHistory(URI baseUri, String runId, int expected) throws Exception {
         final long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
         DashboardSnapshot[] snapshots = new DashboardSnapshot[0];

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -12,6 +12,7 @@ package io.sbk.dashboard;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -69,10 +70,36 @@ final class DashboardServerTest {
             try (DashboardClient client = DashboardClient.connect(config, run("plain-http-run"))) {
                 assertEquals("http", client.getRunUri().getScheme());
                 assertEquals("127.0.0.1", client.getRunUri().getHost());
+                assertTrue(client.getRunLinks().stream().anyMatch(link -> "Hostname".equals(link.label())));
                 assertEquals(200, get(URI.create("http://127.0.0.1:" + server.getAddress().getPort()
                         + "/api/v1/health")).statusCode());
             }
         }
+    }
+
+    @Test
+    void createsCopyPasteLinksForHostnameAndHostAddresses() throws Exception {
+        final var links = DashboardClient.dashboardLinks("0.0.0.0", 9720, "test-run", "benchmark-host",
+                java.util.List.of(InetAddress.getByName("127.0.0.1"), InetAddress.getByName("10.2.3.4"),
+                        InetAddress.getByName("8.8.8.8")));
+
+        assertEquals("http://127.0.0.1:9720/?run=test-run", links.get(0).uri().toString());
+        assertTrue(links.stream().anyMatch(link -> "Hostname".equals(link.label())
+                && "benchmark-host".equals(link.uri().getHost())));
+        assertTrue(links.stream().anyMatch(link -> "Public IP".equals(link.label())
+                && "8.8.8.8".equals(link.uri().getHost())));
+        assertTrue(links.stream().anyMatch(link -> "Private IP".equals(link.label())
+                && "10.2.3.4".equals(link.uri().getHost())));
+    }
+
+    @Test
+    void doesNotAdvertiseRemoteLinksForLoopbackBinding() throws Exception {
+        final var links = DashboardClient.dashboardLinks("127.0.0.1", 9720, "test-run", "benchmark-host",
+                java.util.List.of(InetAddress.getByName("10.2.3.4")));
+
+        assertEquals(1, links.size());
+        assertEquals("Configured", links.getFirst().label());
+        assertEquals("127.0.0.1", links.getFirst().uri().getHost());
     }
 
     @Test

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -61,6 +61,21 @@ final class DashboardServerTest {
     }
 
     @Test
+    void connectsOverPlainHttpWhenServerListensOnAllInterfaces() throws Exception {
+        try (DashboardServer server = new DashboardServer("0.0.0.0", 0, 2)) {
+            server.start();
+            final DashboardConfig config = config(server.getAddress().getPort());
+            config.host = "0.0.0.0";
+            try (DashboardClient client = DashboardClient.connect(config, run("plain-http-run"))) {
+                assertEquals("http", client.getRunUri().getScheme());
+                assertEquals("127.0.0.1", client.getRunUri().getHost());
+                assertEquals(200, get(URI.create("http://127.0.0.1:" + server.getAddress().getPort()
+                        + "/api/v1/health")).statusCode());
+            }
+        }
+    }
+
+    @Test
     void rejectsASecondActiveBenchmarkWithOwnershipDetails() throws Exception {
         try (DashboardServer server = new DashboardServer("127.0.0.1", 0, 2)) {
             server.start();

--- a/sbk-api/src/test/java/io/sbk/utils/ApplicationShutdownHookTest.java
+++ b/sbk-api/src/test/java/io/sbk/utils/ApplicationShutdownHookTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests bounded application shutdown execution. */
+public class ApplicationShutdownHookTest {
+
+    /** Verifies that a cleanup operation is invoked and allowed to finish. */
+    @Test
+    public void completesCleanup() {
+        final AtomicBoolean cleaned = new AtomicBoolean();
+
+        ApplicationShutdownHook.runBounded("test", () -> cleaned.set(true), 1, TimeUnit.SECONDS);
+
+        assertTrue(cleaned.get());
+    }
+
+    /** Verifies that a blocked cleanup operation cannot block the hook indefinitely. */
+    @Test
+    public void boundsBlockedCleanup() {
+        final CountDownLatch blocked = new CountDownLatch(1);
+        final long start = System.nanoTime();
+
+        ApplicationShutdownHook.runBounded("test", () -> {
+            try {
+                blocked.await();
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }, 20, TimeUnit.MILLISECONDS);
+
+        final long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        assertTrue(elapsedMillis < 1000, "shutdown cleanup must have a bounded wait");
+    }
+}

--- a/sbk-gem/README.md
+++ b/sbk-gem/README.md
@@ -136,12 +136,15 @@ Before a multi-host run:
 | `GemPrometheusLogger` | GEM/SBM aggregate metrics output |
 | `GemWebLogger` | GEM adapter for the embedded SBM local live dashboard |
 
-Select `-out GemWebLogger` for dependency-free aggregate graphs at `http://127.0.0.1:9720`. Remote SBK processes
-still use `GrpcLogger`; the embedded SBM publishes the combined cluster result to the local dashboard. Dashboard
+Select `-out GemWebLogger` for dependency-free aggregate graphs. The dashboard uses plain HTTP and listens on all
+interfaces at port 9720 by default; open `http://127.0.0.1:9720` locally or
+`http://<sbk-gem-host>:9720` remotely. Remote SBK processes still use `GrpcLogger`; the embedded SBM publishes the
+combined cluster result to the local dashboard. Dashboard
 options are listed by `sbk-gem -out GemWebLogger -help` and are forwarded only to the local SBM logger. A running
 idle dashboard is reused, but an active SBK, SBM, or SBK-GEM WebLogger owner causes SBK-GEM to exit with a clear
 ownership error. After a run, graphs remain available while a browser is connected; the unused dashboard exits
-after one minute.
+after one minute. Dashboard HTTP access does not use SBK-GEM's SSH connections and is not encrypted; expose it only
+on a trusted benchmark network.
 
 See the [WebLogger guide](../docs/WEB_LOGGER.md) for dashboard options, ownership and shutdown behavior, network
 security, and complete SBK, SBM, and SBK-GEM examples.

--- a/sbk-gem/src/main/java/io/gem/api/impl/SbkGem.java
+++ b/sbk-gem/src/main/java/io/gem/api/impl/SbkGem.java
@@ -31,6 +31,7 @@ import io.sbk.logger.impl.GrpcLogger;
 import io.sbk.params.InputParameterOptions;
 import io.sbk.params.impl.SbkDriversParameters;
 import io.sbm.logger.RamLogger;
+import io.sbk.utils.ApplicationShutdownHook;
 import io.sbk.utils.SbkUtils;
 import io.sbk.config.Config;
 import io.sbm.config.SbmConfig;
@@ -120,14 +121,14 @@ final public class SbkGem {
         } catch (HelpException ex) {
             return null;
         }
-        final CompletableFuture<RemoteResponse[]> ret = benchmark.start();
-        ret.thenAccept(results -> printRemoteResults(results, false));
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println();
-            benchmark.stop();
-        }));
-        return ret.get();
+        final Thread shutdownHook = ApplicationShutdownHook.register("SBK-GEM", benchmark::stop);
+        try {
+            final CompletableFuture<RemoteResponse[]> ret = benchmark.start();
+            ret.thenAccept(results -> printRemoteResults(results, false));
+            return ret.get();
+        } finally {
+            ApplicationShutdownHook.remove(shutdownHook);
+        }
     }
 
 

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -62,11 +62,12 @@ Start a dependency-free local live dashboard instead of Prometheus:
 ./sbm/build/install/sbm/bin/sbm -out SbmWebLogger -class file -action r
 ```
 
-The browser dashboard defaults to `http://127.0.0.1:9720` and displays aggregate SBM connection, workload,
-throughput, request-pressure, timeout, and latency-percentile data. It permits one active WebLogger benchmark,
+The browser dashboard uses plain HTTP and listens on all interfaces at port 9720 by default. Open
+`http://127.0.0.1:9720` locally or `http://<sbm-host>:9720` remotely. It displays aggregate SBM connection,
+workload, throughput, request-pressure, timeout, and latency-percentile data. It permits one active WebLogger benchmark,
 keeps completed graphs while a browser remains connected, and exits after one minute without a connected browser.
 An existing idle dashboard is reused; an active SBK, SBM, or SBK-GEM dashboard owner causes SBM to exit with an
-ownership error.
+ownership error. The dashboard does not start SSH or enable TLS; expose it only on a trusted benchmark network.
 
 See the [WebLogger guide](../docs/WEB_LOGGER.md) for dashboard options, lifecycle, browser leases, security, and a
 complete distributed example.

--- a/sbm/src/main/java/io/sbm/api/impl/Sbm.java
+++ b/sbm/src/main/java/io/sbm/api/impl/Sbm.java
@@ -16,6 +16,7 @@ import io.micrometer.core.instrument.util.IOUtils;
 import io.perl.api.impl.PerlBuilder;
 import io.sbk.api.Benchmark;
 import io.sbk.config.Config;
+import io.sbk.utils.ApplicationShutdownHook;
 import io.sbk.utils.SbkUtils;
 import io.sbm.api.RamLoggerPackage;
 import io.sbm.config.SbmConfig;
@@ -87,13 +88,13 @@ final public class Sbm {
         } catch (HelpException ex) {
             return;
         }
-        final CompletableFuture<Void> ret = benchmark.start();
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println();
-            benchmark.stop();
-        }));
-        ret.get();
+        final Thread shutdownHook = ApplicationShutdownHook.register("SBM", benchmark::stop);
+        try {
+            final CompletableFuture<Void> ret = benchmark.start();
+            ret.get();
+        } finally {
+            ApplicationShutdownHook.remove(shutdownHook);
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- bind the WebLogger dashboard to all network interfaces by default for direct unsecured HTTP access
- keep local dashboard publication and browser URLs on loopback when using the wildcard bind address
- document that dashboard SSH, TLS, and HTTPS are disabled by default and describe the trusted-network implications
- add integration coverage for plain HTTP with an all-interface listener

## Validation
- `./gradlew :sbk-api:check`
- `./gradlew check`
- `./gradlew installDist`
- installed `sbk -out WebLogger -help` reports `dashboardhost` default `0.0.0.0`
- installed one-second Null/WebLogger smoke benchmark passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified dashboard networking, lifecycle, ownership, and access behavior.
  * Documented plain HTTP access on port 9720, including local and remote URLs.
  * Added security guidance recommending trusted networks and loopback binding when remote access is unnecessary.
  * Updated dashboard option and troubleshooting guidance.

* **Improvements**
  * Dashboard graphs now recover historical snapshots when live updates are delayed or interrupted.
  * Improved dashboard handling for waiting, completed, and disconnected runs.
  * Wildcard server binding now connects correctly through the local browser/client address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->