### PR TITLE
Enforce bounded async benchmark completion

### DIFF
--- a/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileOperations.java
+++ b/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileOperations.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.AsyncFile;
+
+import java.io.IOException;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Tracks asynchronous file operations without adding an object per request.
+ *
+ * <p>A {@link Phaser} represents pending operation count without allocating a
+ * queue node, future, or tracking wrapper for every request. Its permanent
+ * coordinator party prevents termination; each submitted operation registers
+ * one party and its callback deregisters that party.
+ */
+final class AsyncFileOperations {
+    private static final long WAIT_NANOS = 100_000;
+    private final Phaser pending = new Phaser(1);
+    private volatile Throwable failure;
+
+    void submitted() {
+        pending.register();
+    }
+
+    void completed() {
+        pending.arriveAndDeregister();
+    }
+
+    void failed(Throwable throwable) {
+        failure = throwable;
+        pending.arriveAndDeregister();
+    }
+
+    void awaitCompletion() throws IOException {
+        while (pending.getRegisteredParties() > 1) {
+            if (Thread.currentThread().isInterrupted()) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while awaiting asynchronous file operations");
+            }
+            LockSupport.parkNanos(WAIT_NANOS);
+        }
+        if (failure != null) {
+            throw new IOException("Asynchronous file operation failed", failure);
+        }
+    }
+}

--- a/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileReader.java
+++ b/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileReader.java
@@ -33,6 +33,7 @@ public class AsyncFileReader implements Reader<ByteBuffer> {
     final private ParameterOptions params;
     final private AsynchronousFileChannel in;
     final private AtomicBoolean isEOF;
+    final private AsyncFileOperations operations;
     private long pos;
 
     public AsyncFileReader(int id, ParameterOptions params, String fileName) throws IOException {
@@ -41,6 +42,7 @@ public class AsyncFileReader implements Reader<ByteBuffer> {
         this.in = AsynchronousFileChannel.open(Paths.get(fileName), StandardOpenOption.READ);
         this.pos = 0;
         this.isEOF = new AtomicBoolean(false);
+        this.operations = new AsyncFileOperations();
     }
 
     @Override
@@ -53,26 +55,41 @@ public class AsyncFileReader implements Reader<ByteBuffer> {
     public void recordRead(DataType<ByteBuffer> dType, int size, Time time, Status status, PerlChannel perlChannel) throws IOException {
         final long ctime = time.getCurrentTime();
         final ByteBuffer buffer = dType.allocate(params.getRecordSize());
-        in.read(buffer, pos, buffer,
-                new CompletionHandler<Integer, ByteBuffer>() {
+        status.startTime = ctime;
+        status.endTime = ctime;
+        status.bytes = size;
+        status.records = 1;
+        operations.submitted();
+        try {
+            in.read(buffer, pos, buffer,
+                    new CompletionHandler<Integer, ByteBuffer>() {
                     @Override
                     public void completed(Integer result, ByteBuffer attachment) {
-                        final long endTime = time.getCurrentTime();
-                        if (result <= 0 && !isEOF.get()) {
-                            isEOF.set(true);
-                            perlChannel.throwException(new EOFException());
-                        } else {
-                            perlChannel.send(ctime, endTime, 1, result);
+                        try {
+                            final long endTime = time.getCurrentTime();
+                            if (result <= 0 && !isEOF.get()) {
+                                isEOF.set(true);
+                                perlChannel.throwException(new EOFException());
+                            } else {
+                                perlChannel.send(ctime, endTime, 1, result);
+                            }
+                        } finally {
+                            operations.completed();
                         }
                     }
 
                     @Override
                     public void failed(Throwable ex, ByteBuffer attachment) {
+                        operations.failed(ex);
                         if (!isEOF.get()) {
                             perlChannel.throwException(ex);
                         }
                     }
-                });
+                    });
+        } catch (RuntimeException ex) {
+            operations.failed(ex);
+            throw ex;
+        }
         pos += dType.length(buffer);
     }
 
@@ -80,32 +97,48 @@ public class AsyncFileReader implements Reader<ByteBuffer> {
     @Override
     public void recordReadTime(DataType<ByteBuffer> dType, int size, Time time, Status status, PerlChannel perlChannel) throws IOException {
         final ByteBuffer buffer = dType.allocate(params.getRecordSize());
-        in.read(buffer, pos, buffer,
-                new CompletionHandler<Integer, ByteBuffer>() {
+        status.startTime = time.getCurrentTime();
+        status.endTime = status.startTime;
+        status.bytes = size;
+        status.records = 1;
+        operations.submitted();
+        try {
+            in.read(buffer, pos, buffer,
+                    new CompletionHandler<Integer, ByteBuffer>() {
 
                     @Override
                     public void completed(Integer result, ByteBuffer attachment) {
-                        final long endTime = time.getCurrentTime();
-                        if (result <= 0 && !isEOF.get()) {
-                            isEOF.set(true);
-                            perlChannel.throwException(new EOFException());
-                        } else {
-                            perlChannel.send(dType.getTime(attachment), endTime, 1, result);
+                        try {
+                            final long endTime = time.getCurrentTime();
+                            if (result <= 0 && !isEOF.get()) {
+                                isEOF.set(true);
+                                perlChannel.throwException(new EOFException());
+                            } else {
+                                perlChannel.send(dType.getTime(attachment), endTime, 1, result);
+                            }
+                        } finally {
+                            operations.completed();
                         }
                     }
 
                     @Override
                     public void failed(Throwable ex, ByteBuffer attachment) {
+                        operations.failed(ex);
                         if (!isEOF.get()) {
                             perlChannel.throwException(ex);
                         }
                     }
-                });
+                    });
+        } catch (RuntimeException ex) {
+            operations.failed(ex);
+            throw ex;
+        }
         pos += dType.length(buffer);
     }
 
     @Override
     public void close() throws IOException {
+        operations.awaitCompletion();
         in.close();
     }
 }

--- a/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileWriter.java
+++ b/drivers/asyncfile/src/main/java/io/sbk/driver/AsyncFile/AsyncFileWriter.java
@@ -32,11 +32,13 @@ import java.util.concurrent.ExecutionException;
 public class AsyncFileWriter implements Writer<ByteBuffer> {
     final private String fileName;
     final private AsynchronousFileChannel out;
+    final private AsyncFileOperations operations;
     private long pos;
 
     public AsyncFileWriter(int id, ParameterOptions params, String fileName) throws IOException {
         this.fileName = fileName;
         this.out = AsynchronousFileChannel.open(Paths.get(fileName), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+        this.operations = new AsyncFileOperations();
         this.pos = 0;
     }
 
@@ -49,19 +51,31 @@ public class AsyncFileWriter implements Writer<ByteBuffer> {
         status.startTime = ctime;
         status.bytes = size;
         status.records = 1;
-        out.write(buffer, pos, buffer,
-                new CompletionHandler<Integer, ByteBuffer>() {
+        operations.submitted();
+        try {
+            out.write(buffer, pos, buffer,
+                    new CompletionHandler<Integer, ByteBuffer>() {
 
-                    @Override
-                    public void completed(Integer result, ByteBuffer attachment) {
-                        final long endTime = time.getCurrentTime();
-                        record.send(ctime, endTime, 1, result);
-                    }
+                        @Override
+                        public void completed(Integer result, ByteBuffer attachment) {
+                            try {
+                                final long endTime = time.getCurrentTime();
+                                record.send(ctime, endTime, 1, result);
+                            } finally {
+                                operations.completed();
+                            }
+                        }
 
-                    @Override
-                    public void failed(Throwable exc, ByteBuffer attachment) {
-                    }
-                });
+                        @Override
+                        public void failed(Throwable exc, ByteBuffer attachment) {
+                            operations.failed(exc);
+                            record.throwException(exc);
+                        }
+                    });
+        } catch (RuntimeException ex) {
+            operations.failed(ex);
+            throw ex;
+        }
         pos += data.capacity();
     }
 
@@ -79,11 +93,13 @@ public class AsyncFileWriter implements Writer<ByteBuffer> {
 
     @Override
     public void sync() throws IOException {
+        operations.awaitCompletion();
         out.force(true);
     }
 
     @Override
     public void close() throws IOException {
+        operations.awaitCompletion();
         out.close();
     }
 }

--- a/drivers/asyncfile/src/test/java/io/sbk/driver/AsyncFile/AsyncFileTest.java
+++ b/drivers/asyncfile/src/test/java/io/sbk/driver/AsyncFile/AsyncFileTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.AsyncFile;
+
+import io.perl.api.PerlChannel;
+import io.sbk.api.Status;
+import io.sbk.data.impl.NioByteBuffer;
+import io.sbk.params.impl.SbkParameters;
+import io.time.NanoSeconds;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Integration tests for asynchronous file completion and measurement.
+ */
+final class AsyncFileTest {
+    private static final int RECORDS = 25;
+    private static final int RECORD_SIZE = 32;
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void fixedRecordWriteAndReadDrainEveryCompletion() throws Exception {
+        Path file = tempDir.resolve("async-file.data");
+        SbkParameters writeParams = parameters("-writers", "1");
+        NioByteBuffer dataType = new NioByteBuffer();
+        CountingChannel writes = new CountingChannel();
+        ByteBuffer data = ByteBuffer.allocate(RECORD_SIZE);
+
+        try (CloseableAsyncFileWriter writer = new CloseableAsyncFileWriter(
+                new AsyncFileWriter(0, writeParams, file.toString()))) {
+            Status status = new Status();
+            for (int index = 0; index < RECORDS; index++) {
+                writer.delegate.recordWrite(dataType, data, RECORD_SIZE,
+                        new NanoSeconds(), status, writes);
+            }
+            writer.delegate.sync();
+        }
+
+        assertEquals(RECORDS, writes.records.sum());
+        assertNull(writes.failure);
+        assertEquals((long) RECORDS * RECORD_SIZE, Files.size(file));
+
+        SbkParameters readParams = parameters("-readers", "1");
+        CountingChannel reads = new CountingChannel();
+        try (CloseableAsyncFileReader reader = new CloseableAsyncFileReader(
+                new AsyncFileReader(0, readParams, file.toString()))) {
+            Status status = new Status();
+            for (int index = 0; index < RECORDS; index++) {
+                reader.delegate.recordRead(dataType, RECORD_SIZE,
+                        new NanoSeconds(), status, reads);
+            }
+        }
+
+        assertEquals(RECORDS, reads.records.sum());
+        assertNull(reads.failure);
+    }
+
+    private static SbkParameters parameters(String workerOption, String workerCount) throws Exception {
+        SbkParameters params = new SbkParameters("async-file-test");
+        params.parseArgs(new String[]{workerOption, workerCount, "-size",
+                Integer.toString(RECORD_SIZE), "-records", Integer.toString(RECORDS)});
+        return params;
+    }
+
+    private static final class CountingChannel implements PerlChannel {
+        private final LongAdder records = new LongAdder();
+        private volatile Throwable failure;
+
+        @Override
+        public void send(long startTime, long endTime, int count, int bytes) {
+            records.add(count);
+        }
+
+        @Override
+        public void throwException(Throwable ex) {
+            failure = ex;
+        }
+    }
+
+    private static final class CloseableAsyncFileWriter implements AutoCloseable {
+        private final AsyncFileWriter delegate;
+
+        private CloseableAsyncFileWriter(AsyncFileWriter delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+
+    private static final class CloseableAsyncFileReader implements AutoCloseable {
+        private final AsyncFileReader delegate;
+
+        private CloseableAsyncFileReader(AsyncFileReader delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/api/AsyncReader.java
+++ b/sbk-api/src/main/java/io/sbk/api/AsyncReader.java
@@ -90,13 +90,14 @@ public non-sealed interface AsyncReader<T> extends DataRecordsReader<T> {
             throw new IOException();
         } else {
             final long beginTime = status.startTime;
-            ret.exceptionally(ex -> {
-                perlChannel.throwException(ex);
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(beginTime, endTime, status.records, dType.length(d));
+            final int completedRecords = status.records;
+            ret.whenComplete((data, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(beginTime, endTime, completedRecords, dType.length(data));
+                } else {
+                    perlChannel.throwException(ex);
+                }
             });
         }
     }
@@ -133,17 +134,16 @@ public non-sealed interface AsyncReader<T> extends DataRecordsReader<T> {
             throw new IOException();
         } else {
             final long beginTime = status.startTime;
-            ret.exceptionally(ex -> {
-                if (ex instanceof TimeoutException) {
-                    logger.recordReadTimeoutEvents(id, status.startTime, 1);
+            final int completedRecords = status.records;
+            ret.whenComplete((data, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(beginTime, endTime, completedRecords, dType.length(data));
+                } else if (ex instanceof TimeoutException) {
+                    logger.recordReadTimeoutEvents(id, beginTime, 1);
                 } else {
                     perlChannel.throwException(ex);
                 }
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(beginTime, endTime, status.records, dType.length(d));
             });
         }
     }
@@ -177,14 +177,14 @@ public non-sealed interface AsyncReader<T> extends DataRecordsReader<T> {
         if (ret == null) {
             throw new IOException();
         } else {
-            ret.exceptionally(ex -> {
-                perlChannel.throwException(ex);
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(dType.getTime(d), endTime, status.records, dType.length(d));
-
+            final int completedRecords = status.records;
+            ret.whenComplete((data, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(dType.getTime(data), endTime, completedRecords, dType.length(data));
+                } else {
+                    perlChannel.throwException(ex);
+                }
             });
         }
     }
@@ -220,17 +220,17 @@ public non-sealed interface AsyncReader<T> extends DataRecordsReader<T> {
         if (ret == null) {
             throw new IOException();
         } else {
-            ret.exceptionally(ex -> {
-                if (ex instanceof TimeoutException) {
-                    logger.recordReadTimeoutEvents(id, status.startTime, 1);
+            final long requestTime = status.startTime;
+            final int completedRecords = status.records;
+            ret.whenComplete((data, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(dType.getTime(data), endTime, completedRecords, dType.length(data));
+                } else if (ex instanceof TimeoutException) {
+                    logger.recordReadTimeoutEvents(id, requestTime, 1);
                 } else {
                     perlChannel.throwException(ex);
                 }
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(dType.getTime(d), endTime, status.records, dType.length(d));
             });
         }
     }

--- a/sbk-api/src/main/java/io/sbk/api/Writer.java
+++ b/sbk-api/src/main/java/io/sbk/api/Writer.java
@@ -193,13 +193,15 @@ public non-sealed interface Writer<T> extends DataRecordsWriter<T> {
             perlChannel.send(status.startTime, status.endTime, status.records, size);
         } else {
             final long beginTime = status.startTime;
-            ret.exceptionally(ex -> {
-                perlChannel.throwException(ex);
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(beginTime, endTime, status.records, size);
+            final int completedRecords = status.records;
+            final int completedBytes = status.bytes;
+            ret.whenComplete((ignored, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(beginTime, endTime, completedRecords, completedBytes);
+                } else {
+                    perlChannel.throwException(ex);
+                }
             });
         }
     }
@@ -233,17 +235,17 @@ public non-sealed interface Writer<T> extends DataRecordsWriter<T> {
             perlChannel.send(status.startTime, status.endTime, status.records, size);
         } else {
             final long beginTime = status.startTime;
-            ret.exceptionally(ex -> {
-                if (ex instanceof TimeoutException) {
-                    logger.recordWriteTimeoutEvents(id, status.startTime, 1);
+            final int completedRecords = status.records;
+            final int completedBytes = status.bytes;
+            ret.whenComplete((ignored, ex) -> {
+                if (ex == null) {
+                    final long endTime = time.getCurrentTime();
+                    perlChannel.send(beginTime, endTime, completedRecords, completedBytes);
+                } else if (ex instanceof TimeoutException) {
+                    logger.recordWriteTimeoutEvents(id, beginTime, 1);
                 } else {
                     perlChannel.throwException(ex);
                 }
-                return null;
-            });
-            ret.thenAccept(d -> {
-                final long endTime = time.getCurrentTime();
-                perlChannel.send(beginTime, endTime, status.records, size);
             });
         }
     }

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
@@ -69,6 +69,7 @@ import java.util.stream.IntStream;
  */
 final public class SbkBenchmark implements Benchmark {
     final private static String CONFIGFILE = "sbk.properties";
+    final private static long FORCED_SHUTDOWN_GRACE_SECONDS = 3;
     final private Storage<Object> storage;
     final private DataType<Object> dType;
     final private Time time;
@@ -86,6 +87,9 @@ final public class SbkBenchmark implements Benchmark {
 
     @GuardedBy("this")
     private State state;
+
+    @GuardedBy("this")
+    private boolean shutdownRequested;
 
     /**
      * Create SBK Benchmark.
@@ -138,11 +142,13 @@ final public class SbkBenchmark implements Benchmark {
             readPerl = null;
         }
 
-        timeoutExecutor = Executors.newScheduledThreadPool(0, Thread.ofVirtual().factory());
+        timeoutExecutor = Executors.newSingleThreadScheduledExecutor(Thread.ofPlatform()
+                .name("sbk-benchmark-deadline").daemon(true).factory());
         retFuture = new CompletableFuture<>();
         writers = new ArrayList<>();
         readers = new ArrayList<>();
         state = State.BEGIN;
+        shutdownRequested = false;
     }
 
     /**
@@ -245,11 +251,6 @@ final public class SbkBenchmark implements Benchmark {
         if (sbkWriters != null) {
             writeFutures = new ArrayList<>();
 
-            final long recordsPerWriter = params.getTotalSecondsToRun() <= 0 ?
-                    params.getTotalRecords() / params.getWritersCount() : 0;
-            final long delta = recordsPerWriter > 0 ?
-                    params.getTotalRecords() - (recordsPerWriter * params.getWritersCount()) : 0;
-
             writersCB = CompletableFuture.runAsync(() -> {
                 long secondsToRun = params.getTotalSecondsToRun();
                 boolean doWork = true;
@@ -259,8 +260,8 @@ final public class SbkBenchmark implements Benchmark {
                     for (int j = 0; j < stepCnt; j++) {
                         try {
                             CompletableFuture<Void> ret = sbkWriters.get(i + j).run(secondsToRun,
-                                    i + j + 1 == params.getWritersCount() ?
-                                            recordsPerWriter + delta : recordsPerWriter);
+                                    recordsForWorker(params.getTotalRecords(),
+                                            params.getWritersCount(), i + j));
                             writeFutures.add(ret);
                         } catch (IOException e) {
                             e.printStackTrace();
@@ -277,7 +278,9 @@ final public class SbkBenchmark implements Benchmark {
                                 }
                             }
                         } catch (InterruptedException ex) {
-                            ex.printStackTrace();
+                            Thread.currentThread().interrupt();
+                            Printer.log.info("Writer ramp-up interrupted at benchmark deadline");
+                            return;
                         }
                     }
                 }
@@ -301,11 +304,6 @@ final public class SbkBenchmark implements Benchmark {
         if (sbkReaders != null) {
             readFutures = new ArrayList<>();
 
-            final long recordsPerReader = params.getTotalSecondsToRun() <= 0 ?
-                    params.getTotalRecords() / params.getReadersCount() : 0;
-            final long delta = recordsPerReader > 0 ?
-                    params.getTotalRecords() - (recordsPerReader * params.getReadersCount()) : 0;
-
             readersCB = CompletableFuture.runAsync(() -> {
                 long secondsToRun = params.getTotalSecondsToRun();
                 boolean doWork = true;
@@ -314,8 +312,9 @@ final public class SbkBenchmark implements Benchmark {
                     int stepCnt = Math.min(params.getReadersStep(), params.getReadersCount() - i);
                     for (int j = 0; j < stepCnt; j++) {
                         try {
-                            CompletableFuture<Void> ret = sbkReaders.get(i + j).run(secondsToRun, i + j + 1 == params.getReadersCount() ?
-                                    recordsPerReader + delta : recordsPerReader);
+                            CompletableFuture<Void> ret = sbkReaders.get(i + j).run(secondsToRun,
+                                    recordsForWorker(params.getTotalRecords(),
+                                            params.getReadersCount(), i + j));
                             readFutures.add(ret);
                         } catch (IOException e) {
                             e.printStackTrace();
@@ -332,7 +331,9 @@ final public class SbkBenchmark implements Benchmark {
                                 }
                             }
                         } catch (InterruptedException ex) {
-                            ex.printStackTrace();
+                            Thread.currentThread().interrupt();
+                            Printer.log.info("Reader ramp-up interrupted at benchmark deadline");
+                            return;
                         }
                     }
                 }
@@ -362,8 +363,10 @@ final public class SbkBenchmark implements Benchmark {
         }
 
         if (params.getTotalSecondsToRun() > 0) {
-            timeoutExecutor.schedule(() -> requestShutdown(null),
-                    params.getTotalSecondsToRun() + 1, TimeUnit.SECONDS);
+            timeoutExecutor.schedule(this::requestTimedShutdown,
+                    params.getTotalSecondsToRun(), TimeUnit.SECONDS);
+            timeoutExecutor.schedule(this::forceTimedCompletion,
+                    params.getTotalSecondsToRun() + FORCED_SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS);
         }
 
         if (wStatFuture != null && !wStatFuture.isDone()) {
@@ -405,10 +408,35 @@ final public class SbkBenchmark implements Benchmark {
      */
     @Synchronized
     private void requestShutdown(Throwable ex) {
-        if (state == State.END || lifecycleExecutor.isShutdown()) {
+        if (state == State.END || shutdownRequested || lifecycleExecutor.isShutdown()) {
             return;
         }
+        shutdownRequested = true;
         lifecycleExecutor.execute(() -> shutdown(ex));
+    }
+
+    /**
+     * Stops worker admission at the configured deadline and starts bounded cleanup.
+     */
+    private void requestTimedShutdown() {
+        executor.shutdownNow();
+        requestShutdown(null);
+    }
+
+    /**
+     * Releases the application after the timed-run cleanup grace period.
+     *
+     * <p>The executable main methods call {@code System.exit} after this future completes,
+     * so a driver or SDK blocked in close cannot extend a timed run indefinitely.
+     */
+    private void forceTimedCompletion() {
+        if (retFuture.complete(null)) {
+            Printer.log.warn("SBK timed benchmark cleanup exceeded "
+                    + FORCED_SHUTDOWN_GRACE_SECONDS + " seconds; forcing application exit");
+            executor.shutdownNow();
+            perlExecutor.shutdownNow();
+            lifecycleExecutor.shutdownNow();
+        }
     }
 
     /**
@@ -425,8 +453,10 @@ final public class SbkBenchmark implements Benchmark {
             return;
         }
         state = State.END;
-        timeoutExecutor.shutdownNow();
         executor.shutdownNow();
+        if (params.getTotalSecondsToRun() > 0) {
+            stopPerformanceRecorders();
+        }
         readers.forEach(c -> {
             try {
                 c.close();
@@ -441,11 +471,8 @@ final public class SbkBenchmark implements Benchmark {
                 Printer.log.warn("Unable to close an SBK writer during shutdown", e);
             }
         });
-        if (writePerl != null) {
-            writePerl.stop();
-        }
-        if (readPerl != null) {
-            readPerl.stop();
+        if (params.getTotalSecondsToRun() <= 0) {
+            stopPerformanceRecorders();
         }
         try {
             storage.closeStorage(params);
@@ -467,8 +494,40 @@ final public class SbkBenchmark implements Benchmark {
             Printer.log.info("SBK Benchmark Shutdown");
             retFuture.complete(null);
         }
+        timeoutExecutor.shutdownNow();
         lifecycleExecutor.shutdown();
 
+    }
+
+    private void stopPerformanceRecorders() {
+        if (writePerl != null) {
+            writePerl.stop();
+        }
+        if (readPerl != null) {
+            readPerl.stop();
+        }
+    }
+
+    /**
+     * Returns the fixed-count share assigned to one worker.
+     *
+     * <p>The first {@code totalRecords % workersCount} workers receive one additional
+     * record, so every requested record is assigned exactly once, including when there
+     * are fewer records than workers.
+     *
+     * @param totalRecords total records requested by the user
+     * @param workersCount number of workers
+     * @param workerIndex zero-based worker index
+     * @return this worker's record count
+     * @throws IllegalArgumentException if the worker count or index is invalid
+     */
+    static long recordsForWorker(long totalRecords, int workersCount, int workerIndex) {
+        if (workersCount <= 0 || workerIndex < 0 || workerIndex >= workersCount) {
+            throw new IllegalArgumentException("Invalid worker count or index");
+        }
+        long recordsPerWorker = totalRecords / workersCount;
+        long remainder = totalRecords % workersCount;
+        return recordsPerWorker + (workerIndex < remainder ? 1 : 0);
     }
 
 

--- a/sbk-api/src/test/java/io/sbk/api/AsyncOperationTimingTest.java
+++ b/sbk-api/src/test/java/io/sbk/api/AsyncOperationTimingTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.api;
+
+import io.perl.api.PerlChannel;
+import io.sbk.data.impl.ByteArray;
+import io.time.NanoSeconds;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that common asynchronous adapters measure callback completion.
+ */
+final class AsyncOperationTimingTest {
+
+    @Test
+    void writerReportsOnlyAfterFutureCompletion() throws Exception {
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+        Writer<byte[]> writer = new Writer<>() {
+            @Override
+            public CompletableFuture<?> writeAsync(byte[] data) {
+                return completion;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        CapturingChannel channel = new CapturingChannel();
+        Status status = new Status();
+
+        writer.recordWrite(new ByteArray(), new byte[16], 16,
+                new NanoSeconds(), status, channel);
+
+        assertEquals(0, channel.records);
+        status.records = 99;
+        completion.complete(null);
+        assertEquals(1, channel.records);
+        assertEquals(16, channel.bytes);
+        assertTrue(channel.endTime >= channel.startTime);
+    }
+
+    @Test
+    void readerReportsOnlyAfterFutureCompletion() throws Exception {
+        CompletableFuture<byte[]> completion = new CompletableFuture<>();
+        AsyncReader<byte[]> reader = new AsyncReader<>() {
+            @Override
+            public CompletableFuture<byte[]> readAsync(int size) {
+                return completion;
+            }
+        };
+        CapturingChannel channel = new CapturingChannel();
+        Status status = new Status();
+
+        reader.recordRead(new ByteArray(), 16, new NanoSeconds(), status, channel);
+
+        assertEquals(0, channel.records);
+        status.records = 99;
+        completion.complete(new byte[16]);
+        assertEquals(1, channel.records);
+        assertEquals(16, channel.bytes);
+        assertTrue(channel.endTime >= channel.startTime);
+    }
+
+    private static final class CapturingChannel implements PerlChannel {
+        private long startTime;
+        private long endTime;
+        private int records;
+        private int bytes;
+
+        @Override
+        public void send(long start, long end, int recordCount, int byteCount) {
+            startTime = start;
+            endTime = end;
+            records = recordCount;
+            bytes = byteCount;
+        }
+
+        @Override
+        public void throwException(Throwable ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/sbk-api/src/test/java/io/sbk/api/impl/SbkBenchmarkTest.java
+++ b/sbk-api/src/test/java/io/sbk/api/impl/SbkBenchmarkTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.api.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests benchmark lifecycle calculations that must be independent of a storage driver.
+ */
+final class SbkBenchmarkTest {
+
+    @Test
+    void distributesRemainderAcrossWorkers() {
+        long[] shares = IntStream.range(0, 3)
+                .mapToLong(index -> SbkBenchmark.recordsForWorker(10, 3, index))
+                .toArray();
+
+        assertArrayEquals(new long[]{4, 3, 3}, shares);
+        assertEquals(10, IntStream.range(0, 3)
+                .mapToLong(index -> SbkBenchmark.recordsForWorker(10, 3, index))
+                .sum());
+    }
+
+    @Test
+    void assignsRecordsWhenThereAreMoreWorkersThanRecords() {
+        long[] shares = IntStream.range(0, 5)
+                .mapToLong(index -> SbkBenchmark.recordsForWorker(2, 5, index))
+                .toArray();
+
+        assertArrayEquals(new long[]{1, 1, 0, 0, 0}, shares);
+    }
+
+    @Test
+    void rejectsInvalidWorkerIndex() {
+        assertThrows(IllegalArgumentException.class,
+                () -> SbkBenchmark.recordsForWorker(1, 1, 1));
+    }
+}


### PR DESCRIPTION
## Summary

- Enforce the configured `-seconds` deadline centrally in `SbkBenchmark` and complete application shutdown no later than the deadline plus a three-second cleanup grace period.
- Keep the low-latency record I/O loops free of `Thread.currentThread().isInterrupted()` checks or new per-operation stop parameters.
- Divide fixed `-records` workloads exactly across writers/readers, assigning remainder records one at a time to the first workers, including when records are fewer than workers.
- Record asynchronous write/read results only from future completion callbacks, using immutable copies of request metadata so reused worker status cannot corrupt measurements.
- Drain outstanding AsyncFile operations before `sync()` or `close()`, report callback failures, and avoid a tracking allocation per request through a shared `Phaser`.

## Behavior

### Duration-based runs

At the exact configured duration, the benchmark scheduler stops worker admission and starts shutdown. If driver or SDK cleanup does not complete within three seconds, SBK completes its lifecycle future so the executable can force termination. Performance data accumulated up to the deadline is retained. Deadline enforcement is outside the record hot path.

### Record-based runs

Every requested record is assigned exactly once. For example, 10 records across 3 workers becomes `4, 3, 3`; 2 records across 5 workers becomes `1, 1, 0, 0, 0`. Async results are emitted only after the corresponding future/callback completes.

## AsyncFile reliability

AsyncFile now tracks submitted callbacks with a coordinator-owned `Phaser`. Completion and failure callbacks deregister their operation, while `sync()` and `close()` wait for the pending count to drain. This prevents final successful operations from being omitted when the channel closes.

## Tests added

- Async writer and reader accounting occurs only after future completion.
- Callback measurement uses captured request metadata even when the reusable status object changes.
- Exact record distribution covers remainders, more workers than records, and invalid worker indices.
- AsyncFile integration writes and reads 25 fixed-size records, validates every recorded completion, validates file size, and detects callback failures.

## Validation

- `./gradlew check` — passed
- `./gradlew :sbk-api:check installDist` — passed (`365 actionable tasks`)
- `git diff --check` — passed
- Local synchronous and asynchronous file write/read testing with both `-seconds` and `-records` — passed
- Synchronous and asynchronous MinIO/ObjectScale write/read testing with both `-seconds` and `-records` — passed

## Performance considerations

- No interrupt polling or added branch in the per-record read/write loops.
- No new hard-stop parameter propagated through driver APIs.
- One daemon platform scheduler owns deadline enforcement.
- Async metadata is copied into callback-local primitives, avoiding shared mutable status races.
- AsyncFile pending tracking uses one shared counter structure rather than per-request futures, queue nodes, maps, or wrapper objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous file read and write reliability by ensuring operations finish before files are closed or synchronized.
  * Improved error and timeout reporting for asynchronous reads and writes.
  * Ensured completion metrics accurately reflect finalized operations.
  * Improved benchmark shutdown handling, including timed runs and forced completion.

* **Tests**
  * Added coverage for asynchronous file transfers, operation timing, completion behavior, and record distribution across workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->