### PR TITLE
Fix WebLogger interval result publishing

### DIFF
--- a/docs/WEB_LOGGER.md
+++ b/docs/WEB_LOGGER.md
@@ -69,7 +69,10 @@ disable automatic browser opening and connect through an appropriate secure tunn
 
 The graphs show completed record rate and throughput, write/read request rates, worker and connection counts,
 pending requests, timeout and invalid-latency counts, average/minimum/maximum latency, and configured latency
-percentiles. The final total snapshot remains selectable after the benchmark finishes.
+percentiles. Every point represents one regular SBK reporting window (five seconds by default). Cumulative
+`printTotal` results produced at shutdown or by a total-buffer flush are deliberately excluded because mixing
+cumulative and interval values would distort the live graphs. The last interval snapshot remains selectable after
+the benchmark finishes.
 
 ## Dashboard options
 
@@ -108,7 +111,8 @@ The server lifecycle is:
 2. A compatible idle server is reused; another server process is not started.
 3. The active logger renews its run lease every 15 seconds. Publishing a measurement snapshot also renews the same
    lease, so normal reporting traffic needs no separate heartbeat.
-4. When the benchmark finishes normally, its bounded history and final snapshot remain in server memory.
+4. When the benchmark finishes normally, its bounded interval history remains in server memory. Completion is
+   tracked as run metadata rather than as a cumulative performance snapshot.
 5. If the benchmark process disappears without completing its run, one minute without a snapshot or logger
    heartbeat marks the run as abandoned and releases dashboard ownership. A new benchmark can then register.
 6. An open browser renews a separate lightweight lease every 15 seconds, keeping completed or abandoned graphs

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
@@ -127,9 +127,15 @@ public final class DashboardLoggerSupport implements AutoCloseable {
     }
 
     /**
-     * Publishes one periodic or total snapshot without blocking the caller on HTTP I/O.
+     * Publishes one periodic snapshot without blocking the caller on HTTP I/O.
      *
-     * @param total                           whether this is the final total
+     * <p>Total snapshots are deliberately ignored. They contain cumulative data
+     * produced at benchmark shutdown or when the total latency buffer is
+     * flushed, whereas dashboard charts represent the regular reporting
+     * windows. Mixing both forms would add a cumulative point to an interval
+     * series and distort its graphs.</p>
+     *
+     * @param total                           whether this is a cumulative total to ignore
      * @param connections                     active connections
      * @param maxConnections                  maximum connections
      * @param writers                         active writers
@@ -182,7 +188,7 @@ public final class DashboardLoggerSupport implements AutoCloseable {
                         double recordsPerSec, double mbPerSec, double averageLatency, long minimumLatency,
                         long maximumLatency, long invalid, long lowerDiscard, long higherDiscard,
                         long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
-        if (client == null) {
+        if (total || client == null) {
             return;
         }
         final DashboardSnapshot.WorkerMetrics workers = new DashboardSnapshot.WorkerMetrics(writers, maxWriters,
@@ -198,7 +204,7 @@ public final class DashboardLoggerSupport implements AutoCloseable {
         final DashboardSnapshot.LatencyMetrics latency = new DashboardSnapshot.LatencyMetrics(averageLatency,
                 minimumLatency, maximumLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentiles,
                 percentileLatencies, percentileLatencyCounts);
-        client.publish(new DashboardSnapshot(runId, System.currentTimeMillis(), total, workers, requests,
+        client.publish(new DashboardSnapshot(runId, System.currentTimeMillis(), false, workers, requests,
                 performance, latency));
     }
 

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardLoggerSupport.java
@@ -127,15 +127,9 @@ public final class DashboardLoggerSupport implements AutoCloseable {
     }
 
     /**
-     * Publishes one periodic snapshot without blocking the caller on HTTP I/O.
+     * Publishes one regular reporting-window snapshot without blocking the
+     * caller on HTTP I/O.
      *
-     * <p>Total snapshots are deliberately ignored. They contain cumulative data
-     * produced at benchmark shutdown or when the total latency buffer is
-     * flushed, whereas dashboard charts represent the regular reporting
-     * windows. Mixing both forms would add a cumulative point to an interval
-     * series and distort its graphs.</p>
-     *
-     * @param total                           whether this is a cumulative total to ignore
      * @param connections                     active connections
      * @param maxConnections                  maximum connections
      * @param writers                         active writers
@@ -176,7 +170,7 @@ public final class DashboardLoggerSupport implements AutoCloseable {
      * @param percentileLatencies             percentile values
      * @param percentileLatencyCounts         percentile counts
      */
-    public void publish(boolean total, int connections, int maxConnections, int writers, int maxWriters,
+    public void publish(int connections, int maxConnections, int writers, int maxWriters,
                         int readers, int maxReaders, long writeRequestBytes, double writeRequestMbPerSec,
                         long writeRequestRecords, double writeRequestRecordsPerSec, long readRequestBytes,
                         double readRequestMbPerSec, long readRequestRecords, double readRequestRecordsPerSec,
@@ -188,7 +182,7 @@ public final class DashboardLoggerSupport implements AutoCloseable {
                         double recordsPerSec, double mbPerSec, double averageLatency, long minimumLatency,
                         long maximumLatency, long invalid, long lowerDiscard, long higherDiscard,
                         long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
-        if (total || client == null) {
+        if (client == null) {
             return;
         }
         final DashboardSnapshot.WorkerMetrics workers = new DashboardSnapshot.WorkerMetrics(writers, maxWriters,
@@ -204,7 +198,7 @@ public final class DashboardLoggerSupport implements AutoCloseable {
         final DashboardSnapshot.LatencyMetrics latency = new DashboardSnapshot.LatencyMetrics(averageLatency,
                 minimumLatency, maximumLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentiles,
                 percentileLatencies, percentileLatencyCounts);
-        client.publish(new DashboardSnapshot(runId, System.currentTimeMillis(), false, workers, requests,
+        client.publish(new DashboardSnapshot(runId, System.currentTimeMillis(), workers, requests,
                 performance, latency));
     }
 

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardServer.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class DashboardServer implements AutoCloseable {
     /** Dashboard HTTP API version. */
-    public static final int API_VERSION = 4;
+    public static final int API_VERSION = 5;
     /** Time an unused dashboard remains available after its benchmark exits. */
     public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(5);

--- a/sbk-api/src/main/java/io/sbk/dashboard/DashboardSnapshot.java
+++ b/sbk-api/src/main/java/io/sbk/dashboard/DashboardSnapshot.java
@@ -14,13 +14,12 @@ package io.sbk.dashboard;
  *
  * @param runId       benchmark run identifier
  * @param timestamp   snapshot time in epoch milliseconds
- * @param total       whether this is the final cumulative snapshot
  * @param workers     active and maximum worker/connection counts
  * @param requests    request, pending-operation, and timeout statistics
  * @param performance completed data and throughput statistics
  * @param latency     latency distribution summary
  */
-public record DashboardSnapshot(String runId, long timestamp, boolean total, WorkerMetrics workers,
+public record DashboardSnapshot(String runId, long timestamp, WorkerMetrics workers,
                                 RequestMetrics requests, PerformanceMetrics performance,
                                 LatencyMetrics latency) {
 

--- a/sbk-api/src/main/java/io/sbk/logger/impl/WebLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/WebLogger.java
@@ -77,7 +77,7 @@ public class WebLogger extends CSVLogger {
                 readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency,
                 maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
                 percentileLatencyCounts);
-        publish(false, writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
+        publish(writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
                 writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
                 readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords, writeResponsePendingBytes,
                 readResponsePendingRecords, readResponsePendingBytes, writeReadRequestPendingRecords,
@@ -108,17 +108,9 @@ public class WebLogger extends CSVLogger {
                 writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
                 recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
                 slc1, slc2, percentileLatencies, percentileLatencyCounts);
-        publish(true, writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
-                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
-                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords, writeResponsePendingBytes,
-                readResponsePendingRecords, readResponsePendingBytes, writeReadRequestPendingRecords,
-                writeReadRequestPendingBytes, writeTimeoutEvents, writeTimeoutEventsPerSec, readTimeoutEvents,
-                readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency, minLatency,
-                maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
-                percentileLatencyCounts);
     }
 
-    private void publish(boolean total, int writers, int maxWriters, int readers, int maxReaders,
+    private void publish(int writers, int maxWriters, int readers, int maxReaders,
                          long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,
                          double writeRequestRecordsPerSec, long readRequestBytes, double readRequestMbPerSec,
                          long readRequestRecords, double readRequestRecordsPerSec,
@@ -130,7 +122,7 @@ public class WebLogger extends CSVLogger {
                          double recsPerSec, double mbPerSec, double avgLatency, long minLatency, long maxLatency,
                          long invalid, long lowerDiscard, long higherDiscard, long slc1, long slc2,
                          long[] percentileLatencies, long[] percentileLatencyCounts) {
-        dashboard.publish(total, 0, 0, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+        dashboard.publish(0, 0, writers, maxWriters, readers, maxReaders, writeRequestBytes,
                 writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
                 readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
                 writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,

--- a/sbk-api/src/main/resources/dashboard/app.js
+++ b/sbk-api/src/main/resources/dashboard/app.js
@@ -54,7 +54,6 @@ function duration(seconds) {
 }
 
 function elapsedSeconds(run, snapshot) {
-    if (snapshot.total) return snapshot.performance.seconds;
     return Math.max(0, (snapshot.timestamp - run.startedAt) / 1000);
 }
 
@@ -77,7 +76,7 @@ function update() {
         elements.status.className = `status ${state.abandoned ? 'abandoned' : 'waiting'}`;
         return;
     }
-    const status = state.abandoned ? 'ABANDONED' : state.completed || snapshot.total ? 'COMPLETE' : 'RUNNING';
+    const status = state.abandoned ? 'ABANDONED' : state.completed ? 'COMPLETE' : 'RUNNING';
     elements.status.textContent = status;
     elements.status.className = `status ${status.toLowerCase()}`;
     elements.elapsed.textContent = duration(elapsedSeconds(run, snapshot));
@@ -92,14 +91,13 @@ function update() {
     elements.timeouts.textContent = compact(snapshot.requests.writeTimeouts + snapshot.requests.readTimeouts);
     elements.invalid.textContent = compact(snapshot.latency.invalid);
     elements.discarded.textContent = compact(snapshot.latency.lowerDiscard + snapshot.latency.higherDiscard);
-    elements.totalRecords.textContent = compact(snapshot.performance.records);
-    elements.totalBytes.textContent = bytes(snapshot.performance.bytes);
+    elements.windowRecords.textContent = compact(snapshot.performance.records);
+    elements.windowBytes.textContent = bytes(snapshot.performance.bytes);
     drawAll();
 }
 
 function mergeSnapshot(snapshot) {
-    const existing = state.snapshots.findIndex(item => item.timestamp === snapshot.timestamp
-        && item.total === snapshot.total);
+    const existing = state.snapshots.findIndex(item => item.timestamp === snapshot.timestamp);
     if (existing >= 0) {
         state.snapshots[existing] = snapshot;
     } else {
@@ -115,7 +113,6 @@ async function refreshHistory(runId) {
     const snapshots = await response.json();
     if (!state.run || state.run.runId !== runId) return;
     snapshots.forEach(mergeSnapshot);
-    if (snapshots.some(snapshot => snapshot.total)) state.completed = true;
     update();
 }
 

--- a/sbk-api/src/main/resources/dashboard/index.html
+++ b/sbk-api/src/main/resources/dashboard/index.html
@@ -69,8 +69,8 @@ http://www.apache.org/licenses/LICENSE-2.0
                 <div><span>Timeout events</span><strong id="timeouts">0</strong></div>
                 <div><span>Invalid latencies</span><strong id="invalid">0</strong></div>
                 <div><span>Discarded latencies</span><strong id="discarded">0</strong></div>
-                <div><span>Total records</span><strong id="totalRecords">0</strong></div>
-                <div><span>Total bytes</span><strong id="totalBytes">0 B</strong></div>
+                <div><span>Window records</span><strong id="windowRecords">0</strong></div>
+                <div><span>Window bytes</span><strong id="windowBytes">0 B</strong></div>
             </div>
         </article>
     </section>

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -9,6 +9,9 @@
  */
 package io.sbk.dashboard;
 
+import io.sbk.action.Action;
+import io.sbk.params.impl.SbkParameters;
+import io.time.TimeUnit;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -18,8 +21,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -324,6 +330,37 @@ final class DashboardServerTest {
         assertThrows(IllegalArgumentException.class, () -> SbkDashboardServerMain.retentionSnapshots(0));
     }
 
+    @Test
+    void loggerSupportPublishesOnlyRegularIntervalResults() throws Exception {
+        try (DashboardServer server = new DashboardServer("127.0.0.1", 0, 4)) {
+            server.start();
+            final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+            final DashboardLoggerSupport support = new DashboardLoggerSupport();
+            final SbkParameters parameters = new SbkParameters("dashboard-test");
+            support.addArgs(parameters);
+            parameters.parseArgs(new String[]{"-writers", "1", "-size", "100",
+                    "-dashboardhost", "127.0.0.1", "-dashboardport",
+                    Integer.toString(server.getAddress().getPort()),
+                    "-dashboardstart", "false", "-dashboardopen", "false"});
+            support.parseArgs(parameters);
+
+            support.open("SBK", "File", Action.Writing, TimeUnit.ns,
+                    new double[]{50, 99});
+            final String runId = activeRunId(baseUri);
+            publish(support, false, 10);
+            assertEquals(1, waitForHistory(baseUri, runId, 1).length);
+            publish(support, true, 1000);
+            support.close();
+
+            final DashboardSnapshot[] history = MAPPER.readValue(
+                    get(baseUri.resolve("/api/v1/runs/" + runId + "/history")).body(),
+                    DashboardSnapshot[].class);
+            assertEquals(1, history.length);
+            assertEquals(10, history[0].performance().records());
+            assertFalse(history[0].total());
+        }
+    }
+
     private static DashboardSnapshot[] waitForHistory(URI baseUri, String runId, int expected) throws Exception {
         final long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
         DashboardSnapshot[] snapshots = new DashboardSnapshot[0];
@@ -372,5 +409,25 @@ final class DashboardServerTest {
                 new DashboardSnapshot.PerformanceMetrics(records, records * 100, records, records, 1),
                 new DashboardSnapshot.LatencyMetrics(10, 1, 20, 0, 0, 0, 0, 0,
                         new double[]{50, 99}, new long[]{10, 20}, new long[]{1, 1}));
+    }
+
+    private static String activeRunId(URI baseUri) throws Exception {
+        final List<?> runs = MAPPER.readValue(
+                get(baseUri.resolve("/api/v1/runs")).body(), List.class);
+        assertEquals(1, runs.size());
+        final Map<?, ?> view = (Map<?, ?>) runs.getFirst();
+        final Map<?, ?> run = (Map<?, ?>) view.get("run");
+        return run.get("runId").toString();
+    }
+
+    private static void publish(DashboardLoggerSupport support, boolean total, long records) {
+        support.publish(total, 0, 0, 1, 1, 0, 0,
+                records * 100, 1, records, 1,
+                0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+                5, records * 100, records, records, 1,
+                10, 1, 20, 0, 0, 0, 0, 0,
+                new long[]{10, 20}, new long[]{1, 1});
     }
 }

--- a/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/dashboard/DashboardServerTest.java
@@ -10,8 +10,9 @@
 package io.sbk.dashboard;
 
 import io.sbk.action.Action;
+import io.sbk.logger.impl.WebLogger;
 import io.sbk.params.impl.SbkParameters;
-import io.time.TimeUnit;
+import io.time.NanoSeconds;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
@@ -331,33 +332,37 @@ final class DashboardServerTest {
     }
 
     @Test
-    void loggerSupportPublishesOnlyRegularIntervalResults() throws Exception {
+    void webLoggerPublishesOnlyRegularIntervalResults() throws Exception {
         try (DashboardServer server = new DashboardServer("127.0.0.1", 0, 4)) {
             server.start();
             final URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
-            final DashboardLoggerSupport support = new DashboardLoggerSupport();
+            final WebLogger logger = new WebLogger();
             final SbkParameters parameters = new SbkParameters("dashboard-test");
-            support.addArgs(parameters);
+            logger.addArgs(parameters);
             parameters.parseArgs(new String[]{"-writers", "1", "-size", "100",
                     "-dashboardhost", "127.0.0.1", "-dashboardport",
                     Integer.toString(server.getAddress().getPort()),
                     "-dashboardstart", "false", "-dashboardopen", "false"});
-            support.parseArgs(parameters);
+            logger.parseArgs(parameters);
 
-            support.open("SBK", "File", Action.Writing, TimeUnit.ns,
-                    new double[]{50, 99});
-            final String runId = activeRunId(baseUri);
-            publish(support, false, 10);
-            assertEquals(1, waitForHistory(baseUri, runId, 1).length);
-            publish(support, true, 1000);
-            support.close();
+            logger.open(parameters, "File", Action.Writing, new NanoSeconds());
+            final String runId;
+            try {
+                runId = activeRunId(baseUri);
+                emitResult(logger, false, 10);
+                assertEquals(1, waitForHistory(baseUri, runId, 1).length);
+                emitResult(logger, true, 1000);
+            } finally {
+                logger.close(parameters);
+            }
 
-            final DashboardSnapshot[] history = MAPPER.readValue(
-                    get(baseUri.resolve("/api/v1/runs/" + runId + "/history")).body(),
-                    DashboardSnapshot[].class);
+            final String historyJson =
+                    get(baseUri.resolve("/api/v1/runs/" + runId + "/history")).body();
+            final DashboardSnapshot[] history =
+                    MAPPER.readValue(historyJson, DashboardSnapshot[].class);
             assertEquals(1, history.length);
             assertEquals(10, history[0].performance().records());
-            assertFalse(history[0].total());
+            assertFalse(historyJson.contains("\"total\""));
         }
     }
 
@@ -402,7 +407,7 @@ final class DashboardServerTest {
     }
 
     private static DashboardSnapshot snapshot(String runId, long records) {
-        return new DashboardSnapshot(runId, records, false,
+        return new DashboardSnapshot(runId, records,
                 new DashboardSnapshot.WorkerMetrics(1, 1, 0, 0, 0, 0),
                 new DashboardSnapshot.RequestMetrics(100, records, 1, 1, 0, 0, 0, 0,
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
@@ -420,14 +425,25 @@ final class DashboardServerTest {
         return run.get("runId").toString();
     }
 
-    private static void publish(DashboardLoggerSupport support, boolean total, long records) {
-        support.publish(total, 0, 0, 1, 1, 0, 0,
-                records * 100, 1, records, 1,
-                0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0,
-                5, records * 100, records, records, 1,
-                10, 1, 20, 0, 0, 0, 0, 0,
-                new long[]{10, 20}, new long[]{1, 1});
+    private static void emitResult(WebLogger logger, boolean total, long records) {
+        if (total) {
+            logger.printTotal(System.currentTimeMillis(), 1, 1, 0, 0,
+                    records * 100, 1, records, 1,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    5, records * 100, records, records, 1,
+                    10, 1, 20, 0, 0, 0, 0, 0,
+                    new long[]{10, 20}, new long[]{1, 1});
+        } else {
+            logger.print(System.currentTimeMillis(), 1, 1, 0, 0,
+                    records * 100, 1, records, 1,
+                    0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    5, records * 100, records, records, 1,
+                    10, 1, 20, 0, 0, 0, 0, 0,
+                    new long[]{10, 20}, new long[]{1, 1});
+        }
     }
 }

--- a/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusLogger.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusLogger.java
@@ -170,14 +170,7 @@ public class SbmPrometheusLogger extends AbstractRamLogger {
                            double recsPerSec, double mbPerSec, double avgLatency, long minLatency,
                            long maxLatency, long invalid, long lowerDiscard, long higherDiscard,
                            long slc1, long slc2, long[] percentileLatencies, long[] percentileLatencyCounts) {
-        publishMetrics(writers, maxWriters, readers, maxReaders, writeRequestBytes, writeRequestMbPerSec,
-                writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes, readRequestMbPerSec,
-                readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
-                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
-                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
-                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
-                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
-                slc1, slc2, percentileLatencies, percentileLatencyCounts);
+        // Prometheus gauges represent the latest regular reporting window; cumulative totals would distort them.
         String timestamp = getTimeStamp(reportTime);
         StringBuilder out = new StringBuilder(timestamp+" Total : " + SBM_PREFIX);
         appendConnections(out, connections, maxConnections);

--- a/sbm/src/main/java/io/sbm/logger/impl/SbmWebLogger.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/SbmWebLogger.java
@@ -107,7 +107,7 @@ public class SbmWebLogger extends AbstractRamLogger {
                 recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
                 slc1, slc2, percentileLatencies, percentileLatencyCounts);
         System.out.println(output);
-        publish(false, connections, maxConnections, writers, maxWriters, readers, maxReaders, writeRequestBytes,
+        publish(connections, maxConnections, writers, maxWriters, readers, maxReaders, writeRequestBytes,
                 writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
                 readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
                 writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
@@ -142,17 +142,9 @@ public class SbmWebLogger extends AbstractRamLogger {
                 recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
                 slc1, slc2, percentileLatencies, percentileLatencyCounts);
         System.out.println(output);
-        publish(true, connections, maxConnections, writers, maxWriters, readers, maxReaders, writeRequestBytes,
-                writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec, readRequestBytes,
-                readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec, writeResponsePendingRecords,
-                writeResponsePendingBytes, readResponsePendingRecords, readResponsePendingBytes,
-                writeReadRequestPendingRecords, writeReadRequestPendingBytes, writeTimeoutEvents,
-                writeTimeoutEventsPerSec, readTimeoutEvents, readTimeoutEventsPerSec, seconds, bytes, records,
-                recsPerSec, mbPerSec, avgLatency, minLatency, maxLatency, invalid, lowerDiscard, higherDiscard,
-                slc1, slc2, percentileLatencies, percentileLatencyCounts);
     }
 
-    private void publish(boolean total, int connections, int maxConnections, int writers, int maxWriters,
+    private void publish(int connections, int maxConnections, int writers, int maxWriters,
                          int readers, int maxReaders, long writeRequestBytes, double writeRequestMbPerSec,
                          long writeRequestRecords, double writeRequestRecordsPerSec, long readRequestBytes,
                          double readRequestMbPerSec, long readRequestRecords, double readRequestRecordsPerSec,
@@ -164,7 +156,7 @@ public class SbmWebLogger extends AbstractRamLogger {
                          double recsPerSec, double mbPerSec, double avgLatency, long minLatency, long maxLatency,
                          long invalid, long lowerDiscard, long higherDiscard, long slc1, long slc2,
                          long[] percentileLatencies, long[] percentileLatencyCounts) {
-        dashboard.publish(total, connections, maxConnections, writers, maxWriters, readers, maxReaders,
+        dashboard.publish(connections, maxConnections, writers, maxWriters, readers, maxReaders,
                 writeRequestBytes, writeRequestMbPerSec, writeRequestRecords, writeRequestRecordsPerSec,
                 readRequestBytes, readRequestMbPerSec, readRequestRecords, readRequestRecordsPerSec,
                 writeResponsePendingRecords, writeResponsePendingBytes, readResponsePendingRecords,


### PR DESCRIPTION
## Summary
- publish only regular interval performance snapshots to the WebLogger dashboard
- exclude cumulative final and total-buffer-flush snapshots from dashboard histories
- preserve existing console and CSV total output
- add an end-to-end dashboard regression test

## Validation
- `./gradlew :sbk-api:test --tests io.sbk.dashboard.DashboardServerTest`
- `./gradlew :sbk-api:check`
- `./gradlew check installDist`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard run history now excludes total snapshots and retains only regular interval results.
  * Prevented snapshot publishing when no active dashboard client is available.

* **Tests**
  * Added coverage verifying that total snapshots are not displayed in dashboard run history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->