### PR TITLE
Document TimeStamp MPSC queue architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ driver SPI.
 
 - **Languages.** Java only (no Kotlin, no Scala). Build with Gradle (wrapper
   in tree: `./gradlew`). JDK 25 required.
-- **Modules.** 6 core modules + 52 enabled storage drivers. The source tree also
+- **Modules.** 6 core modules + 53 enabled storage drivers. The source tree also
   contains disabled drivers and a driver template. Each module is a
   Gradle subproject.
 - **License.** Apache 2.0.
@@ -48,7 +48,7 @@ driver SPI.
 | `sbk-yal/` | YML-driven launcher (single-node). | Rarely. |
 | `sbk-gem/` | **SBK-GEM** — SSH-based distributed launcher. | When changing the multi-host orchestration. |
 | `sbk-gem-yal/` | YML-driven SBK-GEM. | Rarely. |
-| `drivers/<name>/` | One subdirectory per storage backend. **52 are enabled in the aggregate build**; disabled drivers and a template also remain in tree. | When adding or fixing a driver. **This is the most common change.** |
+| `drivers/<name>/` | One subdirectory per storage backend. **53 are enabled in the aggregate build**; disabled drivers and a template also remain in tree. | When adding or fixing a driver. **This is the most common change.** |
 
 **For new drivers, see <ref_file file="/root/projects/SBK/docs/DRIVER_SPECIFICATION.md" />
 (spec template + worked example) and

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Driver-specific options are added after SBK discovers `-class`. Use the selected
 | `-seconds N` | Time-based run duration |
 | `-records N` | Total records in count mode, or the per-second target in timed mode |
 | `-throughput MBPS` | Throughput target; `-1` requests maximum throughput |
+| `-mpscqueue true\|false` | Select intrusive `TimeStampMpscQueue` or the JDK `ConcurrentLinkedQueue` fallback |
 | `-sync N` | Records per flush/sync or transaction |
 | `-ro true` | With readers and writers configured, read without writing new records |
 | `-thread p\|f\|v` | Platform, fork-join, or virtual worker executor; default: virtual (`v`) |
@@ -242,6 +243,12 @@ The dependency direction is `perl <- sbk-api <- drivers`. SBM depends on `sbk-ap
 ## Drivers and output loggers
 
 Enabled drivers are registered in both `settings-drivers.gradle` and `build-drivers.gradle`. The complete categorized inventory and the driver contract are in [docs/DRIVER_GUIDE.md](docs/DRIVER_GUIDE.md).
+
+Use the synthetic [`PerlBench` driver](drivers/perlbench/README.md) to compare
+the intrusive PerL timestamp queue with the JDK fallback under exact-count,
+timed-saturation, and rate-controlled workloads. It performs no storage I/O,
+so its results describe harness and measurement-pipeline behavior rather than
+a storage device.
 
 SBK currently ships these logger implementations:
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Driver-specific options are added after SBK discovers `-class`. Use the selected
 | `-seconds N` | Time-based run duration |
 | `-records N` | Total records in count mode, or the per-second target in timed mode |
 | `-throughput MBPS` | Throughput target; `-1` requests maximum throughput |
-| `-mpscqueue true\|false` | Select intrusive `TimeStampMpscQueue` or the JDK `ConcurrentLinkedQueue` fallback |
+| `-mpscqueue true\|false` | Select intrusive `TimeStampMpscQueue` or the JDK `ConcurrentLinkedQueue` fallback; default comes from `sbk.properties` |
 | `-sync N` | Records per flush/sync or transaction |
 | `-ro true` | With readers and writers configured, read without writing new records |
 | `-thread p\|f\|v` | Platform, fork-join, or virtual worker executor; default: virtual (`v`) |
@@ -248,7 +248,9 @@ Use the synthetic [`PerlBench` driver](drivers/perlbench/README.md) to compare
 the intrusive PerL timestamp queue with the JDK fallback under exact-count,
 timed-saturation, and rate-controlled workloads. It performs no storage I/O,
 so its results describe harness and measurement-pipeline behavior rather than
-a storage device.
+a storage device. Do not confuse it with the [`Null` driver](drivers/null/README.md):
+Null's default operation deliberately remains pending for idle, timeout, and
+shutdown tests, while PerlBench completes every operation immediately.
 
 SBK currently ships these logger implementations:
 

--- a/build-drivers.gradle
+++ b/build-drivers.gradle
@@ -25,6 +25,7 @@ dependencies {
     api project(':drivers:couchdb')
     api project(':drivers:hive')
     api project(':drivers:null')
+    api project(':drivers:perlbench')
     api project(':drivers:sqlite')
     api project(':drivers:mysql')
     api project(':drivers:mariadb')

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,7 +201,7 @@ flowchart LR
     W1[Worker 1] --> C[PerlChannel]
     W2[Worker 2] --> C
     WN[Worker N] --> C
-    C --> Q[Concurrent queue array]
+    C --> Q[Selected timestamp queue array]
     Q --> R[Performance recorder]
     R --> P[Periodic window]
     R --> T[Total window]
@@ -211,11 +211,34 @@ flowchart LR
 
 Each measurement contains start time, end time, record count, and byte count. PerL records all submitted operations rather than sampling them. The recorder drains concurrent queues and updates latency storage and counters away from the I/O worker.
 
+By default, the selected array contains intrusive
+`TimeStampMpscQueue` instances. Each submitted `TimeStampNode` is both the
+measurement payload and its linked-queue node, so enqueue does not allocate a
+second wrapper. `-mpscqueue false` selects the compatibility path based on JDK
+`ConcurrentLinkedQueue<TimeStamp>`; `-mpscqueue true` selects the intrusive
+path. The default comes from `MpscQueueEnable` in
+`sbk-api/src/main/resources/sbk.properties`.
+
+Queue topology is a separate concern. `qPerWorker` and `maxQs` remain
+property-backed settings rather than public CLI options. SBK prints both the
+effective queue implementation and topology after argument parsing, before the
+benchmark starts.
+
+The timestamp queues have a multiple-producer, single-consumer workload:
+worker threads produce measurements and the PerL recorder consumes them.
+`TimeStampMpscQueue` specializes for that contract; the JDK fallback retains
+general MPMC Collection behavior. See
+[the queue research guide](TIMESTAMP_MPSC_QUEUE.md) for linearization,
+memory-ordering, reclamation, complexity, and benchmark evidence.
+
 The phrase “lock-free hot path” applies to harness measurement transport. It does not promise that a vendor SDK, filesystem, JVM scheduler, allocator, or backend is lock-free. Driver wrappers should avoid adding their own locks to the per-operation path.
 
 Primary sources:
 
 - `perl/src/main/java/io/perl/api/PerlChannel.java`
+- `perl/src/main/java/io/perl/api/TimeStampNode.java`
+- `perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java`
+- `perl/src/main/java/io/perl/api/impl/TimeStampMpscQueueArray.java`
 - `perl/src/main/java/io/perl/api/impl/ConcurrentLinkedQueueArray.java`
 - `perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleBusyWait.java`
 - `perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleSleep.java`
@@ -275,6 +298,13 @@ Configuration comes from several layers:
 5. Parsed CLI values override applicable defaults.
 6. YAL variants translate YML entries into the same argument model; they do not bypass normal validation.
 
+For the PerL transport, `MpscQueueEnable` supplies the default and the common
+`-mpscqueue true|false` option overrides it for that benchmark. The topology
+properties `qPerWorker` and `maxQs` are validated when `SbkParameters` loads
+`sbk.properties`, but are not exposed as command-line options. This keeps an
+A/B queue comparison to one explicit runtime switch while preventing
+accidental topology changes between runs.
+
 Use generated `-help` output as the authority for accepted options. Use the relevant resource property file as the authority for defaults that are not printed in help.
 
 ## Packaging and class loading
@@ -298,6 +328,7 @@ A driver can compile successfully yet be unavailable at runtime if either regist
 | Add a payload representation | `io.sbk.data` implementation |
 | Add result output | `io.sbk.logger` implementation |
 | Change latency storage or percentile behavior | `perl` |
+| Change timestamp queue selection or topology | `perl`, `SbkParameters`, and `SbkBenchmark` |
 | Change distributed aggregation | `sbm` and protobuf compatibility review |
 | Change remote launch | `sbk-gem` |
 | Change YML mapping | the applicable YAL module |
@@ -326,8 +357,10 @@ For a practical code walkthrough:
 6. `SbkWriter`, `SbkReader`, `Writer`, and `Reader`
 7. `perl/src/main/java/io/perl/api/impl/PerlBuilder.java`
 8. The PerL queue and recorder selected by that builder
-9. `GrpcLogger` and `SbmGrpcService` for distributed reporting
-10. `SbkGem` and `SbkGemBenchmark` for remote orchestration
+9. `drivers/perlbench/` and [the queue research guide](TIMESTAMP_MPSC_QUEUE.md)
+   for a controlled end-to-end queue comparison
+10. `GrpcLogger` and `SbmGrpcService` for distributed reporting
+11. `SbkGem` and `SbkGemBenchmark` for remote orchestration
 
 ## Architectural invariants
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,6 +231,26 @@ general MPMC Collection behavior. See
 [the queue research guide](TIMESTAMP_MPSC_QUEUE.md) for linearization,
 memory-ordering, reclamation, complexity, and benchmark evidence.
 
+`TimeStampMpscQueue` uses one single-use `TimeStampNode` as both payload and
+link. Producers publish through a CAS on the predecessor's `next` reference;
+the single consumer owns `head`. Every 16 dequeues, the consumer
+release-publishes a recovery head and self-links the retired predecessor
+batch. A producer paused on an old node detects that self-link and resumes
+from the recovery head. This bounds stale-chain retention without pooling
+nodes or adding a consumer-side head CAS. The specialization is appropriate
+only for PerL's many-producer/one-consumer hand-off; it is not intended for
+multiple consumers, iterators, arbitrary removals, or general collection use.
+
+The default recorder also avoids querying the clock on every queue scan.
+While records are available it reuses `TimeStamp.endTime`. While all queues
+are empty, `ElasticWait` parks and checks the clock only after an adaptively
+calibrated batch. The learned parks-per-millisecond rate is retained in an
+exponential moving average. When activity briefly interrupts idleness, the
+first subsequent empty scan starts a clean idle sample from the last record
+timestamp while retaining that learned rate. This prevents active time from
+diluting calibration and adds no new clock read. Setting `sleepMS > 0`
+selects the simpler sleeping recorder and bypasses `ElasticWait`.
+
 The phrase “lock-free hot path” applies to harness measurement transport. It does not promise that a vendor SDK, filesystem, JVM scheduler, allocator, or backend is lock-free. Driver wrappers should avoid adding their own locks to the per-operation path.
 
 Primary sources:
@@ -242,6 +262,7 @@ Primary sources:
 - `perl/src/main/java/io/perl/api/impl/ConcurrentLinkedQueueArray.java`
 - `perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleBusyWait.java`
 - `perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleSleep.java`
+- `perl/src/main/java/io/perl/api/impl/ElasticWait.java`
 - `perl/src/main/java/io/perl/api/impl/PerlBuilder.java`
 
 ## Output boundary

--- a/docs/DRIVER_GUIDE.md
+++ b/docs/DRIVER_GUIDE.md
@@ -108,10 +108,15 @@ Discovery uses simple Java class names. Keep directory, package, public class, r
 | Relational operations | `drivers/jdbc` and a concrete SQL driver |
 | Custom payload type | `drivers/file`, `drivers/csv`, or `drivers/fdbrecord` |
 | Callback reader | Search for implementations of `AbstractCallbackReader` |
-| Minimal no-op storage baseline | `drivers/null` |
-| End-to-end SBK/PerL queue comparison | `drivers/perlbench` |
+| Idle windows, pending futures, timeout, and shutdown | `drivers/null` |
+| Immediate synthetic completions and end-to-end SBK/PerL queue comparison | `drivers/perlbench` |
 
 Prefer the driver whose SDK and completion semantics resemble the new backend, not merely the driver with the shortest source.
+
+`null` and `perlbench` are not interchangeable no-op baselines. The default
+Null write intentionally remains incomplete, whereas every PerlBench operation
+completes immediately and feeds a timestamp into PerL. Use their READMEs to
+avoid interpreting an idle-control result as measurement-pipeline throughput.
 
 ## Add a driver
 

--- a/docs/DRIVER_GUIDE.md
+++ b/docs/DRIVER_GUIDE.md
@@ -20,7 +20,7 @@ Drivers are the primary SBK extension point. A driver converts the harness's gen
 
 ## Runtime inventory
 
-The aggregate distribution currently enables 52 driver projects. The source tree also contains disabled drivers and a template.
+The aggregate distribution currently enables 53 driver projects. The source tree also contains disabled drivers and a template.
 
 | Category | Enabled drivers |
 |---|---|
@@ -30,7 +30,7 @@ The aggregate distribution currently enables 52 driver projects. The source tree
 | Relational and SQL systems | `db2`, `derby`, `exasol`, `h2`, `hive`, `jdbc`, `mariadb`, `mssql`, `mysql`, `postgresql`, `sqlite` |
 | Document, search, and analytical systems | `chromadb`, `couchbase`, `couchdb`, `dynamodb`, `elasticsearch`, `mongodb`, `solr` |
 | Key-value and embedded stores | `fdbrecord`, `foundationdb`, `leveldb`, `memcached`, `redis`, `rocksdb` |
-| Harness and local data structures | `atomicq`, `cassandra`, `concurrentq`, `conqueue`, `csv`, `linkedbq`, `null`, `syncq` |
+| Harness and local data structures | `atomicq`, `cassandra`, `concurrentq`, `conqueue`, `csv`, `linkedbq`, `null`, `perlbench`, `syncq` |
 
 `ignite` is disabled in the Gradle registration files. `halodb` is disabled because its GitHub Packages dependency can be unavailable without credentials or package quota. `sbktemplate` is intentionally excluded because it is a scaffold.
 
@@ -108,7 +108,8 @@ Discovery uses simple Java class names. Keep directory, package, public class, r
 | Relational operations | `drivers/jdbc` and a concrete SQL driver |
 | Custom payload type | `drivers/file`, `drivers/csv`, or `drivers/fdbrecord` |
 | Callback reader | Search for implementations of `AbstractCallbackReader` |
-| Minimal no-op baseline | `drivers/null` |
+| Minimal no-op storage baseline | `drivers/null` |
+| End-to-end SBK/PerL queue comparison | `drivers/perlbench` |
 
 Prefer the driver whose SDK and completion semantics resemble the new backend, not merely the driver with the shortest source.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,8 +38,9 @@ This directory contains the authoritative engineering documentation for Storage 
 
 1. [Architecture and code flow](ARCHITECTURE.md): ownership boundaries and lifecycle.
 2. [Internal design](sbk-internals.md): detailed PerL, SBM, SBP, and measurement design.
-3. [Documentation maintenance](DOCUMENTATION_GUIDE.md): how to keep examples and links current.
-4. [Agent-documentation distribution](AGENT_DOCUMENTATION_DISTRIBUTION.md): how documentation enters release artifacts.
+3. [TimeStampMpscQueue research guide](TIMESTAMP_MPSC_QUEUE.md): intrusive MPSC queue architecture, correctness evidence, JDK comparison, and reproducible performance methodology.
+4. [Documentation maintenance](DOCUMENTATION_GUIDE.md): how to keep examples and links current.
+5. [Agent-documentation distribution](AGENT_DOCUMENTATION_DISTRIBUTION.md): how documentation enters release artifacts.
 
 ### Coding agent
 
@@ -62,6 +63,7 @@ This directory contains the authoritative engineering documentation for Storage 
 | [DRIVER_SPECIFICATION.md](DRIVER_SPECIFICATION.md) | Fillable design template for new drivers |
 | [WEB_LOGGER.md](WEB_LOGGER.md) | Local live dashboard usage, lifecycle, options, security, and troubleshooting |
 | [sbk-internals.md](sbk-internals.md) | Detailed design rationale and research-oriented treatment |
+| [TIMESTAMP_MPSC_QUEUE.md](TIMESTAMP_MPSC_QUEUE.md) | Intrusive timestamp queue architecture, JDK comparison, correctness evidence, and research methodology |
 | Component READMEs | Component operation and component-specific examples |
 | Driver READMEs | Backend prerequisites, properties, limitations, and example commands |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ This directory contains the authoritative engineering documentation for Storage 
 | [WEB_LOGGER.md](WEB_LOGGER.md) | Local live dashboard usage, lifecycle, options, security, and troubleshooting |
 | [sbk-internals.md](sbk-internals.md) | Detailed design rationale and research-oriented treatment |
 | [TIMESTAMP_MPSC_QUEUE.md](TIMESTAMP_MPSC_QUEUE.md) | Intrusive timestamp queue architecture, JDK comparison, correctness evidence, and research methodology |
+| [PerlBench driver](../drivers/perlbench/README.md) | End-to-end timestamp-queue comparison using exact-count, timed, and rate-controlled SBK workloads |
 | Component READMEs | Component operation and component-specific examples |
 | Driver READMEs | Backend prerequisites, properties, limitations, and example commands |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,8 @@ This directory contains the authoritative engineering documentation for Storage 
 ### Maintainer or reviewer
 
 1. [Architecture and code flow](ARCHITECTURE.md): ownership boundaries and lifecycle.
-2. [Internal design](sbk-internals.md): detailed PerL, SBM, SBP, and measurement design.
+2. [Internal design](sbk-internals.md): detailed PerL measurement flow,
+   `ElasticWait`, timestamp queues, SBM, and SBP design.
 3. [TimeStampMpscQueue research guide](TIMESTAMP_MPSC_QUEUE.md): intrusive MPSC queue architecture, correctness evidence, JDK comparison, and reproducible performance methodology.
 4. [Documentation maintenance](DOCUMENTATION_GUIDE.md): how to keep examples and links current.
 5. [Agent-documentation distribution](AGENT_DOCUMENTATION_DISTRIBUTION.md): how documentation enters release artifacts.

--- a/docs/REPOSITORY_MAP.md
+++ b/docs/REPOSITORY_MAP.md
@@ -55,6 +55,15 @@ the recorder. For SBK launches, `SbkParameters` loads the PerL defaults and
 builder. The specialized queue algorithm is documented in
 [TIMESTAMP_MPSC_QUEUE.md](TIMESTAMP_MPSC_QUEUE.md).
 
+For recorder clock-query behavior, follow
+`PerformanceRecorderIdleBusyWait` into `ElasticWait`. Records provide the
+current time through their existing `endTime`; empty scans park and use an
+adaptive counter before querying the clock. `ElasticWait.startIdle()` resets
+only the current idle sample after an active interval while retaining the
+learned moving-average park rate. Its deterministic transition and overflow
+tests are in `ElasticWaitTest`; the Null driver supplies an end-to-end idle
+reporting test.
+
 ## `sbk-api/`
 
 | Package | Responsibility |
@@ -145,6 +154,7 @@ Because many vendor drivers require external services, their strongest verificat
 | New driver | `drivers/sbktemplate`, similar driver, both registration files | New driver `check` |
 | Common CLI | `SbkParameters`, `ParameterOptions`, worker consumers | `./gradlew :sbk-api:check` |
 | Timing or percentiles | `Writer`/`Reader`, PerL builder/window/recorder | `./gradlew :perl:check :sbk-api:check` |
+| Elastic idle calibration | `ElasticWait`, `PerformanceRecorderIdleBusyWait`, `ElasticWaitTest`, Null idle test | `./gradlew :perl:test :drivers:null:test` |
 | Timestamp queue algorithm | `TimeStampNode`, `TimeStampMpscQueue`, queue arrays/channels | `./gradlew :perl:concurrencyCheck :perl:timeStampQueuePerformanceTest` |
 | End-to-end queue comparison | `drivers/perlbench`, `SbkParameters`, `SbkBenchmark` | `./gradlew :drivers:perlbench:check :sbk-api:check` |
 | Logger | `RWLogger`, `AbstractRWLogger`, similar implementation | `./gradlew :sbk-api:check` |

--- a/docs/REPOSITORY_MAP.md
+++ b/docs/REPOSITORY_MAP.md
@@ -42,14 +42,18 @@ Important packages:
 
 | Package | Responsibility |
 |---|---|
-| `io.perl.api` | Public measurement contracts, records, windows, and channels |
-| `io.perl.api.impl` | Queue arrays, recorder loops, histogram/window implementations, builder |
+| `io.perl.api` | Public measurement contracts, `TimeStamp`, intrusive `TimeStampNode`, windows, and channels |
+| `io.perl.api.impl` | Intrusive and JDK queue paths, queue arrays, recorder loops, histogram/window implementations, builder |
 | `io.perl.config` | Measurement defaults |
 | `io.perl.logger` | PerL-level reporting interfaces and implementations |
 | `io.time` | Millisecond, microsecond, and nanosecond clock abstractions |
 | `io.state` | Shared lifecycle states |
 
-Start at `io.perl.api.impl.PerlBuilder` to see which implementation is selected from configuration.
+Start at `io.perl.api.impl.PerlBuilder` to see how configuration constructs
+the recorder. For SBK launches, `SbkParameters` loads the PerL defaults and
+`SbkBenchmark` applies the common `-mpscqueue` override before invoking that
+builder. The specialized queue algorithm is documented in
+[TIMESTAMP_MPSC_QUEUE.md](TIMESTAMP_MPSC_QUEUE.md).
 
 ## `sbk-api/`
 
@@ -87,6 +91,17 @@ drivers/<name>/
 ```
 
 Some drivers legitimately differ: they may share a JDBC implementation, provide callback or asynchronous readers, omit unsupported read/write directions, or use a custom payload type.
+
+The synthetic drivers have no backend:
+
+| Driver | Location | Purpose |
+|---|---|---|
+| `Null` | `drivers/null` | Pending operations, idle windows, timeout, interruption, and shutdown |
+| `PerlBench` | `drivers/perlbench` | Immediate completions for end-to-end SBK/PerL queue throughput and allocation comparison |
+
+They are intentionally separate. The default Null write does not produce a
+completed timestamp; PerlBench is designed to produce timestamps as fast as
+the harness permits.
 
 ## Distributed modules
 
@@ -130,6 +145,8 @@ Because many vendor drivers require external services, their strongest verificat
 | New driver | `drivers/sbktemplate`, similar driver, both registration files | New driver `check` |
 | Common CLI | `SbkParameters`, `ParameterOptions`, worker consumers | `./gradlew :sbk-api:check` |
 | Timing or percentiles | `Writer`/`Reader`, PerL builder/window/recorder | `./gradlew :perl:check :sbk-api:check` |
+| Timestamp queue algorithm | `TimeStampNode`, `TimeStampMpscQueue`, queue arrays/channels | `./gradlew :perl:concurrencyCheck :perl:timeStampQueuePerformanceTest` |
+| End-to-end queue comparison | `drivers/perlbench`, `SbkParameters`, `SbkBenchmark` | `./gradlew :drivers:perlbench:check :sbk-api:check` |
 | Logger | `RWLogger`, `AbstractRWLogger`, similar implementation | `./gradlew :sbk-api:check` |
 | gRPC aggregation | Proto definitions, `GrpcLogger`, `SbmGrpcService` | `./gradlew :sbm:check` |
 | Remote launch | `SbkGem`, `SbkGemBenchmark`, SSH classes | `./gradlew :sbk-gem:check` |

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -16,6 +16,16 @@ limitations under the License.
 
 # TimeStampMpscQueue: architecture, correctness, and performance
 
+**System:** Storage Benchmark Kit (SBK) 10.4, Performance Logger (PerL)
+
+**Implementation baseline:** JDK 25 `ConcurrentLinkedQueue`
+
+**Evaluation date:** 2026-07-27
+
+**Keywords:** MPSC queue, lock-free queue, intrusive data structure, Java
+Memory Model, VarHandle, garbage collection, low latency, throughput,
+microbenchmarking
+
 ## Abstract
 
 `TimeStampMpscQueue` is the specialized hand-off queue used by SBK's
@@ -31,6 +41,13 @@ both the measurement and its linked-queue node. The JDK fallback stores a
 25 runtime measured in this repository, the complete intrusive round trip
 allocates 40 bytes instead of 56 bytes per measurement.
 
+On the declared 16-vCPU JDK 25 host, the intrusive queue measured 30.55% lower
+round-trip latency and 14.35% higher four-producer enqueue throughput than the
+CLQ path. End-to-end PerlBench runs also showed higher saturation throughput
+and lower peak resident memory. These are environment-specific observations,
+not claims of universal superiority; the structural removal of one wrapper
+object per record is the portable design result.
+
 This document is intended for graduate students, researchers, performance
 engineers, and reviewers of concurrent algorithms. It distinguishes:
 
@@ -38,6 +55,17 @@ engineers, and reviewers of concurrent algorithms. It distinguishes:
 - safety arguments from empirical testing;
 - deterministic allocation differences from environment-sensitive throughput;
 - implementation evidence from general performance claims.
+
+The paper makes four concrete contributions:
+
+1. it derives a minimal queue contract from PerL's actual producer-consumer
+   topology instead of beginning with the Java Collections API;
+2. it presents a field-level and operation-level comparison with the JDK 25
+   `ConcurrentLinkedQueue` implementation;
+3. it explains which CLQ mechanisms were retained, specialized, or rejected,
+   including the one-node tail-slack optimization;
+4. it reports correctness, reclamation, allocation, latency, throughput, and
+   end-to-end SBK evidence with explicit threats to validity.
 
 The authoritative implementation is
 [`TimeStampMpscQueue.java`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java).
@@ -66,7 +94,62 @@ JDK `ConcurrentLinkedQueue` is a general-purpose, unbounded, non-blocking FIFO
 collection with multiple consumers, weakly consistent iterators, bulk
 operations, interior-node deletion, serialization, and the complete Java
 Collections `Queue` contract. `TimeStampMpscQueue` deliberately does not
-provide those features.
+provide those features [3, 4].
+
+### 1.1 Hypotheses
+
+The implementation and evaluation test three hypotheses:
+
+- **H1 -- allocation:** representing the measurement and queue link with one
+  intrusive object removes the JDK queue's private wrapper allocation;
+- **H2 -- latency:** specializing dequeue for one consumer and reducing shared
+  metadata updates lowers queue round-trip latency;
+- **H3 -- throughput:** fewer allocations and less producer/consumer cache
+  coherence traffic increase sustainable MPSC publication throughput.
+
+H1 follows structurally from the object graphs and is verified with JMH
+normalized allocation. H2 and H3 are empirical and must be re-measured on each
+relevant JVM and machine.
+
+### 1.2 Terminology and observation boundary
+
+```mermaid
+flowchart LR
+    OP["Storage operation completes"]
+    PAY["Timestamp payload is initialized"]
+    ENQ["Queue enqueue"]
+    QW["Waiting in queue"]
+    DEQ["Recorder dequeue"]
+    AGG["Latency-window aggregation"]
+
+    OP --> PAY --> ENQ --> QW --> DEQ --> AGG
+
+    subgraph QUEUE["Queue study boundary"]
+        ENQ
+        QW
+        DEQ
+    end
+
+    classDef operation fill:#fef3c7,stroke:#a16207,color:#111
+    classDef queue fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef recorder fill:#dcfce7,stroke:#166534,color:#111
+    class OP,PAY operation
+    class ENQ,QW,DEQ queue
+    class AGG recorder
+```
+
+In this document:
+
+- **payload** means the four measurement fields;
+- **wrapper node** means CLQ's private structural `Node`;
+- **intrusive node** means a payload object that also contains its queue link;
+- **live node** means reachable queue state not yet consumed;
+- **retired node** means a consumed predecessor awaiting or completing
+  detachment;
+- **linearization point** means the single atomic event at which an operation
+  appears to take effect;
+- **storage allocation** means heap storage allocated by the timestamp hand-off
+  path, not bytes written to the benchmarked storage system.
 
 ## 2. Position in the PerL measurement pipeline
 
@@ -207,6 +290,105 @@ The 40 and 56 byte values are observations from the controlled JMH run
 documented in Section 10. Object size depends on VM layout, alignment, pointer
 compression, and flags; it is not a Java language constant.
 
+### 3.3 Field-level storage model
+
+The following table describes logical fields rather than promising a fixed
+physical layout. HotSpot may change headers, alignment, and reference width.
+
+| Object | Logical content | Intrusive path | JDK path |
+|---|---|---:|---:|
+| Timestamp payload | two `long` values and two `int` values | one instance | one instance |
+| Queue link | one node reference | inside `TimeStampNode` | inside private CLQ `Node` |
+| Payload indirection | reference from wrapper to payload | none | one `item` reference |
+| Structural object header | header for queue node object | shared with payload | additional header |
+| Enqueue-time queue allocation | allocation performed inside queue | none | one private CLQ `Node` |
+
+For `n` measurements, ignoring the one-time sentinel and VM alignment:
+
+```text
+intrusive object count(n) = n
+JDK path object count(n)  = 2n
+object-count reduction    = n, or 50% of the JDK path's per-record objects
+```
+
+The measured byte model on the declared JDK 25 configuration is:
+
+```text
+intrusive allocation(n) = 40n bytes
+JDK path allocation(n)  = 56n bytes
+saved allocation(n)     = 16n bytes
+```
+
+At one million records per second this corresponds to approximately 16 MB/s
+less normalized allocation; at ten million records per second it corresponds
+to approximately 160 MB/s less. These are decimal-rate illustrations derived
+from the measured 16 B/op difference, not universal object sizes.
+
+```mermaid
+flowchart TB
+    subgraph M["TimeStampMpscQueue: one record"]
+        MN["TimeStampNode<br/>header + payload + next"]
+    end
+
+    subgraph J["ConcurrentLinkedQueue path: one record"]
+        JN["CLQ Node<br/>header + item + next"]
+        JT["TimeStamp<br/>header + payload"]
+        JN -->|"item reference"| JT
+    end
+
+    subgraph COST["Per million completed records"]
+        MO["MPSC: 1,000,000 objects<br/>40 MB measured allocation"]
+        JO["JDK path: 2,000,000 objects<br/>56 MB measured allocation"]
+        SV["Difference: 1,000,000 objects<br/>16 MB measured allocation"]
+    end
+
+    MN --> MO
+    JN --> JO
+    MO --> SV
+    JO --> SV
+
+    classDef intrusive fill:#dcfce7,stroke:#166534,color:#111
+    classDef jdk fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef result fill:#fef3c7,stroke:#a16207,color:#111
+    class MN,MO intrusive
+    class JN,JT,JO jdk
+    class SV result
+```
+
+### 3.4 Why object count matters to a latency recorder
+
+Allocation in a thread-local allocation buffer is usually cheap, but the
+allocated objects are not free over their complete lifetime. More objects
+consume allocation bandwidth, increase the rate at which allocation regions
+fill, add references for the collector to trace or relocate, and increase
+memory traffic. A linked wrapper also adds a pointer dereference from
+`Node.item` to `TimeStamp`.
+
+```mermaid
+flowchart LR
+    RATE["Higher completion rate"] --> OBJ["More timestamp objects"]
+    OBJ --> BW["More allocation and memory bandwidth"]
+    OBJ --> GC["More objects for GC lifecycle"]
+    OBJ --> PTR["More pointer chasing"]
+    BW --> TAIL["Potential latency-tail interference"]
+    GC --> TAIL
+    PTR --> CACHE["Additional cache/TLB pressure"]
+    CACHE --> TAIL
+
+    CUT["Intrusive node removes wrapper"] -. "reduces" .-> OBJ
+    CUT -. "removes one indirection" .-> PTR
+
+    classDef pressure fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef mitigation fill:#dcfce7,stroke:#166534,color:#111
+    class RATE,OBJ,BW,GC,PTR,CACHE,TAIL pressure
+    class CUT mitigation
+```
+
+This does not mean every allocation immediately triggers a stop-the-world
+collection, nor that allocation alone determines latency. It means the wrapper
+is avoidable work in PerL's fixed data model, so removing it lowers the amount
+of work presented to the allocator, memory hierarchy, and collector.
+
 ## 4. State and ownership
 
 ```mermaid
@@ -258,6 +440,75 @@ The queue starts with one sentinel. The sentinel simplifies empty/non-empty
 transitions because `head` always identifies a node and the first real element
 is `head.next`.
 
+### 4.1 JDK CLQ internal state
+
+JDK 25 CLQ is a modified Michael-Scott queue adapted to garbage collection and
+interior deletion. Each private node has a volatile `item` and volatile
+`next`. The queue has independently advancing volatile `head` and `tail`
+pointers. A node may remain structurally linked after its item has been
+logically removed by changing `item` to `null` [1, 4].
+
+```mermaid
+stateDiagram-v2
+    [*] --> Live: Node(item = E, next = successor)
+    Live --> LogicallyDeleted: CAS item from E to null
+    LogicallyDeleted --> StructurallyLinked: unlink not yet performed
+    StructurallyLinked --> Detached: head advance or predecessor unlink
+    Detached --> SelfLinked: old head next points to itself
+    SelfLinked --> [*]: no external references remain
+```
+
+The separate `item` field is essential to CLQ's multi-consumer and arbitrary
+removal contract: a successful CAS from a non-null item to `null` decides which
+consumer or remover owns the element. It is also the source of the structural
+wrapper that PerL can eliminate.
+
+```mermaid
+flowchart LR
+    subgraph CLQ["JDK CLQ shared state"]
+        CH["volatile head"]
+        CT["volatile tail"]
+        CN1["Node<br/>volatile item<br/>volatile next"]
+        CN2["Node<br/>volatile item<br/>volatile next"]
+        CH --> CN1 --> CN2
+        CT --> CN2
+    end
+
+    subgraph MPSC["TimeStampMpscQueue split state"]
+        MH["HeadRef<br/>consumer owned"]
+        MT["TailRef<br/>producer shared"]
+        MN1["TimeStampNode<br/>payload + next"]
+        MN2["TimeStampNode<br/>payload + next"]
+        MH --> MN1 --> MN2
+        MT --> MN2
+    end
+
+    classDef jdk fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef mpsc fill:#dcfce7,stroke:#166534,color:#111
+    class CH,CT,CN1,CN2 jdk
+    class MH,MT,MN1,MN2 mpsc
+```
+
+CLQ places `head` and `tail` as fields of the same queue object and relies on
+the JVM's layout decisions. `TimeStampMpscQueue` places producer-shared and
+consumer-owned state in separately padded holder objects. Padding reduces the
+chance of false sharing but is deliberately described as a heuristic because
+the Java language does not guarantee cache-line placement.
+
+### 4.2 Ownership specialization
+
+| State transition | JDK CLQ reason | PerL specialization |
+|---|---|---|
+| Claim an item | Multiple consumers/removers may race | Exactly one consumer; no claim CAS |
+| Advance head | Multiple threads may update head | Consumer-owned plain head write |
+| Update tail | Producers race; tail is a hint | Same principle, with one-node slack |
+| Remove interior item | Required by Collection APIs | Unsupported and unnecessary |
+| Traverse dead nodes | Required by iteration, removal, and MPMC polling | FIFO consumer sees only the next link |
+| Recover stale traversal | Self-link means restart from head | Self-link means use newer tail or published recovery head |
+
+The specialization does not make CLQ's mechanisms defective. It removes
+mechanisms whose preconditions cannot occur in the PerL topology.
+
 ## 5. Producer algorithm and linearization
 
 ### 5.1 Normal enqueue
@@ -275,14 +526,23 @@ sequenceDiagram
     L-->>P: null
     P->>L: CAS candidate.next from null to N
     Note over P,L: Successful CAS is the enqueue linearization point
-    P->>T: weak release-CAS tail hint to N
+    alt producer traversed beyond initial tail
+        P->>T: weak release-CAS tail hint to N
+    else initial tail was the trailing node
+        P-->>T: leave one-node tail slack
+    end
     Note over P,T: Tail update is an optimization, not publication correctness
 ```
 
 The successful `NEXT.compareAndSet(current, null, newNode)` is the enqueue
 linearization point. Before that CAS, another thread cannot reach the new node
 from the queue. After it succeeds, the node is in the FIFO chain even if the
-best-effort tail update fails.
+best-effort tail update fails. Following JDK 25 `ConcurrentLinkedQueue`, the
+queue deliberately leaves one-node tail slack when the producer appended
+directly to its initial tail candidate. The next producer traverses that one
+node and then advances the tail. This approximately halves tail compare-and-set
+traffic in the uncontended path and reduces cache-line invalidation among
+producers [2, 4].
 
 ### 5.2 Contended enqueue
 
@@ -291,20 +551,27 @@ flowchart TD
     A["Acquire-read tail hint"] --> B["Acquire-read current.next"]
     B --> C{"next is null?"}
     C -->|yes| D{"CAS link succeeds?"}
-    D -->|yes| E["Best-effort release update of tail"]
-    E --> F["Return true"]
+    D -->|yes| E{"Traversed beyond initial tail?"}
+    E -->|yes| K["Best-effort release update of tail"]
+    E -->|no| F["Keep one-node tail slack"]
+    K --> L
+    F --> L
+    L["Return true"]
     D -->|no| B
     C -->|no| G{"next self-links?"}
     G -->|no| H["Follow next or refresh newer tail"]
     H --> B
-    G -->|yes| I["Acquire-read recoveryHead"]
+    G -->|yes| M{"A newer tail is visible?"}
+    M -->|yes| N["Resume from newer tail"]
+    M -->|no| I["Acquire-read recoveryHead"]
     I --> J["Best-effort move tail hint to recoveryHead"]
+    N --> B
     J --> B
 
     classDef decision fill:#fef3c7,stroke:#a16207,color:#111
     classDef progress fill:#dcfce7,stroke:#166534,color:#111
-    class C,D,G decision
-    class E,F,H,I,J progress
+    class C,D,E,G,M decision
+    class F,H,I,J,K,L,N progress
 ```
 
 If a producer loses the link CAS, some other producer has linked a node and
@@ -312,6 +579,81 @@ therefore the system has made progress. The losing producer follows the chain
 or refreshes the tail hint and retries. This is a lock-free system-progress
 argument; it is not a wait-free per-thread bound. One producer may retry
 indefinitely under adversarial scheduling.
+
+### 5.3 Enqueue comparison and adopted CLQ optimization
+
+Both implementations publish a new node by CASing the final node's `next`
+from `null` to the new node. Both treat `tail` as a traversal hint rather than
+the source of correctness. The important differences occur before and after
+that shared linearization point.
+
+```mermaid
+flowchart TB
+    START["Caller has completed timestamp payload"]
+
+    subgraph J["JDK ConcurrentLinkedQueue.offer"]
+        JA["Allocate private Node"]
+        JB["Store payload reference in Node.item"]
+        JC["Read tail and traverse next links"]
+        JD["CAS final.next from null to new Node"]
+        JE{"Traversed beyond original tail?"}
+        JF["Weak CAS tail to new Node"]
+        JG["Return"]
+        JA --> JB --> JC --> JD --> JE
+        JE -->|yes| JF --> JG
+        JE -->|no| JG
+    end
+
+    subgraph M["TimeStampMpscQueue.add"]
+        MA["Use caller's TimeStampNode directly"]
+        MC["Read padded tail holder and traverse next links"]
+        MD["CAS final.next from null to TimeStampNode"]
+        ME{"Traversed beyond original tail?"}
+        MF["Weak release-CAS tail to node"]
+        MG["Return"]
+        MA --> MC --> MD --> ME
+        ME -->|yes| MF --> MG
+        ME -->|no| MG
+    end
+
+    START --> JA
+    START --> MA
+
+    classDef jdk fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef mpsc fill:#dcfce7,stroke:#166534,color:#111
+    class JA,JB,JC,JD,JE,JF,JG jdk
+    class MA,MC,MD,ME,MF,MG mpsc
+```
+
+The **one-node tail-slack** mechanism was taken from JDK 25 CLQ because it is
+independent of the MPMC Collection features:
+
+```mermaid
+sequenceDiagram
+    participant P1 as Producer 1
+    participant P2 as Producer 2
+    participant T as Tail hint
+    participant A as Last node A
+    participant B as New node B
+    participant C as New node C
+
+    P1->>T: read tail = A
+    P1->>A: CAS A.next = B
+    Note over P1,T: P1 does not update tail because A was its initial tail
+    P2->>T: read tail = A
+    P2->>A: read A.next = B
+    P2->>B: CAS B.next = C
+    P2->>T: weak CAS tail from A to C
+    Note over T: One tail CAS covers two successful links
+```
+
+The former SBK implementation attempted a shared tail update after every
+successful link. Tail slack changes the common sequence from approximately one
+link CAS plus one tail CAS per record to one link CAS per record plus one
+best-effort tail CAS for approximately every two links. The exact hardware cost
+depends on contention and architecture, but removing atomic writes to a
+producer-shared cache line gives a direct mechanism for the observed throughput
+improvement.
 
 ## 6. Consumer algorithm
 
@@ -347,6 +689,81 @@ the producer before publication.
 
 The node returned by `poll` becomes the new head sentinel while also carrying
 the returned timestamp. It must never be enqueued again.
+
+### 6.1 Why CLQ poll performs more coordination
+
+CLQ must allow several consumers, iterator removal, and `remove(Object)` to
+race safely. Its element-removal linearization point is therefore a CAS of
+`Node.item` from the payload reference to `null`. A polling thread may
+encounter null-item nodes, lose the item CAS to another consumer, traverse
+forward, attempt to advance `head`, or restart after seeing a self-link.
+
+PerL has one recorder. It reads `head.next`, moves its owner-only head to that
+node, and returns the same `TimeStampNode`. It does not atomically claim an item
+because no second consumer exists.
+
+```mermaid
+flowchart TB
+    subgraph JP["JDK CLQ poll"]
+        J0["Read shared head"]
+        J1{"Current item non-null?"}
+        J2{"CAS item to null succeeds?"}
+        J3["Return payload"]
+        J4{"next is null?"}
+        J5["Best-effort CAS head"]
+        J6{"self-link observed?"}
+        J7["Restart from head"]
+        J8["Advance traversal"]
+        J0 --> J1
+        J1 -->|yes| J2
+        J2 -->|yes| J5 --> J3
+        J2 -->|no| J4
+        J1 -->|no| J4
+        J4 -->|yes| J5
+        J4 -->|no| J6
+        J6 -->|yes| J7 --> J0
+        J6 -->|no| J8 --> J1
+    end
+
+    subgraph MP["TimeStampMpscQueue poll"]
+        M0["Read consumer-owned head"]
+        M1["Acquire-read head.next"]
+        M2{"next is null?"}
+        M3["Return null"]
+        M4["Plain-write head = next"]
+        M5["Stage old head for batched retirement"]
+        M6["Return next TimeStampNode"]
+        M0 --> M1 --> M2
+        M2 -->|yes| M3
+        M2 -->|no| M4 --> M5 --> M6
+    end
+
+    classDef jdk fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef mpsc fill:#dcfce7,stroke:#166534,color:#111
+    class J0,J1,J2,J3,J4,J5,J6,J7,J8 jdk
+    class M0,M1,M2,M3,M4,M5,M6 mpsc
+```
+
+### 6.2 Hot-path operation budget
+
+The following is a qualitative budget for successful, non-empty operations.
+It is not an instruction count: retries, compiler transformations, cache
+misses, and collector barriers vary.
+
+| Hot-path work | JDK CLQ path | `TimeStampMpscQueue` |
+|---|---|---|
+| Producer payload allocation | `TimeStamp` | `TimeStampNode` |
+| Producer structural allocation | private `Node` | none |
+| Producer publication CAS | `Node.next` | `TimeStampNode.next` |
+| Producer tail policy | one-node slack | one-node slack |
+| Consumer payload-claim CAS | required on `Node.item` | none |
+| Consumer head update | shared CAS when advanced | plain owner write |
+| Consumer payload indirection | `Node.item -> TimeStamp` | returned node is payload |
+| Consumer retirement | general dead-node/head logic | amortized batch of 16 |
+
+The MPSC path shifts some retirement work into every sixteenth dequeue. This
+reduces the average release-store count but introduces a small periodic burst;
+Section 7 explains why the batch remains bounded.
 
 ## 7. Batched retirement and stale-producer recovery
 
@@ -413,6 +830,109 @@ The implementation clears each `retiredNodes` array slot after self-linking.
 This avoids retaining the retired object through the helper array. At most 15
 not-yet-retired predecessors remain in the current partial batch.
 
+### 7.1 Reclamation differs because the payload placement differs
+
+CLQ can logically delete an element by nulling `Node.item` while keeping the
+wrapper node reachable for traversal safety. The payload may become
+collectable even when the structural node remains. That distinction is useful
+for MPMC traversal and interior deletion.
+
+An intrusive node has no separate item reference to clear. If a consumed
+`TimeStampNode` remains linked to the live suffix, the node itself—and
+therefore its timestamp payload—remains reachable. `TimeStampMpscQueue` must
+detach or self-link consumed nodes promptly rather than directly copying CLQ's
+payload-nulling policy.
+
+```mermaid
+flowchart TB
+    subgraph J["JDK CLQ after logical removal"]
+        JP["predecessor"] --> JN["wrapper Node<br/>item = null"]
+        JN --> JL["live successor"]
+        JT["TimeStamp payload"]
+        JN -. "former item reference cleared" .-> JT
+        JT --> JGC["payload eligible for GC<br/>if no other references"]
+        JN --> JKEEP["wrapper may remain for traversal"]
+    end
+
+    subgraph M["Intrusive queue after consumption"]
+        MP["retired TimeStampNode<br/>payload is inside node"]
+        MP --> ML["live successor"]
+        MP --> MR["must sever live-chain retention"]
+        MR --> MS["self-link retired node"]
+        MS --> MGC["whole timestamp node eligible for GC<br/>when producer references disappear"]
+    end
+
+    classDef jdk fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef mpsc fill:#dcfce7,stroke:#166534,color:#111
+    class JP,JN,JL,JT,JGC,JKEEP jdk
+    class MP,ML,MR,MS,MGC mpsc
+```
+
+### 7.2 Why the retirement batch is 16
+
+Batching balances two opposing costs:
+
+- a batch of one performs a release self-link and helper cleanup on every
+  dequeue;
+- a very large batch retains a longer consumed prefix and creates a larger
+  periodic cleanup burst;
+- a batch of 16 bounds the partial retired set at 15 nodes while amortizing
+  retirement stores.
+
+```mermaid
+flowchart LR
+    SMALL["Small batch"]
+    MID["Batch 16<br/>implemented point"]
+    LARGE["Large batch"]
+
+    SMALL --> S1["More frequent release stores"]
+    SMALL --> S2["Shorter partial retention"]
+    MID --> M1["One retirement pass per 16 polls"]
+    MID --> M2["At most 15 partial retired nodes"]
+    LARGE --> L1["Less frequent retirement passes"]
+    LARGE --> L2["Longer retention and larger cleanup burst"]
+
+    classDef tradeoff fill:#fef3c7,stroke:#a16207,color:#111
+    classDef chosen fill:#dcfce7,stroke:#166534,color:#111
+    class SMALL,LARGE,S1,S2,L1,L2 tradeoff
+    class MID,M1,M2 chosen
+```
+
+The chart is conceptual, not benchmark data. Sixteen is the implemented and
+tested engineering point. Changing it requires repeating GC retention,
+stale-producer, latency, and throughput tests rather than optimizing only one
+metric.
+
+### 7.3 Node lifetime comparison
+
+```mermaid
+sequenceDiagram
+    participant P as Producer
+    participant Q as Queue
+    participant C as Consumer
+    participant G as Garbage collector
+
+    rect rgb(224, 231, 255)
+        Note over P,G: JDK CLQ path
+        P->>P: allocate TimeStamp
+        P->>Q: offer allocates wrapper Node
+        C->>Q: CAS wrapper.item to null
+        Q-->>C: return TimeStamp
+        Note over Q: wrapper may remain structurally reachable
+        G->>G: reclaim payload and wrapper when separately unreachable
+    end
+
+    rect rgb(220, 252, 231)
+        Note over P,G: Intrusive MPSC path
+        P->>P: allocate TimeStampNode
+        P->>Q: link same node
+        C->>Q: owner-only head advance
+        Q-->>C: return same TimeStampNode
+        C->>Q: batch self-link consumed predecessor
+        G->>G: reclaim whole node when unreachable
+    end
+```
+
 ## 8. Java Memory Model argument
 
 ```mermaid
@@ -445,8 +965,8 @@ The queue uses JDK `VarHandle`, not `sun.misc.Unsafe`:
 | `headRef.head` | none | plain read/write | Single-consumer ownership |
 
 The argument relies on the JDK 25 `VarHandle` acquire/release and
-compare-and-set semantics cited in the references. Tests can find violations;
-they are not a substitute for a complete mechanized proof.
+compare-and-set semantics and the Java Memory Model [5, 6, 8]. Tests can find
+violations; they are not a substitute for a complete mechanized proof.
 
 ## 9. Feature comparison with JDK ConcurrentLinkedQueue
 
@@ -461,7 +981,7 @@ they are not a substitute for a complete mechanized proof.
 | Queue allocation during enqueue | None after caller creates intrusive node | Private JDK node per offered element |
 | Measurement objects per operation | One `TimeStampNode` | One `TimeStamp` plus one private node |
 | Consumer head update | Plain owner write | General multi-consumer coordination |
-| Tail | Best-effort traversal hint | Best-effort traversal hint |
+| Tail | Best-effort hint with one-node slack | Best-effort hint with one-node slack |
 | Stale traversal recovery | Batched self-links plus published recovery head | Self-links and JDK traversal recovery |
 | Retired-node policy | Batch of 16 predecessors | General-purpose head advancement and unlinking |
 | Interior dead-node cleanup | Not needed; removal is unsupported | Supported by traversal/unlink behavior |
@@ -471,6 +991,167 @@ they are not a substitute for a complete mechanized proof.
 | Serialization | Unsupported | Supported |
 | Public interface | PerL's three-method `io.perl.api.Queue` | Java Collections `java.util.Queue` |
 | Portability risk | Custom algorithm must be revalidated on JVM changes | Maintained and tested with the JDK |
+
+### 9.1 CLQ limitations for PerL's timestamp hand-off
+
+The word **limitation** here means "cost or semantic mismatch for this specific
+PerL workload." It does not mean a defect in CLQ.
+
+#### 9.1.1 Mandatory wrapper allocation
+
+CLQ owns a private `Node<E>` and therefore must allocate one node for each
+ordinary `offer(E)`. A caller cannot supply an intrusive node or reuse the
+payload object as CLQ's structural node. PerL consequently creates a
+`TimeStamp`, and CLQ creates the second object. This is the most deterministic
+disadvantage because it follows directly from the public API and private node
+representation.
+
+#### 9.1.2 Multi-consumer item claiming
+
+CLQ's `poll` must CAS a non-null `item` to `null` so only one of multiple
+consumers or removers obtains it. PerL has exactly one recorder, so this
+read-modify-write operation provides no additional correctness. The specialized
+queue replaces it with a consumer-owned head advance.
+
+#### 9.1.3 General traversal and interior deletion
+
+CLQ supports weakly consistent iterators, `contains`, `remove(Object)`,
+`removeIf`, `forEach`, spliterators, and bulk operations. Supporting these
+operations requires:
+
+- distinguishing live nodes from null-item dead nodes;
+- traversing and opportunistically collapsing dead-node chains;
+- recovering from self-linked stale traversal positions;
+- preserving reachability for concurrent iterators and removers.
+
+PerL performs strict FIFO `poll` only and never removes an interior timestamp.
+Its hot path does not need these states.
+
+#### 9.1.4 Shared general-purpose head coordination
+
+CLQ cannot assign `head` to one owner because consumers, traversal methods, and
+removal methods may all help advance it. `TimeStampMpscQueue` separates
+consumer-owned head state from producer-shared tail state and uses a plain head
+write. This reduces atomic coordination and reduces the probability of
+producer-consumer false sharing.
+
+#### 9.1.5 O(n), observational `size`
+
+The Java SE 25 API explicitly states that CLQ `size()` traverses the queue,
+takes O(n) time, and may be inaccurate during concurrent modification. This is
+appropriate for its weakly consistent Collection contract but unsuitable as
+hot-path flow control. PerL does not expose `size`; it drains until `poll`
+returns `null`.
+
+#### 9.1.6 No capacity bound or backpressure
+
+Both queues are unbounded. CLQ does not solve overload when producers
+permanently outrun the consumer, and neither does the intrusive queue. PerL
+addresses contention with configurable queue topology, but queue sharding does
+not impose a memory bound.
+
+#### 9.1.7 Genericity prevents payload-aware layout
+
+CLQ must accept arbitrary non-null reference types. It cannot know that every
+element contains exactly two times, a record count, and a byte count, or that
+the element is single-use. `TimeStampMpscQueue` can encode those invariants in
+the type and eliminate the `item` indirection.
+
+```mermaid
+flowchart LR
+    subgraph REQUIRED["What CLQ must support"]
+        MC["Multiple consumers"]
+        IT["Iterators and spliterators"]
+        IR["Interior removal"]
+        GE["Generic element type"]
+        CO["Collection operations"]
+    end
+
+    subgraph MECHANISM["Resulting mechanisms"]
+        IC["CAS item to null"]
+        WR["Private wrapper node"]
+        DN["Dead-node traversal"]
+        HC["Shared head coordination"]
+        BI["Bulk and iteration paths"]
+    end
+
+    subgraph PERL["PerL fixed contract"]
+        SC["One consumer"]
+        FO["FIFO add and poll only"]
+        TT["TimeStampNode only"]
+    end
+
+    MC --> IC
+    GE --> WR
+    IT --> DN
+    IR --> DN
+    MC --> HC
+    CO --> BI
+
+    SC -. "removes need for" .-> IC
+    FO -. "removes need for" .-> DN
+    FO -. "removes need for" .-> BI
+    TT -. "removes need for" .-> WR
+
+    classDef requirement fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef mechanism fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef specialization fill:#dcfce7,stroke:#166534,color:#111
+    class MC,IT,IR,GE,CO requirement
+    class IC,WR,DN,HC,BI mechanism
+    class SC,FO,TT specialization
+```
+
+### 9.2 What SBK borrowed, specialized, and did not copy
+
+| JDK CLQ concept | SBK decision | Reason |
+|---|---|---|
+| CAS the final `next` from null | **Retained** | Simple lock-free publication and FIFO linearization |
+| Tail is only a hint | **Retained** | Correctness remains in the linked chain |
+| One-node pointer slack | **Retained** | Fewer shared tail CAS operations |
+| Self-link marks an off-list node | **Retained and specialized** | Stale producers need a recognizable recovery condition |
+| Jump to a live point after self-link | **Specialized** | Prefer newer tail, otherwise use release-published `recoveryHead` |
+| Separate wrapper and item | **Rejected** | Intrusive timestamp removes allocation and indirection |
+| CAS item to null on poll | **Rejected** | Only one consumer exists |
+| Shared CAS head advancement | **Rejected** | Head is consumer-owned |
+| Interior deletion and iterators | **Rejected** | Not part of the PerL contract |
+| Immediate old-head self-link only | **Not copied directly** | Intrusive payload requires prompt whole-node detachment |
+| Node pooling/reuse | **Rejected** | Retention, ownership complexity, and ABA/reuse hazards |
+
+```mermaid
+flowchart TB
+    CLQ["JDK 25 CLQ engineering"]
+    KEEP["Retain<br/>link CAS, tail hint,<br/>tail slack, self-link marker"]
+    SPEC["Specialize<br/>single-consumer head,<br/>recoveryHead, batch retirement"]
+    DROP["Remove from hot path<br/>wrapper item, item CAS,<br/>iteration, interior removal"]
+    RESULT["TimeStampMpscQueue"]
+
+    CLQ --> KEEP --> RESULT
+    CLQ --> SPEC --> RESULT
+    CLQ --> DROP --> RESULT
+
+    classDef source fill:#e0e7ff,stroke:#4338ca,color:#111
+    classDef keep fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef specialize fill:#dcfce7,stroke:#166534,color:#111
+    classDef remove fill:#fee2e2,stroke:#991b1b,color:#111
+    class CLQ source
+    class KEEP keep
+    class SPEC,RESULT specialize
+    class DROP remove
+```
+
+### 9.3 Complexity and contention model
+
+| Operation/property | JDK CLQ | `TimeStampMpscQueue` |
+|---|---|---|
+| Successful enqueue | Amortized O(1), lock-free | Amortized O(1), lock-free |
+| Successful dequeue | Amortized O(1), lock-free MPMC | O(1) owner-only, plus amortized retirement |
+| Empty poll | Traverses/updates head as required | One acquire read of `head.next` |
+| Enqueue allocation | O(1) wrapper allocation | zero queue allocation |
+| `size` | O(n), observational | unsupported |
+| Worst-case individual retry | Unbounded | unbounded |
+| Capacity | Unbounded | unbounded |
+| Primary producer contention | final-node `next`, tail hint | final-node `next`, padded tail hint |
+| Primary consumer contention | `item` and head with other consumers/helpers | none with another consumer by contract |
 
 The two classes sharing the name `Queue` can be confusing.
 `TimeStampMpscQueue` implements SBK's minimal
@@ -508,7 +1189,31 @@ contains two complementary experiments:
 
 The verification task uses three isolated JVM forks, three one-second warm-up
 iterations, five one-second measurement iterations, JMH's GC profiler, and
-99.9% confidence intervals.
+99.9% confidence intervals [10, 13, 14].
+
+```mermaid
+flowchart LR
+    SRC["Same timestamp values"]
+    A["Intrusive benchmark path"]
+    B["JDK CLQ benchmark path"]
+    FORK["3 isolated JVM forks"]
+    WARM["3 warm-up iterations"]
+    MEAS["5 measurement iterations"]
+    GC["JMH GC profiler"]
+    OUT["ns/op, B/op, ops/s,<br/>99.9% confidence interval"]
+
+    SRC --> A --> FORK
+    SRC --> B --> FORK
+    FORK --> WARM --> MEAS
+    MEAS --> GC --> OUT
+
+    classDef input fill:#fef3c7,stroke:#a16207,color:#111
+    classDef path fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef output fill:#dcfce7,stroke:#166534,color:#111
+    class SRC input
+    class A,B,FORK,WARM,MEAS,GC path
+    class OUT output
+```
 
 ### 10.2 Reproducible run on 2026-07-27
 
@@ -535,17 +1240,17 @@ Results:
 
 | Metric | `TimeStampMpscQueue` | JDK `ConcurrentLinkedQueue` path | Relative result |
 |---|---:|---:|---:|
-| Round-trip latency | 34.208 ns/op | 47.107 ns/op | 27.38% lower |
+| Round-trip latency | 33.107 ns/op | 47.673 ns/op | 30.55% lower |
 | Round-trip normalized allocation | 40.000 B/op | 56.000 B/op | 28.57% lower |
-| Four-producer producer throughput | 5,406,094 ops/s | 5,557,486 ops/s | 2.72% lower |
-| Producer-throughput 99.9% CI | 5,317,109 to 5,495,078 | 5,248,995 to 5,865,977 | intervals overlap |
+| Four-producer producer throughput | 5,904,509 ops/s | 5,163,359 ops/s | 14.35% higher |
+| Producer-throughput 99.9% CI | 5,819,992 to 5,989,025 | 5,047,306 to 5,279,412 | intervals do not overlap |
 
 ```mermaid
 xychart-beta
     title "Round-trip latency: lower is better"
     x-axis ["TimeStampMpscQueue", "JDK CLQ path"]
     y-axis "nanoseconds per operation" 0 --> 60
-    bar [34.208, 47.107]
+    bar [33.107, 47.673]
 ```
 
 ```mermaid
@@ -561,7 +1266,7 @@ xychart-beta
     title "Four-producer throughput: higher is better"
     x-axis ["TimeStampMpscQueue", "JDK CLQ"]
     y-axis "producer operations per second" 0 --> 6000000
-    bar [5406094, 5557486]
+    bar [5904509, 5163359]
 ```
 
 ### 10.3 Interpretation
@@ -575,21 +1280,64 @@ a narrower API, a single-consumer head, and separated head/tail state are
 plausible contributing mechanisms. The benchmark establishes correlation
 under this setup; it does not isolate the contribution of each mechanism.
 
-The contended producer-throughput result did **not** favor the intrusive queue.
-The JDK path was 2.72% faster by point estimate, but the wide, overlapping
-99.9% confidence intervals do not resolve a statistically clear winner. The
-Gradle verification consequently failed its policy gate requiring the
+The contended producer-throughput result favored the intrusive queue by
+14.35%. Its 99.9% confidence interval was entirely above the JDK path's
+interval, and the Gradle verification passed its policy gate requiring the
 intrusive producer metric to exceed the JDK metric by at least 2%.
+
+The improvement came from adopting CLQ's tail-slack strategy. The earlier
+implementation attempted to update the producer-shared tail after every
+successful link. The optimized implementation skips that update when the
+producer appended directly to its initial tail candidate and advances tail
+after a later producer traverses beyond it. This retains the intrusive
+representation and MPSC consumer specialization while removing unnecessary
+tail cache-line traffic.
 
 This outcome is important:
 
 - lower allocation is a stable structural advantage for the compared paths;
 - lower round-trip latency was observed on this host;
-- higher MPSC throughput must not be presented as universal;
+- higher MPSC throughput was demonstrated for this controlled topology;
 - virtualization, scheduling, NUMA placement, CPU frequency, JIT decisions,
   GC phase, and producer/consumer balance can change throughput;
 - a successful verification run is evidence for that environment, not proof
   that one implementation dominates all environments.
+
+```mermaid
+flowchart LR
+    IR["Intrusive representation"] --> OA["One object per record"]
+    OA --> BA["16 B/op measured saving"]
+    OA --> GI["No wrapper item indirection"]
+
+    SC["Single-consumer specialization"] --> NC["No item-claim CAS"]
+    SC --> PH["Plain owner head write"]
+
+    TS["JDK-derived tail slack"] --> TC["Fewer tail CAS updates"]
+    TC --> CC["Less shared cache-line traffic"]
+
+    BR["Batched retirement"] --> AR["Amortized release stores"]
+    BR --> BD["At most 15 partial retired nodes"]
+
+    BA --> LAT["Lower measured round-trip latency"]
+    GI --> LAT
+    NC --> LAT
+    PH --> LAT
+    CC --> THR["Higher measured MPSC throughput"]
+    AR --> THR
+    BD --> MEM["Lower observed memory pressure"]
+
+    classDef design fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef mechanism fill:#fef3c7,stroke:#a16207,color:#111
+    classDef evidence fill:#dcfce7,stroke:#166534,color:#111
+    class IR,SC,TS,BR design
+    class OA,GI,NC,PH,TC,CC,AR,BD mechanism
+    class BA,LAT,THR,MEM evidence
+```
+
+Arrows in this causal map identify plausible mechanisms supported by source
+inspection and aggregate measurements. They do not claim that the experiment
+independently estimates every arrow. A factorial benchmark would be required
+to isolate each mechanism's effect.
 
 ### 10.4 Recommended experimental protocol
 
@@ -610,6 +1358,61 @@ For publishable comparisons:
 9. Run end-to-end SBK workloads in addition to microbenchmarks. A nanosecond
    queue result may be immaterial for a millisecond storage operation.
 10. Retain correctness gates independently of performance outcomes.
+
+### 10.5 End-to-end SBK evaluation with PerlBench
+
+The queue JMH benchmark isolates add/poll latency and allocation. The
+[`PerlBench` driver](../drivers/perlbench/README.md) answers a different
+question: how do the queue paths affect the complete SBK worker, clock,
+timestamp publication, recorder, latency-window, and reporting pipeline?
+
+```mermaid
+flowchart LR
+    PB["PerlBench no-op operation"]
+    TS["Start and end timestamp"]
+    SEL{"-mpscqueue"}
+    MQ["TimeStampMpscQueue"]
+    JQ["JDK ConcurrentLinkedQueue"]
+    REC["One PerL recorder"]
+    RES["Throughput, latency,<br/>count, process memory"]
+
+    PB --> TS --> SEL
+    SEL -->|"true"| MQ
+    SEL -->|"false"| JQ
+    MQ --> REC
+    JQ --> REC
+    REC --> RES
+
+    classDef intrusive fill:#dcfce7,stroke:#166534,color:#111
+    classDef fallback fill:#e0e7ff,stroke:#4338ca,color:#111
+    class MQ intrusive
+    class JQ fallback
+```
+
+For a deliberate all-producers-to-one-queue experiment, set `maxQs=1` in
+`sbk-api/src/main/resources/sbk.properties` and rebuild SBK. Queue topology is
+not exposed as a command-line option because an unsuitable shared-queue count
+can add benchmark-harness contention. Use `-records` to verify exact delivery
+and complete draining, `-seconds` for maximum timed throughput, and `-seconds`
+with `-throughput` to compare latency and stability at the same offered MB/s.
+Startup logs identify the effective queue implementation and topology.
+
+The operation's end timestamp is captured before queue insertion. PerlBench
+latency percentiles therefore measure the no-op operation and clock path, not
+direct enqueue latency. Queue effects appear in sustainable record rate,
+allocation, garbage collection, memory, and drain behavior. This separation
+is why JMH and PerlBench are complementary rather than interchangeable.
+
+On the Section 10.2 host, three 20-million-record runs with four producers and
+one shared queue had median rates of 5.53 M records/s for the intrusive queue
+and 5.19 M records/s for the JDK path, a 6.6% advantage. Median peak resident
+memory was about 1.24 GiB and 1.54 GiB respectively. A one-producer timed run
+favored the intrusive queue by 26.9%. Fresh six-second saturation checks after
+the tail-slack change measured 5.61 M records/s versus 4.47 M with four writers
+and 8.11 M records/s versus 6.16 M with one reader. All runs reported zero
+invalid latencies. These observations support both the microbenchmark mechanism
+and the end-to-end benefit, while remaining specific to the declared host,
+JVM, topology, and workload.
 
 ## 11. Correctness and reclamation evidence
 
@@ -661,9 +1464,11 @@ Commands:
 Lincheck and JCStress are complementary. Lincheck searches operation histories
 for violations of a sequential FIFO model. JCStress samples Java Memory Model
 outcomes and can expose publication or reordering errors. Neither can enumerate
-all executions of an unbounded concurrent system.
+all executions of an unbounded concurrent system [11, 12].
 
 ## 12. Limitations and threats to validity
+
+### 12.1 TimeStampMpscQueue limitations
 
 1. **Single-consumer requirement.** A second consumer creates a data race on
    `head` and invalidates the design.
@@ -688,7 +1493,114 @@ all executions of an unbounded concurrent system.
     `ConcurrentLinkedQueue` implementation details may change. Re-run the full
     evidence suite for each supported JDK.
 
-## 13. References
+### 12.2 Comparison limitations
+
+1. **Specialized versus general-purpose API.** The performance comparison is
+   intentionally asymmetric: CLQ provides substantially more functionality.
+   Results must not be generalized to workloads requiring multiple consumers,
+   iteration, or arbitrary removal.
+2. **Object-size dependence.** The observed 40 B/op and 56 B/op values depend
+   on JDK 25, compact headers, alignment, and the benchmark path. The
+   one-object-versus-two-object distinction is structural; exact bytes are not.
+3. **JMH topology.** Four producers and one consumer represent an important
+   PerL case but do not cover every producer count, queue depth, NUMA placement,
+   or consumer service rate.
+4. **End-to-end coupling.** PerlBench includes timestamp capture, worker
+   scheduling, recorder work, reporting, JVM warm-up, and shutdown. Its
+   throughput difference cannot be assigned only to the queue.
+5. **Short saturation observations.** Six-second SBK runs are smoke-level
+   evidence. Publication-quality results need longer alternating runs,
+   multiple process forks, affinity control, and preserved raw data.
+6. **No formal proof.** Linearization arguments, JCStress, Lincheck, unit
+   tests, and GC soaks provide complementary confidence but are not a
+   machine-checked proof over all executions.
+7. **Collector dependence.** ZGC was used for the reported measurement.
+   Generational ZGC, G1, Shenandoah, and other collectors can respond
+   differently to allocation rate and cross-generational links.
+8. **Hardware dependence.** CAS cost, cache-coherence behavior, memory
+   bandwidth, SMT, and frequency scaling differ across architectures.
+
+```mermaid
+flowchart TB
+    CLAIM["Measured result on declared host"]
+    JVM["JVM and GC"]
+    HW["CPU, NUMA, cache hierarchy"]
+    LOAD["Producer count and queue depth"]
+    OS["Scheduler and virtualization"]
+    API["Required queue semantics"]
+    GENERAL["Valid conclusion"]
+
+    JVM --> CLAIM
+    HW --> CLAIM
+    LOAD --> CLAIM
+    OS --> CLAIM
+    API --> CLAIM
+    CLAIM --> GENERAL
+    GENERAL --> TEXT["For PerL's MPSC contract, this implementation<br/>showed lower allocation and better measured performance"]
+    GENERAL -. "does not establish" .-> UNIVERSAL["Universal dominance over CLQ"]
+
+    classDef factor fill:#fef3c7,stroke:#a16207,color:#111
+    classDef evidence fill:#dcfce7,stroke:#166534,color:#111
+    classDef warning fill:#fee2e2,stroke:#991b1b,color:#111
+    class JVM,HW,LOAD,OS,API factor
+    class CLAIM,GENERAL,TEXT evidence
+    class UNIVERSAL warning
+```
+
+### 12.3 When CLQ remains the better engineering choice
+
+Use JDK `ConcurrentLinkedQueue` when any of the following is required:
+
+- more than one consumer;
+- a general `Queue<E>` usable by unrelated element types;
+- weakly consistent iteration or spliteration;
+- arbitrary element removal or Collection bulk operations;
+- JDK-maintained implementation and compatibility are more important than
+  PerL-specific allocation savings;
+- the workload has not justified the verification burden of custom lock-free
+  code.
+
+Use neither unbounded linked queue when a hard memory limit or explicit
+backpressure is required.
+
+## 13. Conclusion
+
+JDK 25 `ConcurrentLinkedQueue` is a mature, lock-free, general-purpose MPMC
+collection. Its private wrapper node, item-claim CAS, shared head coordination,
+dead-node traversal, and Collection operations are consequences of that broad
+contract. They are useful when the application needs them.
+
+PerL has a narrower topology: many timestamp producers, exactly one recorder,
+FIFO hand-off, single-use elements, and no iteration or arbitrary removal.
+`TimeStampMpscQueue` converts those restrictions into implementation
+advantages:
+
+- `TimeStampNode` combines payload and link, removing one object and one
+  indirection per measurement;
+- the consumer owns `head`, eliminating an MPMC item-claim CAS and shared head
+  CAS;
+- separately padded head and tail state reduce likely producer-consumer cache
+  interference;
+- the queue retains CLQ's successful final-link CAS, tail-as-hint invariant,
+  self-link recovery concept, and one-node tail slack;
+- batched self-link retirement is adapted to the fact that an intrusive node
+  cannot discard a separate payload reference.
+
+The resulting implementation allocated 40 B/op rather than 56 B/op in the
+declared JDK 25 experiment, measured 30.55% lower round-trip latency, and
+measured 14.35% higher four-producer throughput. End-to-end PerlBench evidence
+was consistent with the microbenchmark and showed lower observed process
+memory. Correctness and reclamation are covered by deterministic tests,
+constrained-heap GC tests, Lincheck, and JCStress.
+
+The defensible conclusion is therefore specific: for SBK PerL's declared MPSC
+timestamp contract, the intrusive specialization removes unnecessary storage
+allocation and coordination and performs better in the reported environment.
+It is not a replacement for CLQ's general MPMC Collection semantics, and its
+performance and correctness evidence must continue to be rerun as the JDK,
+hardware, and queue implementation evolve.
+
+## 14. References
 
 ### Foundational research
 
@@ -710,20 +1622,29 @@ all executions of an unbounded concurrent system.
 5. OpenJDK, [JEP 193: Variable Handles](https://openjdk.org/jeps/193).
 6. Oracle, [`VarHandle`, Java SE 25 API](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/invoke/VarHandle.html).
 7. OpenJDK, [JEP 519: Compact Object Headers](https://openjdk.org/jeps/519).
+8. Oracle, [Java Language Specification, Chapter 17: Threads and
+   Locks](https://docs.oracle.com/javase/specs/jls/se25/html/jls-17.html).
+9. OpenJDK, [Java Object Layout](https://openjdk.org/projects/code-tools/jol/).
 
 ### Evaluation and concurrency testing
 
-8. OpenJDK, [Java Microbenchmark Harness](https://github.com/openjdk/jmh).
-9. OpenJDK, [Java Concurrency Stress tests](https://openjdk.org/projects/code-tools/jcstress/).
-10. JetBrains, [Lincheck](https://github.com/JetBrains/lincheck) and
+10. OpenJDK, [Java Microbenchmark Harness](https://github.com/openjdk/jmh).
+11. OpenJDK, [Java Concurrency Stress tests](https://openjdk.org/projects/code-tools/jcstress/).
+12. JetBrains, [Lincheck](https://github.com/JetBrains/lincheck) and
     [result validation](https://kotlinlang.org/docs/lincheck-results-validation.html).
+13. A. Georges, D. Buytaert, and L. Eeckhout, "Statistically Rigorous
+    Java Performance Evaluation," *Proceedings of OOPSLA*, 2007.
+    [DOI: 10.1145/1297027.1297033](https://doi.org/10.1145/1297027.1297033).
+14. T. Kalibera and R. Jones, "Rigorous Benchmarking in Reasonable
+    Time," *Proceedings of ISMM*, 2013.
+    [DOI: 10.1145/2464157.2464160](https://doi.org/10.1145/2464157.2464160).
 
 ### SBK implementation evidence
 
-11. [`TimeStampNode`](../perl/src/main/java/io/perl/api/TimeStampNode.java).
-12. [`TimeStampMpscQueue`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java).
-13. [`TimeStampQueueBenchmark`](../perl/src/jmh/java/io/perl/benchmark/TimeStampQueueBenchmark.java).
-14. [`TimeStampMpscQueueTest`](../perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java).
-15. [`TimeStampMpscQueueLincheckTest`](../perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java).
-16. [`TimeStampMpscQueuePublicationStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueuePublicationStress.java).
-17. [`TimeStampMpscQueueProducerOrderStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueProducerOrderStress.java).
+15. [`TimeStampNode`](../perl/src/main/java/io/perl/api/TimeStampNode.java).
+16. [`TimeStampMpscQueue`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java).
+17. [`TimeStampQueueBenchmark`](../perl/src/jmh/java/io/perl/benchmark/TimeStampQueueBenchmark.java).
+18. [`TimeStampMpscQueueTest`](../perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java).
+19. [`TimeStampMpscQueueLincheckTest`](../perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java).
+20. [`TimeStampMpscQueuePublicationStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueuePublicationStress.java).
+21. [`TimeStampMpscQueueProducerOrderStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueProducerOrderStress.java).

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -1,0 +1,729 @@
+<!--
+Copyright (c) KMG. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# TimeStampMpscQueue: architecture, correctness, and performance
+
+## Abstract
+
+`TimeStampMpscQueue` is the specialized hand-off queue used by SBK's
+Performance Logger (PerL). Many benchmark workers publish completed-operation
+timestamps, while exactly one recorder consumes them and updates latency
+windows. The queue exploits this multiple-producer, single-consumer (MPSC)
+contract instead of implementing every operation and concurrency pattern
+supported by JDK `ConcurrentLinkedQueue`.
+
+The central optimization is **intrusive representation**. A `TimeStampNode` is
+both the measurement and its linked-queue node. The JDK fallback stores a
+`TimeStamp` inside a second, private `ConcurrentLinkedQueue.Node`. On the JDK
+25 runtime measured in this repository, the complete intrusive round trip
+allocates 40 bytes instead of 56 bytes per measurement.
+
+This document is intended for graduate students, researchers, performance
+engineers, and reviewers of concurrent algorithms. It distinguishes:
+
+- the queue's required contract from properties it does not provide;
+- safety arguments from empirical testing;
+- deterministic allocation differences from environment-sensitive throughput;
+- implementation evidence from general performance claims.
+
+The authoritative implementation is
+[`TimeStampMpscQueue.java`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java).
+
+## 1. Research question and scope
+
+SBK measures storage operations that may complete at millions of operations per
+second. Each completion contributes four values:
+
+```text
+(startTime, endTime, records, bytes)
+```
+
+The measurement transport must preserve every submitted record while adding as
+little latency, allocation, cache coherence, and garbage-collection pressure as
+practical.
+
+The relevant comparison is not "which Java queue is universally better?" The
+research question is narrower:
+
+> Under PerL's MPSC, FIFO, add/poll/clear-only contract, does an intrusive
+> timestamp queue reduce measurement overhead relative to placing a separate
+> `TimeStamp` object in JDK 25 `ConcurrentLinkedQueue`?
+
+JDK `ConcurrentLinkedQueue` is a general-purpose, unbounded, non-blocking FIFO
+collection with multiple consumers, weakly consistent iterators, bulk
+operations, interior-node deletion, serialization, and the complete Java
+Collections `Queue` contract. `TimeStampMpscQueue` deliberately does not
+provide those features.
+
+## 2. Position in the PerL measurement pipeline
+
+```mermaid
+flowchart LR
+    subgraph P["Benchmark workers: multiple producers"]
+        W1["Writer 1"]
+        W2["Reader 2"]
+        WN["Worker N"]
+    end
+
+    subgraph H["PerL hand-off"]
+        PC["PerlChannel"]
+        QA["TimeStampMpscQueueArray"]
+        Q0["Queue 0"]
+        Q1["Queue 1"]
+        QM["Queue M-1"]
+    end
+
+    subgraph C["Exactly one recorder consumer"]
+        DR["Drain queues"]
+        LW["Update latency windows"]
+        RP["Publish interval report"]
+    end
+
+    W1 --> PC
+    W2 --> PC
+    WN --> PC
+    PC --> QA
+    QA --> Q0
+    QA --> Q1
+    QA --> QM
+    Q0 --> DR
+    Q1 --> DR
+    QM --> DR
+    DR --> LW
+    LW --> RP
+
+    classDef producer fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef transport fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef consumer fill:#dcfce7,stroke:#166534,color:#111
+    class W1,W2,WN producer
+    class PC,QA,Q0,Q1,QM transport
+    class DR,LW,RP consumer
+```
+
+`CQueuePerl` creates one `TimeStampMpscQueueChannel` per configured worker by
+default. Each channel contains several queues, and a worker-local index rotates
+submissions across them. One recorder drains all channels. Queue sharding
+distributes producer writes across more head/tail locations; it does not create
+multiple latency-window consumers.
+
+Source trail:
+
+1. [`CQueuePerl`](../perl/src/main/java/io/perl/api/impl/CQueuePerl.java)
+   selects the intrusive or JDK-backed channel.
+2. [`TimeStampMpscQueueArray`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueueArray.java)
+   owns the indexed queues.
+3. [`PerformanceRecorderIdleBusyWait`](../perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleBusyWait.java)
+   is the single queue consumer.
+
+## 3. Data representation: one object versus two
+
+### 3.1 Intrusive PerL representation
+
+```mermaid
+classDiagram
+    class TimeStamp {
+        +long startTime
+        +long endTime
+        +int records
+        +int bytes
+    }
+
+    class TimeStampNode {
+        -TimeStampNode next
+    }
+
+    class TimeStampMpscQueue {
+        -HeadRef headRef
+        -TailRef tailRef
+        +add(TimeStampNode) boolean
+        +poll() TimeStampNode
+        +clear() void
+    }
+
+    TimeStamp <|-- TimeStampNode
+    TimeStampMpscQueue o-- TimeStampNode : links directly
+```
+
+The producer constructs one `TimeStampNode`. Its inherited fields are the
+measurement payload; its `next` field is the queue link. `add` does not create
+a wrapper.
+
+### 3.2 JDK fallback representation
+
+The following diagram is conceptual. `ConcurrentLinkedQueue.Node` is a private
+JDK implementation type and is not part of the public API.
+
+```mermaid
+flowchart LR
+    TS["TimeStamp object<br/>start, end, records, bytes"]
+    JN["JDK private queue node<br/>item reference, next reference"]
+    NX["Next JDK node"]
+
+    JN -->|item| TS
+    JN -->|next| NX
+
+    classDef payload fill:#fef3c7,stroke:#a16207,color:#111
+    classDef node fill:#e0e7ff,stroke:#4338ca,color:#111
+    class TS payload
+    class JN,NX node
+```
+
+```mermaid
+flowchart TB
+    OP["One completed storage operation"]
+    OP --> I["Intrusive path"]
+    OP --> J["JDK fallback path"]
+
+    I --> IN["Allocate TimeStampNode"]
+    IN --> IE["Enqueue the same object"]
+
+    J --> JT["Allocate TimeStamp"]
+    JT --> JN["ConcurrentLinkedQueue allocates private node"]
+    JN --> JE["Enqueue wrapper plus payload"]
+
+    IE --> IA["Measured round-trip allocation<br/>40 B/op"]
+    JE --> JA["Measured round-trip allocation<br/>56 B/op"]
+
+    classDef good fill:#dcfce7,stroke:#166534,color:#111
+    classDef neutral fill:#e5e7eb,stroke:#374151,color:#111
+    class IN,IE,IA good
+    class JT,JN,JE,JA neutral
+```
+
+The 40 and 56 byte values are observations from the controlled JMH run
+documented in Section 10. Object size depends on VM layout, alignment, pointer
+compression, and flags; it is not a Java language constant.
+
+## 4. State and ownership
+
+```mermaid
+flowchart LR
+    subgraph HS["HeadRef: consumer-owned cache region"]
+        H["head"]
+        RH["recoveryHead"]
+        RN["retiredNodes array"]
+        RC["retiredNodeCount"]
+    end
+
+    subgraph TS["TailRef: producer-shared cache region"]
+        T["volatile tail hint"]
+    end
+
+    subgraph CH["Linked node chain"]
+        S["sentinel or consumed head"]
+        A["node A"]
+        B["node B"]
+        N["new node"]
+    end
+
+    H --> S
+    RH --> S
+    T --> B
+    S --> A
+    A --> B
+    B -. "CAS null to new node" .-> N
+    RN -. "up to 16 retired predecessors" .-> S
+
+    classDef consumer fill:#dcfce7,stroke:#166534,color:#111
+    classDef producer fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef chain fill:#dbeafe,stroke:#1d4ed8,color:#111
+    class H,RH,RN,RC consumer
+    class T producer
+    class S,A,B,N chain
+```
+
+The state is split into padded `HeadRef` and `TailRef` holders:
+
+- only the consumer writes `head`, `retiredNodes`, and `retiredNodeCount`;
+- producers share the `tail` hint and node `next` links;
+- `recoveryHead` is release-published by the consumer and acquire-read by a
+  producer that encounters a retired self-link;
+- padding attempts to keep producer and consumer state on different cache
+  lines. It is an implementation hint, not a Java-level cache-line guarantee.
+
+The queue starts with one sentinel. The sentinel simplifies empty/non-empty
+transitions because `head` always identifies a node and the first real element
+is `head.next`.
+
+## 5. Producer algorithm and linearization
+
+### 5.1 Normal enqueue
+
+```mermaid
+sequenceDiagram
+    participant P as Producer
+    participant T as TailRef
+    participant L as Linked nodes
+    participant N as New TimeStampNode
+
+    P->>T: acquire-read tail hint
+    T-->>P: candidate node
+    P->>L: acquire-read candidate.next
+    L-->>P: null
+    P->>L: CAS candidate.next from null to N
+    Note over P,L: Successful CAS is the enqueue linearization point
+    P->>T: weak release-CAS tail hint to N
+    Note over P,T: Tail update is an optimization, not publication correctness
+```
+
+The successful `NEXT.compareAndSet(current, null, newNode)` is the enqueue
+linearization point. Before that CAS, another thread cannot reach the new node
+from the queue. After it succeeds, the node is in the FIFO chain even if the
+best-effort tail update fails.
+
+### 5.2 Contended enqueue
+
+```mermaid
+flowchart TD
+    A["Acquire-read tail hint"] --> B["Acquire-read current.next"]
+    B --> C{"next is null?"}
+    C -->|yes| D{"CAS link succeeds?"}
+    D -->|yes| E["Best-effort release update of tail"]
+    E --> F["Return true"]
+    D -->|no| B
+    C -->|no| G{"next self-links?"}
+    G -->|no| H["Follow next or refresh newer tail"]
+    H --> B
+    G -->|yes| I["Acquire-read recoveryHead"]
+    I --> J["Best-effort move tail hint to recoveryHead"]
+    J --> B
+
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#111
+    classDef progress fill:#dcfce7,stroke:#166534,color:#111
+    class C,D,G decision
+    class E,F,H,I,J progress
+```
+
+If a producer loses the link CAS, some other producer has linked a node and
+therefore the system has made progress. The losing producer follows the chain
+or refreshes the tail hint and retries. This is a lock-free system-progress
+argument; it is not a wait-free per-thread bound. One producer may retry
+indefinitely under adversarial scheduling.
+
+## 6. Consumer algorithm
+
+```mermaid
+sequenceDiagram
+    participant C as Single consumer
+    participant H as HeadRef
+    participant Q as Current head node
+    participant N as Next node
+    participant R as Retired batch
+
+    C->>H: read consumer-owned head
+    H-->>C: Q
+    C->>Q: acquire-read Q.next
+    alt Q.next is null
+        C-->>C: return null
+    else Q.next is N
+        C->>H: plain-write head = N
+        C->>R: store Q in retiredNodes
+        alt batch count reaches 16
+            C->>H: release-publish recoveryHead = N
+            C->>R: release self-link retired predecessors
+            C->>R: clear array references
+        end
+        C-->>C: return N
+    end
+```
+
+Only one consumer may call `poll` or `clear`. Because there is no competing
+consumer, advancing `head` is a plain owner-thread write rather than a head
+CAS. The acquire read of `currentHead.next` observes the fields initialized by
+the producer before publication.
+
+The node returned by `poll` becomes the new head sentinel while also carrying
+the returned timestamp. It must never be enqueued again.
+
+## 7. Batched retirement and stale-producer recovery
+
+Immediate self-linking of every consumed predecessor would add a release store
+to every dequeue. Never unlinking predecessors would allow a producer paused on
+an old node to retain a long consumed chain. The implementation groups
+retirement work in batches of 16.
+
+```mermaid
+flowchart LR
+    subgraph BEFORE["Before retirement"]
+        R0["retired 0"] --> R1["retired 1"]
+        R1 --> RD["... retired 15"]
+        RD --> H["current head"]
+        H --> L["live successor"]
+    end
+
+    subgraph AFTER["After retirement"]
+        S0["retired 0"] --> S0
+        S1["retired 1"] --> S1
+        SD["retired 15"] --> SD
+        RH["recoveryHead"] --> NH["current head"]
+        NH --> NL["live successor"]
+    end
+
+    BEFORE -->|"release-publish recovery head,<br/>then self-link and clear batch"| AFTER
+
+    classDef retired fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef live fill:#dcfce7,stroke:#166534,color:#111
+    class R0,R1,RD,S0,S1,SD retired
+    class H,L,RH,NH,NL live
+```
+
+A producer may be descheduled after reading an old tail or traversal node. If
+the consumer drains and retires that region before the producer resumes, the
+producer reads `next == current`. This self-link is a recovery marker, not a
+queue cycle:
+
+```mermaid
+sequenceDiagram
+    participant P as Paused producer
+    participant C as Consumer
+    participant O as Old node
+    participant H as HeadRef
+
+    P->>O: retain stale traversal pointer
+    Note over P: producer is descheduled
+    C->>H: advance head while draining
+    C->>H: release-publish recoveryHead
+    C->>O: release-write O.next = O
+    Note over P: producer resumes
+    P->>O: acquire-read O.next
+    O-->>P: O, a self-link
+    P->>H: acquire-read recoveryHead
+    H-->>P: live recovery node
+    P->>P: resume traversal from live chain
+```
+
+The ordering of retirement matters: the consumer publishes a live recovery
+head before it creates self-links. A producer that observes a self-link can
+therefore acquire a recovery point that was made available first.
+
+The implementation clears each `retiredNodes` array slot after self-linking.
+This avoids retaining the retired object through the helper array. At most 15
+not-yet-retired predecessors remain in the current partial batch.
+
+## 8. Java Memory Model argument
+
+```mermaid
+flowchart LR
+    I["Producer initializes<br/>timestamp fields"] --> PO["Program order"]
+    PO --> CAS["CAS publishes node<br/>through predecessor.next"]
+    CAS --> HB["Synchronization order<br/>on the next field"]
+    HB --> ACQ["Consumer acquire-reads<br/>predecessor.next"]
+    ACQ --> OBS["Consumer observes initialized<br/>timestamp fields"]
+
+    RHW["Consumer release-writes<br/>recoveryHead"] --> SR["Consumer release-writes<br/>retired.next = retired"]
+    SR --> SA["Producer acquire-reads<br/>the self-link"]
+    SA --> RHR["Producer acquire-reads<br/>recoveryHead"]
+
+    classDef producer fill:#fee2e2,stroke:#991b1b,color:#111
+    classDef consumer fill:#dcfce7,stroke:#166534,color:#111
+    classDef relation fill:#e0e7ff,stroke:#4338ca,color:#111
+    class I,PO,CAS producer
+    class ACQ,OBS,RHW,SR consumer
+    class HB,SA,RHR relation
+```
+
+The queue uses JDK `VarHandle`, not `sun.misc.Unsafe`:
+
+| Shared location | Producer operation | Consumer operation | Purpose |
+|---|---|---|---|
+| `node.next` | acquire read and compare-and-set | acquire read; release self-link on retirement | Publish and consume nodes; mark retired nodes |
+| `tailRef.tail` | acquire read and weak release CAS | none | Traversal hint only |
+| `headRef.recoveryHead` | acquire read after self-link | release write before self-link | Recover stale producers |
+| `headRef.head` | none | plain read/write | Single-consumer ownership |
+
+The argument relies on the JDK 25 `VarHandle` acquire/release and
+compare-and-set semantics cited in the references. Tests can find violations;
+they are not a substitute for a complete mechanized proof.
+
+## 9. Feature comparison with JDK ConcurrentLinkedQueue
+
+| Property | `TimeStampMpscQueue` | JDK 25 `ConcurrentLinkedQueue` |
+|---|---|---|
+| Intended role | PerL timestamp hand-off | General concurrent collection |
+| Element type | Exactly `TimeStampNode` | Any non-null reference type |
+| Producers | Multiple | Multiple |
+| Consumers | Exactly one | Multiple |
+| FIFO | Yes; per-producer order and successful-link order | Yes |
+| Progress | Lock-free enqueue; owner-only dequeue | Non-blocking general queue |
+| Queue allocation during enqueue | None after caller creates intrusive node | Private JDK node per offered element |
+| Measurement objects per operation | One `TimeStampNode` | One `TimeStamp` plus one private node |
+| Consumer head update | Plain owner write | General multi-consumer coordination |
+| Tail | Best-effort traversal hint | Best-effort traversal hint |
+| Stale traversal recovery | Batched self-links plus published recovery head | Self-links and JDK traversal recovery |
+| Retired-node policy | Batch of 16 predecessors | General-purpose head advancement and unlinking |
+| Interior dead-node cleanup | Not needed; removal is unsupported | Supported by traversal/unlink behavior |
+| Iteration | Unsupported | Weakly consistent iterator |
+| `remove(Object)` and bulk operations | Unsupported | Supported |
+| `size()` | Unsupported | Supported but requires traversal |
+| Serialization | Unsupported | Supported |
+| Public interface | PerL's three-method `io.perl.api.Queue` | Java Collections `java.util.Queue` |
+| Portability risk | Custom algorithm must be revalidated on JVM changes | Maintained and tested with the JDK |
+
+The two classes sharing the name `Queue` can be confusing.
+`TimeStampMpscQueue` implements SBK's minimal
+[`io.perl.api.Queue`](../perl/src/main/java/io/perl/api/Queue.java), which
+contains only `add`, `poll`, and `clear`. It does **not** implement
+`java.util.Queue`.
+
+```mermaid
+flowchart TB
+    NEED{"Application requirement"}
+    NEED -->|"PerL timestamps,<br/>many producers,<br/>one consumer"| TM["TimeStampMpscQueue"]
+    NEED -->|"Multiple consumers,<br/>iterators, remove, bulk APIs,<br/>general element types"| CLQ["ConcurrentLinkedQueue"]
+    NEED -->|"Bounded memory or<br/>explicit backpressure"| BQ["Use a bounded queue design;<br/>neither linked queue is bounded"]
+
+    classDef selected fill:#dcfce7,stroke:#166534,color:#111
+    classDef general fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef warning fill:#fef3c7,stroke:#a16207,color:#111
+    class TM selected
+    class CLQ general
+    class BQ warning
+```
+
+## 10. Performance evaluation
+
+### 10.1 Benchmarks
+
+[`TimeStampQueueBenchmark`](../perl/src/jmh/java/io/perl/benchmark/TimeStampQueueBenchmark.java)
+contains two complementary experiments:
+
+1. **Round trip:** one thread allocates a measurement, enqueues it, and polls
+   it. This isolates end-to-end queue latency and normalized allocation.
+2. **Contended MPSC:** four producer threads and one consumer share a queue.
+   The consumer drains up to eight records and briefly parks after an empty
+   poll, matching PerL's non-spinning idle behavior.
+
+The verification task uses three isolated JVM forks, three one-second warm-up
+iterations, five one-second measurement iterations, JMH's GC profiler, and
+99.9% confidence intervals.
+
+### 10.2 Reproducible run on 2026-07-27
+
+Environment:
+
+| Variable | Value |
+|---|---|
+| Host | VMware virtual machine |
+| CPU allocation | 16 vCPUs, Intel Xeon Platinum 8462Y+ |
+| Memory | 61 GiB |
+| OS | Linux 5.15.0-181-generic, x86-64 |
+| JVM | Oracle HotSpot 25.0.2+10-LTS-69 |
+| GC and layout | ZGC, compact object headers enabled |
+| JMH | 1.37 |
+| JVM options | `-XX:+UseZGC -XX:+UseCompactObjectHeaders -XX:MaxRAMPercentage=50.0 -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError` |
+
+Command:
+
+```bash
+./gradlew :perl:timeStampQueuePerformanceTest
+```
+
+Results:
+
+| Metric | `TimeStampMpscQueue` | JDK `ConcurrentLinkedQueue` path | Relative result |
+|---|---:|---:|---:|
+| Round-trip latency | 34.208 ns/op | 47.107 ns/op | 27.38% lower |
+| Round-trip normalized allocation | 40.000 B/op | 56.000 B/op | 28.57% lower |
+| Four-producer producer throughput | 5,406,094 ops/s | 5,557,486 ops/s | 2.72% lower |
+| Producer-throughput 99.9% CI | 5,317,109 to 5,495,078 | 5,248,995 to 5,865,977 | intervals overlap |
+
+```mermaid
+xychart-beta
+    title "Round-trip latency: lower is better"
+    x-axis ["TimeStampMpscQueue", "JDK CLQ path"]
+    y-axis "nanoseconds per operation" 0 --> 60
+    bar [34.208, 47.107]
+```
+
+```mermaid
+xychart-beta
+    title "Normalized allocation: lower is better"
+    x-axis ["TimeStampMpscQueue", "JDK CLQ path"]
+    y-axis "bytes per operation" 0 --> 64
+    bar [40, 56]
+```
+
+```mermaid
+xychart-beta
+    title "Four-producer throughput: higher is better"
+    x-axis ["TimeStampMpscQueue", "JDK CLQ"]
+    y-axis "producer operations per second" 0 --> 6000000
+    bar [5406094, 5557486]
+```
+
+### 10.3 Interpretation
+
+The allocation result directly supports the intrusive-object hypothesis:
+removing the JDK wrapper node saved 16 normalized bytes for each complete
+measurement round trip on this VM configuration.
+
+The latency result favored the intrusive queue in this run. Fewer allocations,
+a narrower API, a single-consumer head, and separated head/tail state are
+plausible contributing mechanisms. The benchmark establishes correlation
+under this setup; it does not isolate the contribution of each mechanism.
+
+The contended producer-throughput result did **not** favor the intrusive queue.
+The JDK path was 2.72% faster by point estimate, but the wide, overlapping
+99.9% confidence intervals do not resolve a statistically clear winner. The
+Gradle verification consequently failed its policy gate requiring the
+intrusive producer metric to exceed the JDK metric by at least 2%.
+
+This outcome is important:
+
+- lower allocation is a stable structural advantage for the compared paths;
+- lower round-trip latency was observed on this host;
+- higher MPSC throughput must not be presented as universal;
+- virtualization, scheduling, NUMA placement, CPU frequency, JIT decisions,
+  GC phase, and producer/consumer balance can change throughput;
+- a successful verification run is evidence for that environment, not proof
+  that one implementation dominates all environments.
+
+### 10.4 Recommended experimental protocol
+
+For publishable comparisons:
+
+1. Pin the JVM and benchmark threads to declared physical cores.
+2. Record SMT, NUMA, frequency governor, turbo state, microcode, kernel, JVM
+   build, GC, heap, and compact-header setting.
+3. Run bare metal when possible; otherwise report hypervisor noise.
+4. Preserve JMH JSON rather than copying only aggregate console values.
+5. Compare normalized allocation (`gc.alloc.rate.norm`), not only MB/s.
+   A faster implementation can allocate more MB/s while allocating fewer bytes
+   per operation.
+6. Repeat across producer counts such as 1, 2, 4, 8, and 16 with one consumer.
+7. Add queue-depth distributions and consumer service-time distributions.
+8. Report confidence intervals and effect sizes; do not rank overlapping
+   estimates without an explicit statistical model.
+9. Run end-to-end SBK workloads in addition to microbenchmarks. A nanosecond
+   queue result may be immaterial for a millisecond storage operation.
+10. Retain correctness gates independently of performance outcomes.
+
+## 11. Correctness and reclamation evidence
+
+```mermaid
+flowchart LR
+    U["JUnit deterministic tests"] --> E["Evidence set"]
+    G["32 MiB GC soak<br/>20 million records"] --> E
+    L["Lincheck histories<br/>against sequential FIFO"] --> E
+    J["JCStress memory-order outcomes"] --> E
+    M["JMH latency, allocation,<br/>throughput, retention"] --> E
+
+    E --> S["Safety confidence"]
+    E --> R["Reclamation confidence"]
+    E --> P["Environment-specific performance"]
+    E -. "does not constitute" .-> F["Formal mechanized proof"]
+
+    classDef test fill:#dbeafe,stroke:#1d4ed8,color:#111
+    classDef evidence fill:#dcfce7,stroke:#166534,color:#111
+    classDef limit fill:#fee2e2,stroke:#991b1b,color:#111
+    class U,G,L,J,M test
+    class E,S,R,P evidence
+    class F limit
+```
+
+| Property under test | Evidence |
+|---|---|
+| FIFO and element identity | `TimeStampMpscQueueTest` |
+| Multiple producer delivery | `TimeStampMpscQueueTest` |
+| Per-producer ordering | Unit, Lincheck, and JCStress tests |
+| Publication visibility | `TimeStampMpscQueuePublicationStress` |
+| Two-producer ordering outcomes | `TimeStampMpscQueueProducerOrderStress` |
+| Linearizable MPSC histories | `TimeStampMpscQueueLincheckTest` |
+| Stale producer recovery | Deterministic paused-producer unit tests |
+| Bounded partial retired batch | Reclamation tests and constrained-heap soak |
+| Prompt release of consumed nodes | Weak-reference and constrained-heap tests |
+| Relative latency and allocation | JMH `timeStampQueuePerformanceTest` |
+
+Commands:
+
+```bash
+./gradlew :perl:test
+./gradlew :perl:timeStampMpscQueueGcTest
+./gradlew :perl:lincheckTest
+./gradlew :perl:jcstress
+./gradlew :perl:concurrencyCheck
+./gradlew :perl:timeStampQueuePerformanceTest
+```
+
+Lincheck and JCStress are complementary. Lincheck searches operation histories
+for violations of a sequential FIFO model. JCStress samples Java Memory Model
+outcomes and can expose publication or reordering errors. Neither can enumerate
+all executions of an unbounded concurrent system.
+
+## 12. Limitations and threats to validity
+
+1. **Single-consumer requirement.** A second consumer creates a data race on
+   `head` and invalidates the design.
+2. **Single-use nodes.** Re-enqueueing a consumed node can create cycles or ABA
+   hazards and is forbidden.
+3. **Unbounded capacity.** If producers permanently exceed recorder capacity,
+   memory grows. Queue sharding is not backpressure.
+4. **No general collection semantics.** Iteration, arbitrary removal, multiple
+   consumers, and bulk operations require a different queue.
+5. **Lock-free is not wait-free.** Overall enqueue progress does not guarantee
+   bounded completion time for every producer.
+6. **One allocation remains.** Intrusion removes the wrapper, not the timestamp
+   object. Object pooling was rejected because it retains memory, complicates
+   ownership, and introduces reuse/ABA risks.
+7. **Consumer bottleneck.** PerL's one recorder owns the latency windows and
+   ultimately limits drain capacity.
+8. **Padding is heuristic.** Java does not promise that the declared padding
+   maps to exact hardware cache-line boundaries.
+9. **Microbenchmark scope.** JMH measures the queue paths, not storage-system
+   latency or complete SBK scalability.
+10. **JDK evolution.** Object layout, JIT compilation, garbage collectors, and
+    `ConcurrentLinkedQueue` implementation details may change. Re-run the full
+    evidence suite for each supported JDK.
+
+## 13. References
+
+### Foundational research
+
+1. M. M. Michael and M. L. Scott, "Simple, Fast, and Practical
+   Non-Blocking and Blocking Concurrent Queue Algorithms," *Proceedings of the
+   15th ACM Symposium on Principles of Distributed Computing*, pp. 267-275,
+   1996. [DOI: 10.1145/248052.248106](https://doi.org/10.1145/248052.248106);
+   [author-hosted PDF](https://www.cs.rochester.edu/u/scott/papers/1996_PODC_queues.pdf).
+2. M. P. Herlihy and J. M. Wing, "Linearizability: A Correctness Condition
+   for Concurrent Objects," *ACM Transactions on Programming Languages and
+   Systems*, vol. 12, no. 3, pp. 463-492, 1990.
+   [DOI: 10.1145/78969.78972](https://doi.org/10.1145/78969.78972);
+   [author-hosted PDF](https://www.cs.cmu.edu/~wing/publications/HerlihyWing90.pdf).
+
+### Java platform and implementation
+
+3. Oracle, [`ConcurrentLinkedQueue`, Java SE 25 API](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/concurrent/ConcurrentLinkedQueue.html).
+4. OpenJDK, [`ConcurrentLinkedQueue.java`, JDK 25 GA source](https://github.com/openjdk/jdk/blob/jdk-25-ga/src/java.base/share/classes/java/util/concurrent/ConcurrentLinkedQueue.java).
+5. OpenJDK, [JEP 193: Variable Handles](https://openjdk.org/jeps/193).
+6. Oracle, [`VarHandle`, Java SE 25 API](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/invoke/VarHandle.html).
+7. OpenJDK, [JEP 519: Compact Object Headers](https://openjdk.org/jeps/519).
+
+### Evaluation and concurrency testing
+
+8. OpenJDK, [Java Microbenchmark Harness](https://github.com/openjdk/jmh).
+9. OpenJDK, [Java Concurrency Stress tests](https://openjdk.org/projects/code-tools/jcstress/).
+10. JetBrains, [Lincheck](https://github.com/JetBrains/lincheck) and
+    [result validation](https://kotlinlang.org/docs/lincheck-results-validation.html).
+
+### SBK implementation evidence
+
+11. [`TimeStampNode`](../perl/src/main/java/io/perl/api/TimeStampNode.java).
+12. [`TimeStampMpscQueue`](../perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java).
+13. [`TimeStampQueueBenchmark`](../perl/src/jmh/java/io/perl/benchmark/TimeStampQueueBenchmark.java).
+14. [`TimeStampMpscQueueTest`](../perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java).
+15. [`TimeStampMpscQueueLincheckTest`](../perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java).
+16. [`TimeStampMpscQueuePublicationStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueuePublicationStress.java).
+17. [`TimeStampMpscQueueProducerOrderStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueProducerOrderStress.java).

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -1511,6 +1511,12 @@ The queue JMH benchmark isolates add/poll latency and allocation. The
 question: how do the queue paths affect the complete SBK worker, clock,
 timestamp publication, recorder, latency-window, and reporting pipeline?
 
+The [`Null` driver](../drivers/null/README.md) is not a substitute for this
+experiment. Its default write deliberately remains incomplete, so it exercises
+idle reporting, timeout, interruption, and shutdown without publishing a
+completed timestamp. PerlBench deliberately does the opposite: every
+operation completes immediately and enters the selected timestamp queue.
+
 ```mermaid
 flowchart LR
     PB["PerlBench no-op operation"]

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -1151,7 +1151,7 @@ The following symbols are used:
 | `m` | Number of elements in an input collection |
 | `k` | Number of stale, retired, or logically deleted nodes skipped before reaching the desired node; `0 <= k <= n` in a quiescent finite queue |
 | `b` | Number of elements copied by one spliterator batch |
-| `B` | `TimeStampMpscQueue` retirement batch size; currently the fixed constant 16 |
+| `B` | `TimeStampMpscQueue` retirement batch size; 16 in production and injectable only through a package-private constructor for concurrency-model tests |
 | `C(m)` | Cost of one `contains` call on an input collection of size `m` |
 
 Three different bounds must not be confused:
@@ -1430,6 +1430,14 @@ The contended producer-throughput result favored the intrusive queue by
 interval, and the Gradle verification passed its policy gate requiring the
 intrusive producer metric to exceed the JDK metric by at least 2%.
 
+That interval separation belongs to the recorded run, not to every rerun.
+Producer-throughput confidence intervals can overlap on a noisy or
+oversubscribed host even when the point-estimate gate passes. A publication
+claim about throughput should therefore use multiple forks, an otherwise idle
+machine, fixed CPU-frequency policy, and producer/consumer affinity to
+dedicated physical cores. The latency and allocation results are the more
+repeatable evidence; the allocation reduction is structural.
+
 The improvement came from adopting CLQ's tail-slack strategy. The earlier
 implementation attempted to update the producer-shared tail after every
 successful link. The optimized implementation skips that update when the
@@ -1595,8 +1603,9 @@ flowchart LR
 | Per-producer ordering | Unit, Lincheck, and JCStress tests |
 | Publication visibility | `TimeStampMpscQueuePublicationStress` |
 | Two-producer ordering outcomes | `TimeStampMpscQueueProducerOrderStress` |
-| Linearizable MPSC histories | `TimeStampMpscQueueLincheckTest` |
-| Stale producer recovery | Deterministic paused-producer unit tests |
+| Linearizable MPSC histories, including batch retirement | `TimeStampMpscQueueLincheckTest` with test batch size 2 |
+| Stale producer recovery | Deterministic paused-producer tests and `TimeStampMpscQueueRetirementRecoveryStress` |
+| Recovery-head acquire/release ordering | `TimeStampMpscQueueRecoveryHeadStress` with test batch size 1 |
 | Bounded partial retired batch | Reclamation tests and constrained-heap soak |
 | Prompt release of consumed nodes | Weak-reference and constrained-heap tests |
 | Relative latency and allocation | JMH `timeStampQueuePerformanceTest` |
@@ -1616,6 +1625,15 @@ Lincheck and JCStress are complementary. Lincheck searches operation histories
 for violations of a sequential FIFO model. JCStress samples Java Memory Model
 outcomes and can expose publication or reordering errors. Neither can enumerate
 all executions of an unbounded concurrent system [11, 12].
+
+Production retires predecessors in batches of 16. Short Lincheck histories and
+the basic publication tests cannot naturally cross that boundary, so the queue
+has a package-private constructor for test injection. Lincheck uses a batch of
+2 to repeatedly model-check self-link retirement. JCStress separately forces a
+producer to retain a pointer across a two-node retired batch, and uses a batch
+of 1 in a focused test to force the fallback acquire-read of the
+release-published recovery head. The public constructor and production path
+remain fixed at 16.
 
 ## 12. Limitations and threats to validity
 
@@ -1799,3 +1817,5 @@ hardware, and queue implementation evolve.
 19. [`TimeStampMpscQueueLincheckTest`](../perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java).
 20. [`TimeStampMpscQueuePublicationStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueuePublicationStress.java).
 21. [`TimeStampMpscQueueProducerOrderStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueProducerOrderStress.java).
+22. [`TimeStampMpscQueueRetirementRecoveryStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRetirementRecoveryStress.java).
+23. [`TimeStampMpscQueueRecoveryHeadStress`](../perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRecoveryHeadStress.java).

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -41,8 +41,8 @@ both the measurement and its linked-queue node. The JDK fallback stores a
 25 runtime measured in this repository, the complete intrusive round trip
 allocates 40 bytes instead of 56 bytes per measurement.
 
-On the declared 16-vCPU JDK 25 host, the intrusive queue measured 30.55% lower
-round-trip latency and 14.35% higher four-producer enqueue throughput than the
+On the declared 16-vCPU JDK 25 host, the intrusive queue measured 30.36% lower
+round-trip latency and 6.74% higher four-producer enqueue throughput than the
 CLQ path. End-to-end PerlBench runs also showed higher saturation throughput
 and lower peak resident memory. These are environment-specific observations,
 not claims of universal superiority; the structural removal of one wrapper
@@ -1385,17 +1385,17 @@ Results:
 
 | Metric | `TimeStampMpscQueue` | JDK `ConcurrentLinkedQueue` path | Relative result |
 |---|---:|---:|---:|
-| Round-trip latency | 33.107 ns/op | 47.673 ns/op | 30.55% lower |
+| Round-trip latency | 32.732 ns/op | 47.000 ns/op | 30.36% lower |
 | Round-trip normalized allocation | 40.000 B/op | 56.000 B/op | 28.57% lower |
-| Four-producer producer throughput | 5,904,509 ops/s | 5,163,359 ops/s | 14.35% higher |
-| Producer-throughput 99.9% CI | 5,819,992 to 5,989,025 | 5,047,306 to 5,279,412 | intervals do not overlap |
+| Four-producer producer throughput | 5,853,294 ops/s | 5,483,912 ops/s | 6.74% higher |
+| Producer-throughput 99.9% CI | 5,763,602 to 5,942,986 | 5,025,833 to 5,941,990 | intervals overlap |
 
 ```mermaid
 xychart-beta
     title "Round-trip latency: lower is better"
     x-axis ["TimeStampMpscQueue", "JDK CLQ path"]
     y-axis "nanoseconds per operation" 0 --> 60
-    bar [33.107, 47.673]
+    bar [32.732, 47.000]
 ```
 
 ```mermaid
@@ -1411,7 +1411,7 @@ xychart-beta
     title "Four-producer throughput: higher is better"
     x-axis ["TimeStampMpscQueue", "JDK CLQ"]
     y-axis "producer operations per second" 0 --> 6000000
-    bar [5904509, 5163359]
+    bar [5853294, 5483912]
 ```
 
 ### 10.3 Interpretation
@@ -1425,10 +1425,11 @@ a narrower API, a single-consumer head, and separated head/tail state are
 plausible contributing mechanisms. The benchmark establishes correlation
 under this setup; it does not isolate the contribution of each mechanism.
 
-The contended producer-throughput result favored the intrusive queue by
-14.35%. Its 99.9% confidence interval was entirely above the JDK path's
-interval, and the Gradle verification passed its policy gate requiring the
-intrusive producer metric to exceed the JDK metric by at least 2%.
+The contended producer-throughput point estimate favored the intrusive queue
+by 6.74%, and the Gradle verification passed its policy gate requiring the
+intrusive producer metric to exceed the JDK metric by at least 2%. The 99.9%
+confidence intervals overlapped, so this run does not establish interval-level
+separation for producer throughput.
 
 That interval separation belongs to the recorded run, not to every rerun.
 Producer-throughput confidence intervals can overlap on a noisy or
@@ -1756,8 +1757,8 @@ advantages:
   cannot discard a separate payload reference.
 
 The resulting implementation allocated 40 B/op rather than 56 B/op in the
-declared JDK 25 experiment, measured 30.55% lower round-trip latency, and
-measured 14.35% higher four-producer throughput. End-to-end PerlBench evidence
+declared JDK 25 experiment, measured 30.36% lower round-trip latency, and
+measured 6.74% higher four-producer throughput. End-to-end PerlBench evidence
 was consistent with the microbenchmark and showed lower observed process
 memory. Correctness and reclamation are covered by deterministic tests,
 constrained-heap GC tests, Lincheck, and JCStress.

--- a/docs/TIMESTAMP_MPSC_QUEUE.md
+++ b/docs/TIMESTAMP_MPSC_QUEUE.md
@@ -1141,17 +1141,162 @@ flowchart TB
 
 ### 9.3 Complexity and contention model
 
+#### 9.3.1 How to read the complexity claims
+
+The following symbols are used:
+
+| Symbol | Meaning |
+|---|---|
+| `n` | Number of nodes reachable during the operation |
+| `m` | Number of elements in an input collection |
+| `k` | Number of stale, retired, or logically deleted nodes skipped before reaching the desired node; `0 <= k <= n` in a quiescent finite queue |
+| `b` | Number of elements copied by one spliterator batch |
+| `B` | `TimeStampMpscQueue` retirement batch size; currently the fixed constant 16 |
+| `C(m)` | Cost of one `contains` call on an input collection of size `m` |
+
+Three different bounds must not be confused:
+
+1. **Fast path** describes an operation whose starting hint is current and whose
+   compare-and-set is not defeated by another thread.
+2. **Quiescent worst case** assumes that concurrent modifications stop, so a
+   call eventually traverses a finite chain.
+3. **Concurrent worst case** includes adversarial scheduling and continued
+   interference.
+
+Both queues are **lock-free**, not wait-free. System-wide progress is
+guaranteed, but a particular producer can repeatedly lose compare-and-set
+races. Consequently, neither implementation has a finite per-thread
+worst-case completion bound while other threads continue to modify the queue.
+Writing only "enqueue is O(1)" would hide this important property.
+The JDK entries below follow the Java SE 25 API contract and the JDK 25 GA
+implementation in references 3 and 4; they are not inferred only from the
+Michael-Scott paper.
+
+```mermaid
+flowchart LR
+    CALL["Queue operation"]
+    FAST{"Current pointer<br/>and no lost CAS?"}
+    DONE["Constant fast path<br/>O(1)"]
+    WALK["Follow stale or<br/>deleted links"]
+    QUIET{"Concurrent changes<br/>eventually stop?"}
+    FINITE["Finite traversal<br/>up to O(n)"]
+    RETRY["Retry may continue<br/>no per-thread bound"]
+
+    CALL --> FAST
+    FAST -->|"yes"| DONE
+    FAST -->|"no"| WALK
+    WALK --> QUIET
+    QUIET -->|"yes"| FINITE
+    QUIET -->|"no"| RETRY
+
+    classDef good fill:#dcfce7,stroke:#166534,color:#111
+    classDef work fill:#fef3c7,stroke:#a16207,color:#111
+    classDef warning fill:#fee2e2,stroke:#991b1b,color:#111
+    class DONE good
+    class WALK,FINITE work
+    class RETRY warning
+```
+
+#### 9.3.2 Core operation complexity
+
+These are the operations relevant to PerL. "Unsupported" means the operation
+is intentionally absent from SBK's minimal
+[`io.perl.api.Queue`](../perl/src/main/java/io/perl/api/Queue.java), not that it
+has an expensive hidden implementation.
+
+| Operation | `TimeStampMpscQueue` | JDK 25 `ConcurrentLinkedQueue` | Explanation |
+|---|---:|---:|---|
+| Construct an empty queue | Time O(1), space O(1) | Time O(1), space O(1) | Each creates a sentinel. The SBK queue also creates one fixed `B`-entry retirement array. |
+| `add(node)` / `offer(element)` fast path | O(1) | O(1) | Allocate or receive a node, read the tail hint, read `next`, and CAS the null terminal link. |
+| Enqueue, amortized | O(1) | O(1) | Tail slack avoids a shared tail CAS on every insertion. Successful terminal-link CAS is the linearization point. |
+| Enqueue after a stale hint, quiescent | O(n) worst case | O(n) worst case | A producer may have to walk from a stale tail or recovery point to the terminal node. |
+| Enqueue under continuing contention | No finite per-thread bound | No finite per-thread bound | A failed CAS proves that some producer progressed, but the same producer may repeatedly lose. |
+| Successful `poll()` fast path | O(1) | O(1) when the head points at a live item | SBK performs one acquire link read and advances its consumer-owned head. CLQ must CAS the live node's `item` to null. |
+| Successful `poll()`, quiescent worst case | O(1), because only the single consumer retires the head | O(k + 1), therefore O(n) worst case | CLQ can skip a prefix of logically deleted nodes. SBK cannot have competing consumers create such a prefix. |
+| Every `B`th SBK `poll()` | O(B), therefore O(1) for fixed `B = 16` | Not applicable | SBK release-publishes a recovery point and self-links up to 16 retired predecessors. Spread over 16 polls, retirement remains amortized O(1). |
+| Empty `poll()` | O(1) | O(k + 1), therefore O(n) worst case | SBK reads `head.next` once. CLQ may scan and help unlink deleted nodes before proving emptiness. |
+| `peek()` | Unsupported | O(k + 1), therefore O(n) worst case | CLQ finds the first live item and may update `head`; PerL never requires a non-removing read. |
+| `element()` | Unsupported | Same as `peek()`, plus an O(1) empty-queue exception path | `AbstractQueue.element()` delegates to `peek()`. |
+| No-argument `remove()` | Unsupported | Same as `poll()`, plus an O(1) empty-queue exception path | `AbstractQueue.remove()` delegates to `poll()`. |
+| `isEmpty()` | Unsupported | O(k + 1), therefore O(n) worst case | CLQ calls its `first()` traversal. PerL detects emptiness through `poll() == null`. |
+| `clear()` | O(n) time, O(1) auxiliary space | O(n) time, O(1) auxiliary space | SBK drains through `poll()` and retires the final partial batch. CLQ traverses nodes, nulls live items, and periodically collapses dead chains. |
+| Queue-capacity check | Not applicable | Not applicable | Both queues are unbounded and therefore provide neither an O(1) full check nor backpressure. |
+
+`TimeStampMpscQueue.poll()` has a stronger constant-time bound only because its
+contract allows exactly one consumer and FIFO head removal only. Calling it
+from multiple consumers violates the contract and invalidates both the
+correctness and complexity claims.
+
+#### 9.3.3 JDK Collection operations
+
+JDK CLQ provides general-purpose traversal, search, bulk mutation, arrays,
+iterators, and spliterators. `TimeStampMpscQueue` intentionally provides none
+of these operations, so they add no code, branches, or coordination to PerL's
+hot path.
+
+| JDK CLQ operation | Time complexity | Auxiliary space | Notes |
+|---|---:|---:|---|
+| `size()` | O(n) | O(1) | Traverses the queue and counts live items. The result is observational and may be inaccurate during concurrent modification. |
+| `contains(object)` | O(n) | O(1) | Linear search; may also help unlink dead-node runs. |
+| `remove(object)` | O(n) | O(1) | Linear search followed by an item CAS and optional dead-node collapse. |
+| `addAll(collection)` | O(m) expected; O(m + n) quiescent worst case after a stale tail | O(m) | Builds `m` private wrapper nodes, then atomically splices the chain at the terminal link. Continued interference gives no finite per-thread bound. |
+| `containsAll(collection)` | O(mn) worst case | O(1) | The inherited implementation performs up to `m` linear `contains` searches. |
+| `removeIf(predicate)` | O(n) plus predicate cost | O(1) | Visits each reachable node and may logically delete matching items. |
+| `removeAll(collection)` | O(n * C(m)) | O(1) | O(nm) with a linear-search collection such as `ArrayList`; expected O(n) when membership is expected O(1), such as a well-sized `HashSet`. |
+| `retainAll(collection)` | O(n * C(m)) | O(1) | Has the same dependency on the input collection's membership complexity as `removeAll`. |
+| `iterator()` construction | O(k + 1), O(n) worst case | O(1) | Finds the first live node and may advance `head`. |
+| Iterator `hasNext()` | O(1) | O(1) | Reads the iterator's cached next item. |
+| Iterator `next()` | O(k + 1), O(n) worst case | O(1) | May skip and help unlink deleted nodes. A complete iteration is O(n) when concurrent restarts are excluded. |
+| Iterator `remove()` | O(1) | O(1) | Logically deletes the last returned item; later traversal performs structural cleanup. |
+| `toArray()` / `toArray(T[])` | O(n) | O(n) if a new/growing array is needed | Concurrent self-link detection can restart traversal. |
+| `toString()` | O(n + characters) | O(n + characters) | Traverses live items and materializes strings/output storage. |
+| `spliterator()` construction | O(1) | O(1) | Traversal is deferred. |
+| Spliterator `tryAdvance()` | O(k + 1), O(n) worst case | O(1) | Skips deleted nodes before yielding one element. |
+| Spliterator `trySplit()` | O(b + k) | O(b) | Copies a bounded batch into a temporary array. |
+| Spliterator `forEachRemaining()` | O(n) plus action cost | O(1) | Weakly consistent traversal. |
+| Serialization | O(n) plus element serialization | Serialization-dependent | Writes every live element in FIFO order. |
+
+For traversal methods, O(n) is the useful quiescent bound. Under concurrent
+self-link detection, a traversal may restart; as with enqueue, sustained
+interference removes a finite per-invocation upper bound.
+
+#### 9.3.4 Allocation and retained-space complexity
+
+| Storage property | `TimeStampMpscQueue` | JDK CLQ used with `TimeStamp` |
+|---|---:|---:|
+| Queue metadata | O(1) | O(1) |
+| Storage for `n` pending measurements | O(n) `TimeStampNode` objects | O(n) `TimeStamp` objects plus O(n) private CLQ wrapper nodes |
+| Per-enqueue queue allocation | **Zero** additional objects and bytes | One O(1)-size CLQ wrapper node |
+| Per-poll auxiliary allocation | **Zero** | **Zero** |
+| Retirement bookkeeping | O(B) references, which is O(1) because `B = 16` | No fixed retirement array; dead wrappers are collapsed during traversal |
+| `clear()` auxiliary storage | O(1) | O(1) |
+
+Both representations therefore have O(n) asymptotic live storage. Big-O alone
+does not expose the practical difference: CLQ needs approximately twice as
+many measurement-related objects in this use case because the timestamp and
+the structural node are separate. The intrusive queue stores the timestamp
+payload and `next` link in one `TimeStampNode`.
+
+The table describes queue-owned reachable storage. Transiently retired nodes
+can add more references. SBK bounds its consumer retirement batch by `B` plus
+the current head; CLQ can retain logically deleted wrappers until a traversal
+advances the head or collapses the dead chain. In either implementation, a
+suspended thread's local variable can independently keep an otherwise retired
+node reachable until that thread resumes or terminates.
+
+#### 9.3.5 Summary for the PerL workload
+
 | Operation/property | JDK CLQ | `TimeStampMpscQueue` |
 |---|---|---|
 | Successful enqueue | Amortized O(1), lock-free | Amortized O(1), lock-free |
-| Successful dequeue | Amortized O(1), lock-free MPMC | O(1) owner-only, plus amortized retirement |
-| Empty poll | Traverses/updates head as required | One acquire read of `head.next` |
-| Enqueue allocation | O(1) wrapper allocation | zero queue allocation |
+| Successful dequeue | Fast-path/amortized O(1), O(n) quiescent worst case, lock-free MPMC | O(1) owner-only, including amortized retirement |
+| Empty poll | O(k + 1), O(n) worst case | O(1): one acquire read of `head.next` |
+| Enqueue allocation | O(1) time and one wrapper object | O(1) time and zero queue allocation |
 | `size` | O(n), observational | unsupported |
-| Worst-case individual retry | Unbounded | unbounded |
+| Worst-case individual retry under interference | Unbounded | unbounded |
 | Capacity | Unbounded | unbounded |
-| Primary producer contention | final-node `next`, tail hint | final-node `next`, padded tail hint |
-| Primary consumer contention | `item` and head with other consumers/helpers | none with another consumer by contract |
+| Primary producer contention | Terminal `next`, tail hint | Terminal `next`, padded tail hint |
+| Primary consumer contention | `item` and head with other consumers/helpers | None with another consumer by contract |
 
 The two classes sharing the name `Queue` can be confusing.
 `TimeStampMpscQueue` implements SBK's minimal

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -448,9 +448,9 @@ bytes)` on its hot path — that's the *only* thing it has to do.
 
 The two channel implementations remain independent.
 `TimeStampMpscQueueChannel` extends `TimeStampMpscQueueArray`; every element is
-a `TimeStampNode`, derived from `TimeStamp`, with its queue link in the same
-object. The original `CQueueChannel` continues to extend
-`ConcurrentLinkedQueueArray<TimeStamp>` unchanged. `MpscQueueEnable` supplies
+a single-use `TimeStampNode`, the only permitted subclass of `TimeStamp`, with
+its queue link in the same object. The original `CQueueChannel` continues to
+extend `ConcurrentLinkedQueueArray<TimeStamp>` unchanged. `MpscQueueEnable` supplies
 the property default, and SBK's common `-mpscqueue true|false` option overrides
 that selection before either writer or reader PerL instance is built. Both
 provide **non-blocking queue operations** without an application mutex or
@@ -470,6 +470,67 @@ The fallback allocates a `TimeStamp`, and `ConcurrentLinkedQueue` allocates
 its internal node. The intrusive path therefore removes one young-generation
 object per operation while keeping percentile calculation, sorting, and
 logger I/O out of the storage-operation call path.
+
+`TimeStampMpscQueue` is specialized for the topology PerL actually has:
+**many worker producers and exactly one recorder consumer**. That restriction
+is what permits the recorder to own `head` without a consumer CAS and permits
+the timestamp itself to be the linked node. It is not a general replacement
+for `ConcurrentLinkedQueue`: use the JDK queue when multiple consumers,
+iterators, arbitrary element types, removal, or collection APIs are required.
+
+```mermaid
+flowchart TD
+    NEED["Queue requirement"] --> TYPE{"PerL timestamp hand-off?"}
+    TYPE -->|"yes"| CARD{"Many producers and<br/>exactly one consumer?"}
+    CARD -->|"yes"| MPSC["TimeStampMpscQueue<br/>intrusive, one object<br/>default: -mpscqueue true"]
+    CARD -->|"no"| JDK["JDK ConcurrentLinkedQueue<br/>general MPMC collection"]
+    TYPE -->|"no"| JDK
+    MPSC --> RULES["Single-use TimeStampNode<br/>unbounded queue<br/>no iterator/remove API"]
+    JDK --> FEATURES["Arbitrary element type<br/>multiple consumers<br/>collection operations"]
+
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#000
+    classDef optimized fill:#dcfce7,stroke:#166534,color:#000
+    classDef general fill:#dbeafe,stroke:#1e40af,color:#000
+    class TYPE,CARD decision
+    class MPSC,RULES optimized
+    class JDK,FEATURES general
+```
+
+The current queue algorithm has four important steps:
+
+```mermaid
+flowchart LR
+    P["Producer creates<br/>one TimeStampNode"] --> L["CAS predecessor.next<br/>linearization point"]
+    L --> A["Consumer acquire-reads next<br/>and advances owned head"]
+    A --> B{"16 predecessors<br/>retired?"}
+    B -->|"no"| HOLD["Keep bounded partial batch"]
+    B -->|"yes"| PUB["Release-publish<br/>recovery head"]
+    PUB --> SELF["Self-link retired nodes<br/>clear batch references"]
+    SELF --> GC["Consumed payloads become<br/>eligible for reclamation"]
+    STALE["Paused producer sees<br/>a self-linked node"] --> REC["Acquire recovery head<br/>resume traversal"]
+    REC --> L
+
+    classDef producer fill:#e0e7ff,stroke:#4338ca,color:#000
+    classDef consumer fill:#dcfce7,stroke:#166534,color:#000
+    classDef recovery fill:#f3e8ff,stroke:#7e22ce,color:#000
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#000
+    class P,L producer
+    class A,HOLD,PUB,SELF,GC consumer
+    class STALE,REC recovery
+    class B decision
+```
+
+The successful `predecessor.next` CAS publishes the immutable timestamp fields
+to the consumer. The consumer's acquire read observes that publication.
+Retirement is batched at 16 in production to group reclamation stores.
+Before self-linking a batch, the consumer release-publishes a live recovery
+head. A producer paused on an old predecessor can therefore detect the
+self-link and restart without retaining or traversing an unbounded consumed
+chain. Nodes are not pooled: pooling would retain heap, complicate ownership,
+and introduce reuse/ABA hazards. Producer and consumer state are held in
+separate manually padded objects as a best-effort false-sharing reduction;
+Java does not guarantee cache-line placement, and the padding is not part of
+the correctness argument.
 
 For a research-oriented treatment of the queue algorithm, including its
 linearization points, Java Memory Model edges, stale-producer recovery,
@@ -544,6 +605,7 @@ while (doWork) {
         t = channels[i].receive(windowIntervalMS);
         if (t != null) {
             notFound = false;
+            dataSinceIdle = true;
             ctime = t.endTime;
             if (t.isEnd()) { doWork = false; }
             else {
@@ -551,14 +613,20 @@ while (doWork) {
                 periodicRecorder.record(t.startTime, t.endTime, t.records, t.bytes);
                 ...
             }
-            if (periodicRecorder.elapsedMilliSecondsWindow(ctime) > windowIntervalMS) {
+            if (periodicRecorder.elapsedMilliSecondsWindow(ctime) >= windowIntervalMS) {
                 periodicRecorder.stopWindow(ctime);  // emit periodic report
                 periodicRecorder.startWindow(ctime);
                 idleWait.reset();
+                dataSinceIdle = false;
             }
         }
     }
     if (doWork && notFound) {
+        if (dataSinceIdle) {
+            idleWait.startIdle(
+                    periodicRecorder.elapsedMilliSecondsWindow(ctime));
+            dataSinceIdle = false;
+        }
         if (idleWait.waitAndCheck()) { /* elastic back-off */ }
     }
 }
@@ -586,9 +654,13 @@ flowchart TD
     END -->|no| RECORD["Compute elapsed latency<br/>update periodic window"]
     RECORD --> ROTATE{"Window interval passed?"}
     ROTATE -->|yes| REPORT["Print/copy periodic window<br/>reset periodic window"]
-    ROTATE -->|no| SCAN
+    ROTATE -->|no| ACTIVE["Mark data consumed<br/>reuse record endTime"]
+    ACTIVE --> SCAN
     REPORT --> SCAN
-    FOUND -->|no| IDLE["ElasticWait park + count<br/>or configured sleep"]
+    FOUND -->|no| TRANS{"Data consumed since<br/>previous idle period?"}
+    TRANS -->|yes| RESETIDLE["ElasticWait.startIdle<br/>reset sample, retain EMA"]
+    TRANS -->|no| IDLE["ElasticWait park + count<br/>or configured sleep"]
+    RESETIDLE --> IDLE
     IDLE --> CHECK{"Time-check batch reached?"}
     CHECK -->|no| SCAN
     CHECK -->|yes| CLOCK["Query clock once<br/>rotate if due"]
@@ -597,9 +669,9 @@ flowchart TD
     classDef decision fill:#fef3c7,stroke:#a16207,color:#000
     classDef work fill:#dcfce7,stroke:#166534,color:#000
     classDef idle fill:#dbeafe,stroke:#1e40af,color:#000
-    class FOUND,END,ROTATE,CHECK decision
-    class START,SCAN,RECORD,REPORT,FINAL work
-    class IDLE,CLOCK idle
+    class FOUND,END,ROTATE,TRANS,CHECK decision
+    class START,SCAN,RECORD,REPORT,FINAL,ACTIVE work
+    class RESETIDLE,IDLE,CLOCK idle
 ```
 
 This diagram explains why the class has two responsibilities: it drains work
@@ -707,17 +779,53 @@ observedWaitsPerMillisecond = parksInThisBatch / elapsedMilliseconds
 
 Later observations use a weighted moving average so that a temporary
 scheduler pause does not completely replace the established estimate. The
-two updater methods work like this:
+calibration and transition methods work like this:
 
 | Method | When called | What it does |
 |---|---|---|
 | `setElastic(actualElapsedMs)` | After a window rotation | Learns from only the just-completed batch, clears all window-local counters, and schedules the next check using `measuredRate × windowIntervalMS`. |
 | `updateElastic(elapsedMs)` | After a clock check that did *not* rotate the window | Learns from only the parks since the previous clock check, clears that batch, and schedules the next check using `measuredRate × remainingWindowMs`. |
+| `startIdle(elapsedMs)` | On the first empty scan after one or more records were consumed | Retains the established moving-average park rate, discards parks from the earlier idle period, advances the sample origin to the greater of its previous value and the last record's elapsed-window time, and schedules a check for the remaining window. During bootstrap it conservatively checks after one park. |
+| `reset()` | After a record timestamp rotates the reporting window | Retains the measured park rate but clears all counters and elapsed state belonging to the old window. |
 
 The learned rate, rather than the requested park duration, is retained across
 reporting windows. Batch counters and elapsed-window state are never retained
 across a rotation. This prevents a busy or partially idle old window from
 inflating the next window's threshold.
+
+A reporting window can alternate between empty and active periods. Without an
+active-to-idle reset, parks accumulated before a brief burst of records would
+be divided by elapsed time that also includes the active burst. That would
+underestimate the measured park rate and cause more frequent clock checks.
+`PerformanceRecorderIdleBusyWait` therefore remembers whether data has been
+consumed. On the first subsequent empty scan it calls `startIdle()` with the
+elapsed time derived from the last consumed `TimeStamp.endTime`. This starts a
+clean idle sample **without a new clock query** and without delaying a window
+boundary. The learned exponential moving average (EMA) survives, so a brief
+data burst does not throw away calibration. Taking the maximum of the prior
+sample origin and the supplied elapsed time also prevents an out-of-order
+completion timestamp from moving calibration backwards.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IdleSampling
+    IdleSampling --> ClockCheck: elasticCount parks complete
+    ClockCheck --> IdleSampling: window not due / updateElastic
+    ClockCheck --> IdleSampling: window rotated / setElastic
+    IdleSampling --> Active: record received
+    Active --> Active: more records / reuse endTime
+    Active --> IdleSampling: first empty scan / startIdle
+    Active --> IdleSampling: record rotates window / reset
+
+    note right of Active
+      No recorder clock call
+      while records are available
+    end note
+    note right of IdleSampling
+      Park count is local to
+      this uninterrupted idle period
+    end note
+```
 
 Every computed threshold is clamped to at least one and saturates at
 `Long.MAX_VALUE`. Consequently, unusual clock resolution, very slow hosts,
@@ -786,6 +894,8 @@ sequenceDiagram
     R->>R: record / window check
 
     Note over W,C: Phase 2 - queue empty, back-off begins
+    R->>E: startIdle(elapsed from last endTime)
+    Note over E: clear prior idle sample<br/>retain learned EMA rate
     R->>E: waitAndCheck()
     E->>E: park idleNS, increment count
     E-->>R: false (not yet)
@@ -2046,6 +2156,12 @@ counters; it queries the clock only after an adaptive batch. `setElastic`
 calibrates the next batch from observed elapsed time, compensating for
 `parkNanos` oversleep. This reduces clock-query and empty-poll overhead without
 changing the operation latency already captured by the worker.
+
+If records briefly interrupt an idle period, the recorder calls `startIdle`
+on the first following empty scan. The call discards the old idle-period
+counters, retains the EMA park-rate estimate, and uses the most recent record
+timestamp as the new sample origin. Active processing time therefore does not
+dilute the measured park rate, and the transition adds no clock call.
 
 The configured default is 1 ms and the enforced minimum is 1 µs. Operators
 can instead set `sleepMS` to select the simpler sleeping recorder. Lower idle

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -468,6 +468,13 @@ its internal node. The intrusive path therefore removes one young-generation
 object per operation while keeping percentile calculation, sorting, and
 logger I/O out of the storage-operation call path.
 
+For a research-oriented treatment of the queue algorithm, including its
+linearization points, Java Memory Model edges, stale-producer recovery,
+batched reclamation, feature-by-feature comparison with JDK 25
+`ConcurrentLinkedQueue`, reproducible JMH results, threats to validity, and
+primary references, see
+[TimeStampMpscQueue: architecture, correctness, and performance](TIMESTAMP_MPSC_QUEUE.md).
+
 The two-level topology is easy to miss in code. With two workers and the
 default `qPerWorker=10`, the conceptual layout is:
 

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -201,9 +201,10 @@ In practice that means:
    linked node, avoiding the separate wrapper allocated by a general-purpose
    `ConcurrentLinkedQueue`. PerL shards traffic across an array of queues to
    reduce contention, while a single recorder owns each latency window.
-   `MpscQueueEnable=false` restores the JDK queue path for compatibility and
-   comparison. Lock-free does not mean zero cost: enqueue can retry a CAS, but
-   progress does not depend on another thread releasing a lock (§3).
+   `MpscQueueEnable=false` supplies a property-level JDK fallback, while the
+   common `-mpscqueue false` option can select that path for one SBK run.
+   Lock-free does not mean zero cost: enqueue can retry a CAS, but progress
+   does not depend on another thread releasing a lock (§3).
 
 3. **The framework is its own ecosystem.** **PerL** (Performance Logger,
    the latency library) is a reusable Java library independent of SBK;
@@ -449,9 +450,11 @@ The two channel implementations remain independent.
 `TimeStampMpscQueueChannel` extends `TimeStampMpscQueueArray`; every element is
 a `TimeStampNode`, derived from `TimeStamp`, with its queue link in the same
 object. The original `CQueueChannel` continues to extend
-`ConcurrentLinkedQueueArray<TimeStamp>` unchanged. `MpscQueueEnable` selects
-which channel class is constructed. Both provide **non-blocking queue
-operations** without an application mutex or monitor.
+`ConcurrentLinkedQueueArray<TimeStamp>` unchanged. `MpscQueueEnable` supplies
+the property default, and SBK's common `-mpscqueue true|false` option overrides
+that selection before either writer or reader PerL instance is built. Both
+provide **non-blocking queue operations** without an application mutex or
+monitor.
 
 The array-of-queues design is the scaling layer. `CQueuePerl` normally
 creates one channel per configured worker. Each channel contains
@@ -824,8 +827,11 @@ flowchart LR
     class HDR,CSV bounded
 ```
 
-The defaults in
-[perl.properties](../perl/src/main/resources/perl.properties):
+Standalone PerL defaults are in
+[perl.properties](../perl/src/main/resources/perl.properties). SBK applications
+load the equivalent values from
+[`sbk.properties`](../sbk-api/src/main/resources/sbk.properties), then apply
+the optional `-mpscqueue` override:
 
 ```properties
 maxArraySizeMB=64           # Use Array backend if latency range fits
@@ -836,6 +842,12 @@ histogram=false             # Optional HdrHistogram for total window
 csv=false                   # Optional raw-CSV total backend
 csvFileSizeGB=1
 ```
+
+`qPerWorker` and `maxQs` are topology properties, not public command-line
+options. SBK validates them while loading `sbk.properties` and prints the
+effective queue name and topology at startup. Keeping topology fixed while
+changing only `-mpscqueue` makes JDK-versus-intrusive comparisons less prone
+to accidental configuration drift.
 
 **How available memory changes the design:** an array has predictable memory
 and direct indexing, but its size is proportional to the configured latency
@@ -2846,8 +2858,11 @@ your "Experimental Setup" section makes the study fully reproducible:
 
 1. **SBK version and commit hash** from the exact build under test.
 2. **Driver** used (e.g. `minio`, `cassandra`, `kafka`).
-3. **PerL configuration**: `qPerWorker`, `idleNS`, `maxArraySizeMB`,
-   `maxHashMapSizeMB`, `histogram` (yes/no). Defaults are in
+3. **PerL configuration**: effective `-mpscqueue` selection,
+   `qPerWorker`, `maxQs`, `idleNS`, `maxArraySizeMB`, `maxHashMapSizeMB`, and
+   `histogram` (yes/no). SBK defaults are in
+   [`sbk.properties`](../sbk-api/src/main/resources/sbk.properties);
+   standalone PerL defaults are in
    [perl.properties](../perl/src/main/resources/perl.properties).
 4. **Workload**: `-writers`, `-readers`, `-size`, `-seconds` or
    `-records`, `-throughput`, and any driver-specific flags.

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -175,7 +175,7 @@ The framework's stated design principle, quoted verbatim from
 
 In practice that means:
 
-- **Storage agnostic.** 52 drivers are enabled in the aggregate build today (Kafka,
+- **Storage agnostic.** 53 drivers are enabled in the aggregate build today (Kafka,
   Pulsar, Pravega, BookKeeper, S3, HDFS, Cassandra, MongoDB, Redis,
   RocksDB, PostgreSQL, …). Adding a new one is a matter of implementing
   one Java interface with seven methods.
@@ -241,7 +241,7 @@ flowchart TB
         GYAL["<b>SBK-GEM-YAL</b><br/>YML + SSH<br/>SbkGemYalMain.main()"]
     end
 
-    subgraph DRIVERS["🔌 Drivers (52 enabled)"]
+    subgraph DRIVERS["🔌 Drivers (53 enabled)"]
         DRV["Kafka · Pulsar · Pravega · S3<br/>HDFS · Cassandra · MongoDB · Redis<br/>JDBC · RocksDB · File · …"]
     end
 

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -38,10 +38,15 @@ The per-driver README describes backend prerequisites and examples. Always confi
 ./build/install/sbk/bin/sbk -class <driver> -help
 ```
 
-For measurement-pipeline experiments rather than storage I/O, use the
-[`PerlBench` synthetic driver](perlbench/README.md). It provides reproducible
-commands for comparing `TimeStampMpscQueue` and the JDK
-`ConcurrentLinkedQueue` path.
+Two synthetic drivers intentionally cover different harness states:
+
+| Driver | Use |
+|---|---|
+| [`Null`](null/README.md) | Pending operations, zero-record periodic windows, timeout, interruption, and shutdown |
+| [`PerlBench`](perlbench/README.md) | High-rate completed operations and reproducible `TimeStampMpscQueue` versus JDK `ConcurrentLinkedQueue` comparisons |
+
+Neither produces storage-system results. Do not use `Null` as the queue
+throughput baseline: its default operation deliberately remains incomplete.
 
 ## Status distinctions
 

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -38,6 +38,11 @@ The per-driver README describes backend prerequisites and examples. Always confi
 ./build/install/sbk/bin/sbk -class <driver> -help
 ```
 
+For measurement-pipeline experiments rather than storage I/O, use the
+[`PerlBench` synthetic driver](perlbench/README.md). It provides reproducible
+commands for comparing `TimeStampMpscQueue` and the JDK
+`ConcurrentLinkedQueue` path.
+
 ## Status distinctions
 
 - Enabled: present in both `settings-drivers.gradle` and `build-drivers.gradle`.

--- a/drivers/null/README.md
+++ b/drivers/null/README.md
@@ -16,12 +16,66 @@ limitations under the License.
 
 # Null driver
 
-`-class null` performs local synthetic writer/reader work without an external storage system. It is useful for smoke tests and estimating harness/JVM overhead under a particular configuration.
+`-class null` is SBK's idle, pending-operation, and timeout test driver. It
+does not access an external storage system.
 
-Driver options include `-n`, the writer iteration-loop bound, and `-timeout`, the maximum per-worker timeout in milliseconds.
+The default writer does **not** complete an operation. It returns an incomplete
+`CompletableFuture` with the configured timeout, which lets tests verify:
+
+- periodic reporting when a window contains no completed records;
+- idle `ElasticWait` behavior;
+- shutdown while an operation is pending;
+- future timeout and error propagation.
+
+The reader sleeps for the configured timeout and then returns `null`. Normal
+timed shutdown can interrupt that sleep.
+
+## Options
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `-n` | `0` | When greater than zero, execute an empty loop with this iteration bound and then complete the write synchronously. At zero, return an incomplete future. |
+| `-timeout` | `2147483647` ms | Timeout applied to the pending writer future and sleep duration used by the reader. |
+
+The empty `-n` loop is only a control-flow workload. A JIT compiler may
+optimize it, so it is not a calibrated CPU-delay mechanism and should not be
+used for latency claims.
+
+## Idle reporting example
+
+This run should print periodic zero-record windows and then stop at the
+configured duration:
 
 ```bash
 ./build/install/sbk/bin/sbk -class null -writers 1 -size 1024 -seconds 15
 ```
 
-Null-driver results are not storage results and should not be compared directly with durable backend operations. Use `-class null -help` for defaults.
+## Synchronous control-flow example
+
+Setting `-n` above zero makes each write complete synchronously:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class null -writers 1 -size 1024 -records 1000 -n 100
+```
+
+This can smoke-test completed-operation control flow, but it is not the
+recommended queue-performance workload.
+
+## Null versus PerlBench
+
+Both drivers are synthetic, but they deliberately exercise opposite states:
+
+| Property | `Null` | [`PerlBench`](../perlbench/README.md) |
+|---|---|---|
+| Default write | Remains pending | Completes immediately |
+| Read | Sleeps, then returns `null` | Immediately returns a reusable payload |
+| Expected default result | Idle windows with zero completed records | High-rate completed records and latency samples |
+| Primary purpose | Idle reporting, timeout, interruption, and shutdown behavior | End-to-end SBK/PerL throughput, allocation, and timestamp-queue comparison |
+| Suitable for `-mpscqueue` A/B performance tests | No | Yes |
+
+They should not be merged: the distinction between "no completion" and
+"completion as fast as possible" is the behavior each driver exists to test.
+
+Null-driver results are not storage results and should not be compared with
+durable backend operations. Use `-class null -help` for current defaults.

--- a/drivers/null/src/test/java/io/sbk/driver/Null/NullIdleReportingTest.java
+++ b/drivers/null/src/test/java/io/sbk/driver/Null/NullIdleReportingTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies time-driven reporting when the Null driver completes no writes.
@@ -30,8 +31,14 @@ public class NullIdleReportingTest {
     private static final int RUN_SECONDS = 3;
 
     /**
-     * A default Null write remains incomplete, yet PerL must print a zero-value
-     * result at every configured reporting interval.
+     * A default Null write remains incomplete, yet PerL must print zero-value
+     * results for completed reporting intervals.
+     *
+     * <p>The run deadline and the third one-second window share a boundary.
+     * Scheduler delay may make that last window partial; PerL deliberately
+     * excludes partial empty windows from regular interval output. Therefore
+     * a three-second run must produce the first two complete windows and may
+     * produce the boundary-aligned third window.</p>
      *
      * @throws Exception if the timed PerL run cannot complete
      */
@@ -47,8 +54,11 @@ public class NullIdleReportingTest {
                     "The default Null writer must not produce a completed timestamp");
             perl.run(RUN_SECONDS, 0).get(RUN_SECONDS + 5L, TimeUnit.SECONDS);
 
-            assertEquals(RUN_SECONDS, logger.windowPrints.get(),
-                    "PerL must print one empty result per configured interval");
+            final int windowPrints = logger.windowPrints.get();
+            assertTrue(windowPrints >= RUN_SECONDS - 1,
+                    "PerL must print every fully completed empty interval");
+            assertTrue(windowPrints <= RUN_SECONDS,
+                    "PerL must not print beyond the timed run boundary");
             assertEquals(0, logger.windowRecords.get(),
                     "An incomplete Null write must not be counted as completed");
             assertEquals(0, logger.totalRecords.get(),

--- a/drivers/perlbench/README.md
+++ b/drivers/perlbench/README.md
@@ -221,14 +221,17 @@ collected on 2026-07-27 on a 16-vCPU VMware guest with an Intel Xeon Platinum
 
 | Metric | `TimeStampMpscQueue` | JDK queue path | Observed difference |
 |---|---:|---:|---:|
-| Add/poll round trip | 33.107 ns/op | 47.673 ns/op | MPSC 30.55% lower |
+| Add/poll round trip | 32.732 ns/op | 47.000 ns/op | MPSC 30.36% lower |
 | Normalized allocation | 40 B/op | 56 B/op | MPSC 28.57% lower |
-| Four-producer enqueue throughput | 5.90 M ops/s | 5.16 M ops/s | MPSC 14.35% higher; 99.9% confidence intervals did not overlap |
+| Four-producer enqueue throughput | 5.85 M ops/s | 5.48 M ops/s | MPSC 6.74% higher; 99.9% confidence intervals overlapped |
 
 The allocation difference is structural: the intrusive
 `TimeStampNode` is both payload and link, whereas the JDK path allocates a
 `TimeStamp` plus a private queue node. Throughput remains dependent on
-contention, scheduling, and consumer service rate.
+contention, scheduling, and consumer service rate. The canonical exact values,
+confidence intervals, environment, and interpretation are maintained in
+[the queue research guide](../../docs/TIMESTAMP_MPSC_QUEUE.md#102-recorded-environment-and-results);
+this summary must not be interpreted as a universal throughput ranking.
 
 ### PerlBench end-to-end observations
 

--- a/drivers/perlbench/README.md
+++ b/drivers/perlbench/README.md
@@ -28,6 +28,22 @@ This is not a storage benchmark. Use it to compare PerL configurations,
 estimate the measurement ceiling of a machine, and check whether timestamp
 collection can keep up with a proposed storage workload.
 
+## Why PerlBench is not the Null driver
+
+Both drivers avoid external storage, but they test different parts of SBK:
+
+| Property | `PerlBench` | [`Null`](../null/README.md) |
+|---|---|---|
+| Default write | Immediate synchronous completion | Incomplete future that remains pending until timeout or shutdown |
+| Read | Immediate, preallocated payload | Sleeps for the configured timeout and returns `null` |
+| Timestamp production | One completed measurement per operation | No completed measurement on the default path |
+| Main question | How fast can SBK and PerL process completed operations? | Does idle reporting, timeout, interruption, and shutdown work correctly? |
+
+Using `Null` for queue throughput would mostly measure an idle or blocked
+worker. Using `PerlBench` for timeout behavior would never create the required
+pending operation. Keeping separate driver identities prevents these results
+from being confused.
+
 ## What the driver measures
 
 ```mermaid

--- a/drivers/perlbench/README.md
+++ b/drivers/perlbench/README.md
@@ -1,0 +1,247 @@
+<!--
+Copyright (c) KMG. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# PerlBench driver
+
+`PerlBench` is SBK's synthetic driver for measuring the end-to-end overhead
+and scalability of the SBK harness and its PerL timestamp pipeline. It removes
+storage, network, serialization, and vendor-SDK work from the operation path:
+
+- a write completes immediately;
+- a reader returns the same worker-owned, preallocated byte array;
+- neither operation allocates, blocks, locks, or accesses shared driver state.
+
+This is not a storage benchmark. Use it to compare PerL configurations,
+estimate the measurement ceiling of a machine, and check whether timestamp
+collection can keep up with a proposed storage workload.
+
+## What the driver measures
+
+```mermaid
+flowchart LR
+    W["SBK worker"]
+    S["start = clock"]
+    OP["PerlBench no-op write<br/>or preallocated read"]
+    E["end = clock"]
+    Q["Timestamp queue"]
+    R["Single PerL recorder"]
+    O["Window and total results"]
+
+    W --> S --> OP --> E --> Q --> R --> O
+
+    classDef timed fill:#dcfce7,stroke:#166534,color:#111
+    classDef transport fill:#dbeafe,stroke:#1d4ed8,color:#111
+    class OP timed
+    class Q,R transport
+```
+
+The reported operation latency is `end - start`. Queue insertion occurs after
+the end timestamp, so displayed latency percentiles do **not** directly measure
+enqueue latency. Queue implementation affects:
+
+- the maximum sustainable end-to-end operation rate;
+- allocation rate and garbage-collection pressure;
+- queue backlog and the recorder's ability to drain it;
+- process memory during large record-count runs.
+
+Use the PerL JMH task when the research question is specifically queue
+add/poll latency and normalized bytes allocated per operation:
+
+```bash
+./gradlew :perl:timeStampQueuePerformanceTest
+```
+
+## Queue selection
+
+The common `-mpscqueue` SBK option works with real storage drivers and is
+especially useful with `PerlBench`.
+
+| Option | Values and default | Meaning |
+|---|---|---|
+| `-mpscqueue` | `true` or `false`; property default | `true` selects intrusive `TimeStampMpscQueue`; `false` selects JDK `ConcurrentLinkedQueue` |
+
+Queue topology is deliberately not exposed through the CLI. SBK loads
+`maxQs` and `qPerWorker` from
+`sbk-api/src/main/resources/sbk.properties`. The default `maxQs=0` creates
+per-worker channels and represents SBK's normal high-throughput deployment.
+Advanced queue research can set `maxQs=1` and rebuild SBK to force every
+writer or reader to publish to one shared MPSC queue.
+
+At startup SBK prints the effective selection:
+
+```text
+PerL Timestamp Queue: TimeStampMpscQueue (MPSC)
+PerL Timestamp Queue Topology: 10 queue(s) per worker
+```
+
+or:
+
+```text
+PerL Timestamp Queue: ConcurrentLinkedQueue (JDK)
+PerL Timestamp Queue Topology: 10 queue(s) per worker
+```
+
+## Test modes
+
+### Exact records: completion, latency, and throughput
+
+`-records` without `-seconds` divides the requested total across the workers
+and waits until every assigned operation has completed and every timestamp has
+been consumed. Odd totals are supported; the first workers receive the
+remainder one record at a time.
+
+Compare the two queue paths with the same command except for `-mpscqueue`:
+
+```bash
+# Intrusive timestamp node and queue
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 4 -size 1024 -records 20000000 \
+  -time ns -thread p -mpscqueue true
+
+# TimeStamp plus the JDK queue's internal node
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 4 -size 1024 -records 20000000 \
+  -time ns -thread p -mpscqueue false
+```
+
+Confirm that each result reports exactly `20000000 records` and
+`0 invalid latencies`. Record mode is the best end-to-end check for lost,
+duplicated, or undrained measurements.
+
+### Timed saturation: maximum throughput
+
+`-seconds` runs at maximum speed when `-throughput` remains `-1`. At the
+duration boundary SBK stops workload generation and reports the measurements
+accumulated by that hard deadline. Timed mode answers: "How many operations
+can this complete pipeline sustain for this period?"
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 1 -size 1024 -seconds 30 \
+  -time ns -thread p -mpscqueue true
+
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 1 -size 1024 -seconds 30 \
+  -time ns -thread p -mpscqueue false
+```
+
+Repeat with `-writers 2`, `4`, `8`, and the available CPU count. A queue can
+win with one producer yet lose at a particular contention level, so one thread
+count is not a scalability study.
+
+### Rate-controlled latency
+
+Use `-throughput MBPS` with `-seconds` to hold offered data throughput near a
+target. This separates behavior at a realistic load from maximum-saturation
+behavior.
+
+For 1,024-byte records, `-throughput 1000` is approximately 1,048,576
+records/second across all workers:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 4 -size 1024 -seconds 30 -throughput 1000 \
+  -time ns -thread p -mpscqueue true
+
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 4 -size 1024 -seconds 30 -throughput 1000 \
+  -time ns -thread p -mpscqueue false
+```
+
+Both runs should approach the same configured MB/s. Compare high-percentile
+latencies, CPU consumption, allocation, GC pauses, and queue-drain stability.
+Do not interpret a small difference in the displayed no-op latency as direct
+queue latency because enqueue is outside the timed interval.
+
+### Reader path
+
+The reader reuses one payload per reader worker, so it exercises SBK's reader
+control flow without per-record driver allocation:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class perlbench -readers 4 -size 1024 -records 1000000 \
+  -time ns -thread p -mpscqueue true
+```
+
+Run the same command with `-mpscqueue false`. No preparation step is required.
+
+## Reproducible A/B protocol
+
+1. Build once with `./gradlew clean :pathingJar installDist --rerun-tasks`.
+2. Keep the JVM, GC, heap, compact-header setting, CPU governor, affinity,
+   worker count, queue topology, duration/count, and record size identical.
+3. Alternate queue order to reduce thermal and background-load bias.
+4. Warm up before collecting results.
+5. Use at least three forks; five or more are preferable for publication.
+6. Record the median and confidence interval, not only the best run.
+7. Capture allocation with JMH and process memory/GC with JFR, `jcmd`,
+   `/usr/bin/time -v`, or equivalent OS tools.
+8. For topology research, test separate builds with `maxQs=1` and the
+   default `maxQs=0` in `sbk.properties`.
+9. Confirm exact counts and zero invalid latencies in record mode.
+10. Treat differences smaller than run-to-run variation as inconclusive.
+
+## Example results and interpretation
+
+The following results are observations, not performance guarantees. They were
+collected on 2026-07-27 on a 16-vCPU VMware guest with an Intel Xeon Platinum
+8462Y+, Linux 5.15, JDK 25.0.2, ZGC, and compact object headers.
+
+### PerL queue microbenchmark
+
+| Metric | `TimeStampMpscQueue` | JDK queue path | Observed difference |
+|---|---:|---:|---:|
+| Add/poll round trip | 33.107 ns/op | 47.673 ns/op | MPSC 30.55% lower |
+| Normalized allocation | 40 B/op | 56 B/op | MPSC 28.57% lower |
+| Four-producer enqueue throughput | 5.90 M ops/s | 5.16 M ops/s | MPSC 14.35% higher; 99.9% confidence intervals did not overlap |
+
+The allocation difference is structural: the intrusive
+`TimeStampNode` is both payload and link, whereas the JDK path allocates a
+`TimeStamp` plus a private queue node. Throughput remains dependent on
+contention, scheduling, and consumer service rate.
+
+### PerlBench end-to-end observations
+
+| Workload | `TimeStampMpscQueue` | JDK queue path | Interpretation |
+|---|---:|---:|---|
+| One writer, six-second saturation | 7.87 M records/s | 6.20 M records/s | MPSC 26.9% higher in this single run |
+| Four writers, six-second saturation | 5.61 M records/s | 4.47 M records/s | MPSC 25.5% higher in this single run |
+| Four writers, 1,000 MB/s target | 993.60 MB/s | 993.35 MB/s | Both sustained the requested load |
+| One reader, six-second saturation | 8.11 M records/s | 6.16 M records/s | MPSC 31.6% higher in this single run |
+| Four writers, 20 M exact records, three-run median | 5.53 M records/s | 5.19 M records/s | MPSC 6.6% higher under shared-queue contention |
+| Same exact-record test, median peak RSS | 1.24 GiB | 1.54 GiB | MPSC used about 20% less process memory |
+
+Every exact-count run completed all requested records with zero invalid
+latencies. The results demonstrate the expected memory advantage and show
+that adopting JDK CLQ's one-node tail-slack strategy removed unnecessary
+shared-tail updates without sacrificing the intrusive queue's latency.
+Results remain environment-specific, so the fallback and runtime comparison
+options remain valuable.
+
+For queue algorithm diagrams, memory-ordering details, correctness evidence,
+and the complete JMH methodology, see
+[TimeStampMpscQueue: architecture, correctness, and performance](../../docs/TIMESTAMP_MPSC_QUEUE.md).
+
+## Limitations
+
+- The driver has no storage durability, network, or data-integrity semantics.
+- Its no-op latency is dominated by clocks and harness control flow.
+- Both linked queues are unbounded; prolonged producer overload can grow
+  memory.
+- Peak RSS includes the JVM heap and SBK latency stores, not only queue nodes.
+- A synthetic result must not replace testing with the intended real driver.
+- Virtualized-host results are especially sensitive to scheduling noise.

--- a/drivers/perlbench/build.gradle
+++ b/drivers/perlbench/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api project(":sbk-api")
+}

--- a/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBench.java
+++ b/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBench.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.PerlBench;
+
+import io.sbk.api.DataReader;
+import io.sbk.api.DataWriter;
+import io.sbk.api.Storage;
+import io.sbk.params.InputOptions;
+import io.sbk.params.ParameterOptions;
+
+import java.io.IOException;
+
+/**
+ * Synthetic storage driver for measuring SBK and PerL instrumentation
+ * overhead without external storage I/O.
+ *
+ * <p>The writer completes synchronously without work. Each reader returns a
+ * worker-owned, preallocated payload. Neither operation allocates, blocks, or
+ * introduces shared mutable state on the per-record path.</p>
+ */
+public final class PerlBench implements Storage<byte[]> {
+
+    /**
+     * Register driver-specific arguments.
+     *
+     * <p>PerlBench intentionally has no driver-specific arguments.</p>
+     *
+     * @param params command-line option registry
+     */
+    @Override
+    public void addArgs(InputOptions params) {
+    }
+
+    /**
+     * Parse driver-specific arguments.
+     *
+     * <p>PerlBench intentionally has no driver-specific arguments.</p>
+     *
+     * @param params parsed benchmark parameters
+     */
+    @Override
+    public void parseArgs(ParameterOptions params) {
+    }
+
+    /**
+     * Open the synthetic storage target.
+     *
+     * @param params parsed benchmark parameters
+     * @throws IOException retained by the storage contract
+     */
+    @Override
+    public void openStorage(ParameterOptions params) throws IOException {
+    }
+
+    /**
+     * Close the synthetic storage target.
+     *
+     * @param params parsed benchmark parameters
+     * @throws IOException retained by the storage contract
+     */
+    @Override
+    public void closeStorage(ParameterOptions params) throws IOException {
+    }
+
+    /**
+     * Create an allocation-free synchronous writer.
+     *
+     * @param id writer identifier
+     * @param params parsed benchmark parameters
+     * @return synthetic writer
+     */
+    @Override
+    public DataWriter<byte[]> createWriter(int id,
+                                           ParameterOptions params) {
+        return new PerlBenchWriter();
+    }
+
+    /**
+     * Create a reader with one worker-owned payload.
+     *
+     * @param id reader identifier
+     * @param params parsed benchmark parameters
+     * @return synthetic reader
+     */
+    @Override
+    public DataReader<byte[]> createReader(int id,
+                                           ParameterOptions params) {
+        return new PerlBenchReader(params.getRecordSize());
+    }
+}

--- a/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBenchReader.java
+++ b/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBenchReader.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.PerlBench;
+
+import io.sbk.api.Reader;
+
+import java.io.IOException;
+
+/**
+ * Synthetic reader returning a preallocated worker-owned payload.
+ */
+public final class PerlBenchReader implements Reader<byte[]> {
+    private final byte[] payload;
+
+    /**
+     * Create a reader payload once, outside the per-record path.
+     *
+     * @param recordSize configured record size in bytes
+     */
+    public PerlBenchReader(int recordSize) {
+        this.payload = new byte[recordSize];
+    }
+
+    /**
+     * Return the preallocated payload.
+     *
+     * @return the same worker-owned payload on every invocation
+     * @throws IOException retained by the reader contract
+     */
+    @Override
+    public byte[] read() throws IOException {
+        return payload;
+    }
+
+    /**
+     * Close the reader.
+     *
+     * @throws IOException retained by the reader contract
+     */
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBenchWriter.java
+++ b/drivers/perlbench/src/main/java/io/sbk/driver/PerlBench/PerlBenchWriter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.PerlBench;
+
+import io.sbk.api.Writer;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Synchronous no-operation writer used to expose measurement-pipeline cost.
+ */
+public final class PerlBenchWriter implements Writer<byte[]> {
+
+    /**
+     * Complete one synthetic operation synchronously.
+     *
+     * @param data worker-owned payload; intentionally unused
+     * @return {@code null}, indicating synchronous completion
+     * @throws IOException retained by the writer contract
+     */
+    @Override
+    public CompletableFuture<?> writeAsync(byte[] data) throws IOException {
+        return null;
+    }
+
+    /**
+     * Close the stateless writer.
+     *
+     * @throws IOException retained by the writer contract
+     */
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/drivers/perlbench/src/test/java/io/sbk/driver/PerlBench/PerlBenchTest.java
+++ b/drivers/perlbench/src/test/java/io/sbk/driver/PerlBench/PerlBenchTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.driver.PerlBench;
+
+import io.sbk.api.Reader;
+import io.sbk.api.Writer;
+import io.sbk.params.impl.SbkParameters;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests the allocation-free synthetic storage operations.
+ */
+public final class PerlBenchTest {
+
+    /**
+     * Verify synchronous writer completion without a future allocation.
+     *
+     * @throws Exception if driver setup or writing fails
+     */
+    @Test
+    public void writerCompletesSynchronously() throws Exception {
+        final SbkParameters parameters = writerParameters();
+        final PerlBench storage = new PerlBench();
+        storage.openStorage(parameters);
+        final Writer<byte[]> writer =
+                (Writer<byte[]>) storage.createWriter(0, parameters);
+
+        try {
+            final CompletableFuture<?> result =
+                    writer.writeAsync(new byte[8]);
+            assertNull(result,
+                    "null denotes allocation-free synchronous completion");
+        } finally {
+            writer.close();
+            storage.closeStorage(parameters);
+        }
+    }
+
+    /**
+     * Verify that a reader reuses one correctly sized worker-owned payload.
+     *
+     * @throws Exception if driver setup or reading fails
+     */
+    @Test
+    public void readerReusesPreallocatedPayload() throws Exception {
+        final SbkParameters parameters =
+                new SbkParameters("perlbench-reader-test");
+        parameters.parseArgs(new String[]{
+                "-readers", "1", "-size", "64", "-records", "2"
+        });
+        final PerlBench storage = new PerlBench();
+        storage.openStorage(parameters);
+        final Reader<byte[]> reader =
+                (Reader<byte[]>) storage.createReader(0, parameters);
+
+        try {
+            final byte[] first = reader.read();
+            final byte[] second = reader.read();
+            assertEquals(64, first.length);
+            assertSame(first, second,
+                    "the read hot path must not allocate a payload");
+        } finally {
+            reader.close();
+            storage.closeStorage(parameters);
+        }
+    }
+
+    private static SbkParameters writerParameters() throws Exception {
+        final SbkParameters parameters =
+                new SbkParameters("perlbench-writer-test");
+        parameters.parseArgs(new String[]{
+                "-writers", "1", "-size", "8", "-records", "1"
+        });
+        return parameters;
+    }
+}

--- a/perl/README.md
+++ b/perl/README.md
@@ -214,6 +214,15 @@ gate because host noise can widen an otherwise faster result. The report is writ
 host-specific; preserve the same JVM flags and an otherwise idle host when
 comparing changes.
 
+The detailed
+[TimeStampMpscQueue research guide](../docs/TIMESTAMP_MPSC_QUEUE.md) explains
+the linearization points, acquire/release edges, batched retired-head
+reclamation, stale-producer recovery, JDK 25 `ConcurrentLinkedQueue`
+differences, correctness evidence, and performance methodology. It also records
+an environment where the intrusive path reduced latency and allocation but did
+not win the contended producer-throughput point estimate; throughput is not a
+universal property of the algorithm.
+
 ## Use as a library
 
 Published coordinates use the project group and version defined in `gradle.properties`. Refer to [Maven Central](https://central.sonatype.com/), the repository's GitHub Packages configuration, or a locally published build for the currently available version instead of copying a version from this README.

--- a/perl/README.md
+++ b/perl/README.md
@@ -298,9 +298,10 @@ The detailed
 the linearization points, acquire/release edges, batched retired-head
 reclamation, stale-producer recovery, JDK 25 `ConcurrentLinkedQueue`
 differences, correctness evidence, and performance methodology. It also records
-an environment where the intrusive path reduced latency and allocation but did
-not win the contended producer-throughput point estimate; throughput is not a
-universal property of the algorithm.
+one environment where the intrusive path reduced latency and allocation and
+passed the point-estimate throughput gate, while the producer-throughput
+confidence intervals overlapped. Throughput is not a universal property of the
+algorithm.
 
 ## Use as a library
 

--- a/perl/README.md
+++ b/perl/README.md
@@ -137,6 +137,48 @@ Use `SbkParameters.loadPerlConfig()` and
 Use `PerlBuilder` as the source-level entry point for standalone PerL
 construction.
 
+## Elastic idle waiting
+
+With the default `sleepMS=0`, `PerformanceRecorderIdleBusyWait` is the sole
+consumer of the timestamp queues. The historical class name does not mean a
+tight spin: after a complete scan finds no data, the recorder calls
+`LockSupport.parkNanos(idleNS)`. `ElasticWait` learns the number of completed
+parks per millisecond and uses that rate to decide how many parks may occur
+before the recorder samples the clock again.
+
+```text
+records available -> reuse TimeStamp.endTime -> no recorder clock call
+queues empty       -> park and count         -> no clock call within batch
+batch complete     -> sample clock once      -> update EMA and next threshold
+```
+
+Calibration begins conservatively with a clock check after one park. If the
+clock has not advanced, the bootstrap batch grows exponentially up to a
+bounded threshold. Once measurable elapsed time exists, the observed park
+rate is folded into an exponential moving average. This adapts to operating
+system timer granularity, scheduling, CPU speed, and platform versus virtual
+thread behavior instead of assuming that `parkNanos` sleeps for precisely the
+requested duration.
+
+A window may alternate between idle and active periods. On the first empty
+scan after consuming data, the recorder calls `ElasticWait.startIdle()` with
+elapsed time derived from the last record's `endTime`. It discards the
+previous idle-period counters but retains the learned EMA rate. Active
+processing time therefore cannot dilute the next idle-rate sample, and the
+transition introduces no additional clock query. The sample origin never
+moves backwards if producer completion timestamps arrive out of order.
+
+`ElasticWait` applies only to the default idle-parking recorder.
+Setting `sleepMS > 0` selects `PerformanceRecorderIdleSleep`, which sleeps for
+the configured interval and does not use adaptive calibration. `idleNS`
+controls the responsiveness/idle-CPU tradeoff; its SBK default is 1 ms and its
+enforced minimum is 1 µs. Neither setting changes the operation latency
+already captured by the worker, but a longer idle delay can temporarily grow
+the queue backlog after new data arrives.
+
+The complete recorder state and timing diagrams are in
+[the internal design guide](../docs/sbk-internals.md#pillar-3--elasticwait-amortising-clock-queries).
+
 ## Build and test
 
 From the repository root:

--- a/perl/README.md
+++ b/perl/README.md
@@ -63,7 +63,18 @@ keeps stale-producer retention bounded while grouping reclamation stores.
 Nodes are not pooled because pooling retains heap and introduces ownership and
 ABA hazards.
 
-Set the following in `perl.properties` to restore the previous JDK path:
+For an SBK command, select the fallback at runtime:
+
+```bash
+./build/install/sbk/bin/sbk \
+  -class perlbench -writers 4 -size 1024 -records 1000000 \
+  -mpscqueue false
+```
+
+`-mpscqueue true` selects the intrusive queue. If the option is absent, SBK
+uses `MpscQueueEnable` from
+`sbk-api/src/main/resources/sbk.properties`. Standalone PerL users instead set
+the same property in `perl/src/main/resources/perl.properties`:
 
 ```properties
 MpscQueueEnable=false
@@ -109,7 +120,22 @@ constraints are documented in the
 
 ## Configuration
 
-Defaults are in `src/main/resources/perl.properties` and `sbk-api/src/main/resources/sbk.properties`. They control queue counts, idle behavior, latency storage limits, and histogram fallback. Use `PerlBuilder` as the source-level entry point for understanding how a configuration selects implementations.
+Standalone PerL defaults are in `src/main/resources/perl.properties`. SBK
+launches use `sbk-api/src/main/resources/sbk.properties`, which contains the
+equivalent queue, idle, latency-storage, and histogram defaults.
+
+For SBK:
+
+- `-mpscqueue true|false` overrides only `MpscQueueEnable`;
+- `qPerWorker` and `maxQs` determine queue topology and remain property-backed;
+- invalid negative `maxQs` or `qPerWorker` below the supported minimum is
+  rejected while common parameters are constructed;
+- startup logs show the effective queue implementation and topology.
+
+Use `SbkParameters.loadPerlConfig()` and
+`SbkBenchmark.buildPerlConfig()` to follow SBK's property-to-runtime path.
+Use `PerlBuilder` as the source-level entry point for standalone PerL
+construction.
 
 ## Build and test
 

--- a/perl/README.md
+++ b/perl/README.md
@@ -235,10 +235,21 @@ speed from distorting producer throughput. The verification requires lower
 round-trip latency, removal of at least eight allocation bytes per operation,
 and at least 2% higher producer throughput. It also reports the 99.9% MPSC
 throughput confidence intervals as diagnostics; interval overlap is not a hard
-gate because host noise can widen an otherwise faster result. The report is written to
+gate because host noise can widen an otherwise faster result. For a firm
+throughput comparison, use multiple forks and pin the producer and consumer
+threads to dedicated physical cores; latency and the structural allocation
+reduction are more stable signals. The report is written to
 `perl/build/reports/jmh/timestamp-queue-performance.json`. Results are
 host-specific; preserve the same JVM flags and an otherwise idle host when
 comparing changes.
+
+The production retirement batch remains 16. Concurrency-model tests inject
+smaller batches: Lincheck uses 2 so short histories cross the retirement
+boundary, while JCStress forces both stale-tail recovery and the
+release/acquire recovery-head fallback. Manual padding around the separate
+producer and consumer holders is a best-effort false-sharing heuristic, not a
+correctness requirement; Java does not guarantee field order or cache-line
+placement.
 
 The detailed
 [TimeStampMpscQueue research guide](../docs/TIMESTAMP_MPSC_QUEUE.md) explains

--- a/perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRecoveryHeadStress.java
+++ b/perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRecoveryHeadStress.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.perl.api.impl;
+
+import io.perl.api.TimeStampNode;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.II_Result;
+
+/**
+ * Exercises acquire/release publication of the recovery-head fallback.
+ *
+ * <p>A batch size of one is an intentionally aggressive test configuration.
+ * The queue starts with one node while the producer tail still points to the
+ * sentinel. The producer races to append a second node as the consumer
+ * release-publishes the first node as recovery head and self-links the
+ * sentinel. If the consumer wins, the producer must acquire-read the recovery
+ * head; if the producer wins, normal linking applies. Both orders must retain
+ * the same FIFO result without any external synchronization edge.</p>
+ */
+@JCStressTest
+@State
+@Outcome(id = "1, 2", expect = Expect.ACCEPTABLE,
+        desc = "The consumer retired the sentinel and the producer recovered.")
+@Outcome(expect = Expect.FORBIDDEN,
+        desc = "Recovery-head publication lost or stranded a timestamp.")
+public class TimeStampMpscQueueRecoveryHeadStress {
+    private final TimeStampMpscQueue queue = new TimeStampMpscQueue(1);
+
+    /**
+     * Seeds one node while leaving the producer tail at the sentinel.
+     */
+    public TimeStampMpscQueueRecoveryHeadStress() {
+        queue.add(node(1));
+    }
+
+    /**
+     * Races to append a second node through the normal or recovery path.
+     */
+    @Actor
+    public void producer() {
+        queue.add(node(2));
+    }
+
+    /**
+     * Retires the sentinel while the producer may still reference it.
+     *
+     * @param result JCStress result slots
+     */
+    @Actor
+    public void consumer(II_Result result) {
+        result.r1 = value(queue.poll());
+    }
+
+    /**
+     * Confirms reachability through the acquire-read recovery head.
+     *
+     * @param result JCStress result slots
+     */
+    @Arbiter
+    public void arbiter(II_Result result) {
+        result.r2 = value(queue.poll());
+    }
+
+    private static TimeStampNode node(int value) {
+        return new TimeStampNode(value, value, value, value);
+    }
+
+    private static int value(TimeStampNode node) {
+        return node == null ? -1 : node.records;
+    }
+}

--- a/perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRetirementRecoveryStress.java
+++ b/perl/src/jcstress/java/io/perl/api/impl/TimeStampMpscQueueRetirementRecoveryStress.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.perl.api.impl;
+
+import io.perl.api.TimeStampNode;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.II_Result;
+
+/**
+ * Exercises stale-producer recovery after a two-node retirement batch.
+ *
+ * <p>The stale producer pauses after reading the sentinel as its tail hint.
+ * The coordinator appends and consumes a second node, causing the batch of
+ * two predecessors to be self-linked, then releases the producer. The
+ * producer must detect its self-linked sentinel, recover through the newer
+ * tail, and publish its node without loss.</p>
+ */
+@JCStressTest
+@State
+@Outcome(id = "12, 3", expect = Expect.ACCEPTABLE,
+        desc = "The retired batch was consumed and the stale producer recovered.")
+@Outcome(expect = Expect.FORBIDDEN,
+        desc = "Retirement lost, duplicated, reordered, or stranded a node.")
+public class TimeStampMpscQueueRetirementRecoveryStress {
+    private final TimeStampMpscQueue queue = new TimeStampMpscQueue(2);
+    private volatile int phase;
+
+    /**
+     * Seeds the queue so its tail may lag at the sentinel.
+     */
+    public TimeStampMpscQueueRetirementRecoveryStress() {
+        queue.add(node(1));
+    }
+
+    /**
+     * Pauses with a tail reference that the consumer will retire.
+     */
+    @Actor
+    public void staleProducer() {
+        queue.add(node(3), () -> {
+            phase = 1;
+            while (phase != 2) {
+                Thread.onSpinWait();
+            }
+        });
+    }
+
+    /**
+     * Completes a retirement batch while the stale producer is paused.
+     *
+     * @param result JCStress result slots
+     */
+    @Actor
+    public void coordinator(II_Result result) {
+        while (phase != 1) {
+            Thread.onSpinWait();
+        }
+        queue.add(node(2));
+        final TimeStampNode first = queue.poll();
+        final TimeStampNode second = queue.poll();
+        result.r1 = value(first) * 10 + value(second);
+        phase = 2;
+    }
+
+    /**
+     * Confirms that the recovered producer's node remains reachable.
+     *
+     * @param result JCStress result slots
+     */
+    @Arbiter
+    public void arbiter(II_Result result) {
+        result.r2 = value(queue.poll());
+    }
+
+    private static TimeStampNode node(int value) {
+        return new TimeStampNode(value, value, value, value);
+    }
+
+    private static int value(TimeStampNode node) {
+        return node == null ? -1 : node.records;
+    }
+}

--- a/perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java
+++ b/perl/src/lincheck/java/io/perl/api/impl/TimeStampMpscQueueLincheckTest.java
@@ -26,12 +26,14 @@ import java.util.Queue;
  * <p>Lincheck normally permits every operation to run on every worker. The
  * queue contract permits multiple concurrent {@link #offer(int)} calls but
  * only one consumer, so {@link #poll()} belongs to a non-parallel operation
- * group. The sequential specification is a conventional FIFO queue.</p>
+ * group. The sequential specification is a conventional FIFO queue. A
+ * test-only retirement batch of two makes short generated histories exercise
+ * retired-head self-linking and stale traversal recovery.</p>
  */
 @Param(name = "value", gen = IntGen.class, conf = "1:4")
 public class TimeStampMpscQueueLincheckTest {
     private static final String CONSUMER_GROUP = "single-consumer";
-    private final TimeStampMpscQueue queue = new TimeStampMpscQueue();
+    private final TimeStampMpscQueue queue = new TimeStampMpscQueue(2);
 
     /**
      * Enqueues a timestamp whose start time carries the model value.

--- a/perl/src/main/java/io/perl/api/TimeStampNode.java
+++ b/perl/src/main/java/io/perl/api/TimeStampNode.java
@@ -29,8 +29,9 @@ import io.perl.api.impl.TimeStampMpscQueue;
 public final class TimeStampNode extends TimeStamp {
     /*
      * Accessed with VarHandle acquire/release operations by
-     * TimeStampMpscQueue. It is intentionally package-private so the linkage
-     * is unavailable to PerL users.
+     * TimeStampMpscQueue. It is intentionally private so the linkage is
+     * unavailable to PerL users; the queue obtains a VarHandle through a
+     * private lookup.
      */
     private TimeStampNode next;
 

--- a/perl/src/main/java/io/perl/api/impl/ElasticWait.java
+++ b/perl/src/main/java/io/perl/api/impl/ElasticWait.java
@@ -92,6 +92,32 @@ public final class ElasticWait {
     }
 
     /**
+     * Starts a fresh idle calibration sample after data was consumed.
+     *
+     * <p>The established moving-average park rate is retained, but parks from
+     * the earlier idle period are discarded so active processing time is not
+     * included in the next observed park rate. The elapsed value comes from
+     * the timestamp already consumed by the recorder, avoiding another
+     * wall-clock read.</p>
+     *
+     * @param elapsedIntervalMS elapsed milliseconds in the current window
+     */
+    void startIdle(long elapsedIntervalMS) {
+        final long elapsed = Math.max(
+                previousElapsedIntervalMS, Math.max(0, elapsedIntervalMS));
+        previousElapsedIntervalMS = elapsed;
+        idleCount = 0;
+        if (calibrated) {
+            final long remainingIntervalMS =
+                    Math.max(1, windowIntervalMS - elapsed);
+            elasticCount = waitCount(
+                    waitsPerMillisecond, remainingIntervalMS);
+        } else {
+            elasticCount = 1;
+        }
+    }
+
+    /**
      * Updates calibration after a clock check within the current window.
      *
      * <p>The completed batch is always cleared. If the clock has not advanced
@@ -113,7 +139,9 @@ public final class ElasticWait {
             final long remainingIntervalMS = Math.max(1, windowIntervalMS - elapsed);
             elasticCount = waitCount(waitsPerMillisecond, remainingIntervalMS);
         } else {
-            elasticCount = Math.min(saturatedDouble(elasticCount), maximumCalibrationCount);
+            elasticCount = Math.min(
+                    saturatingMultiplyByTwo(elasticCount),
+                    maximumCalibrationCount);
         }
     }
 
@@ -153,7 +181,7 @@ public final class ElasticWait {
         return Math.max(1, (long) count);
     }
 
-    private static long saturatedDouble(long value) {
+    private static long saturatingMultiplyByTwo(long value) {
         return value > Long.MAX_VALUE / 2 ? Long.MAX_VALUE : value * 2;
     }
 }

--- a/perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleBusyWait.java
+++ b/perl/src/main/java/io/perl/api/impl/PerformanceRecorderIdleBusyWait.java
@@ -57,6 +57,7 @@ public final class PerformanceRecorderIdleBusyWait extends PerformanceRecorder {
         long ctime = startTime;
         long recordsCnt = 0;
         boolean notFound;
+        boolean dataSinceIdle = false;
         TimeStamp t;
         PerlPrinter.log.info("PerformanceRecorderIdleBusyWait Started : {} nanoseconds idle busy wait", this.idleNS);
         periodicRecorder.start(startTime);
@@ -67,6 +68,7 @@ public final class PerformanceRecorderIdleBusyWait extends PerformanceRecorder {
                 t = channels[i].receive(windowIntervalMS);
                 if (t != null) {
                     notFound = false;
+                    dataSinceIdle = true;
                     ctime = t.endTime;
                     if (t.isEnd()) {
                         doWork = false;
@@ -85,11 +87,18 @@ public final class PerformanceRecorderIdleBusyWait extends PerformanceRecorder {
                         periodicRecorder.stopWindow(ctime);
                         periodicRecorder.startWindow(ctime);
                         idleWait.reset();
+                        dataSinceIdle = false;
                     }
                 }
             }
             if (doWork) {
                 if (notFound) {
+                    if (dataSinceIdle) {
+                        idleWait.startIdle(
+                                periodicRecorder.elapsedMilliSecondsWindow(
+                                        ctime));
+                        dataSinceIdle = false;
+                    }
                     if (idleWait.waitAndCheck()) {
                         ctime = time.getCurrentTime();
                         final long diffTime = periodicRecorder.elapsedMilliSecondsWindow(ctime);

--- a/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
+++ b/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
@@ -61,6 +61,14 @@ import java.util.Objects;
  * compare-and-set on every enqueue while preserving the linked-node
  * compare-and-set as the linearization point.</p>
  *
+ * <p>Producer and consumer state live in separate, manually padded holder
+ * objects to reduce false sharing. This is a best-effort layout optimization:
+ * the Java language and HotSpot do not guarantee field order or cache-line
+ * placement. The implementation deliberately avoids the internal
+ * {@code @Contended} annotation because using it would require internal-module
+ * access and JVM flags in every embedding application. Padding is not part of
+ * the correctness argument.</p>
+ *
  * <h2>Usage constraints</h2>
  * <ul>
  *     <li>Only one thread may invoke {@code poll} or {@code clear}.</li>
@@ -90,8 +98,7 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
         private long pad06;
         private TimeStampNode head;
         private TimeStampNode recoveryHead;
-        private final TimeStampNode[] retiredNodes =
-                new TimeStampNode[RETIRE_BATCH_SIZE];
+        private final TimeStampNode[] retiredNodes;
         private int retiredNodeCount;
         @SuppressWarnings("unused")
         private long pad10;
@@ -107,6 +114,10 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
         private long pad15;
         @SuppressWarnings("unused")
         private long pad16;
+
+        private HeadRef(int retireBatchSize) {
+            retiredNodes = new TimeStampNode[retireBatchSize];
+        }
     }
 
     @SuppressFBWarnings(value = "UUF_UNUSED_FIELD",
@@ -150,6 +161,7 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
 
     private final HeadRef headRef;
     private final TailRef tailRef;
+    private final int retireBatchSize;
 
     static {
         try {
@@ -168,9 +180,26 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
      * Creates an empty queue with one constant-cost sentinel node.
      */
     public TimeStampMpscQueue() {
+        this(RETIRE_BATCH_SIZE);
+    }
+
+    /**
+     * Creates an empty queue with an injectable retirement batch for
+     * concurrency-model tests.
+     *
+     * @param retireBatchSize number of consumed predecessors retired together
+     * @throws IllegalArgumentException when {@code retireBatchSize} is less
+     *                                  than one
+     */
+    TimeStampMpscQueue(int retireBatchSize) {
+        if (retireBatchSize < 1) {
+            throw new IllegalArgumentException(
+                    "Retirement batch size must be positive");
+        }
         final TimeStampNode sentinel = new TimeStampNode(0, 0, 0, 0);
-        this.headRef = new HeadRef();
+        this.headRef = new HeadRef(retireBatchSize);
         this.tailRef = new TailRef();
+        this.retireBatchSize = retireBatchSize;
         this.headRef.head = sentinel;
         this.headRef.recoveryHead = sentinel;
         this.tailRef.tail = sentinel;
@@ -194,8 +223,8 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
         headRef.head = next;
         final int retiredNodeCount = headRef.retiredNodeCount;
         headRef.retiredNodes[retiredNodeCount] = currentHead;
-        if (retiredNodeCount + 1 == RETIRE_BATCH_SIZE) {
-            retireBatch(next, RETIRE_BATCH_SIZE);
+        if (retiredNodeCount + 1 == retireBatchSize) {
+            retireBatch(next, retireBatchSize);
         } else {
             headRef.retiredNodeCount = retiredNodeCount + 1;
         }

--- a/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
+++ b/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
@@ -48,9 +48,18 @@ import java.util.Objects;
  * {@value #RETIRE_BATCH_SIZE}. The consumer release-publishes a recovery head
  * before self-linking every retired predecessor in the completed batch. A
  * producer suspended with any stale pointer detects that self-link and resumes
- * from the recovery head. This bounds obsolete linked-node retention while
- * grouping retirement stores. Nodes are deliberately not pooled: pooling
- * would retain heap, complicate ownership, and introduce ABA risks.</p>
+ * from the recovery head. Unlike JDK
+ * {@link java.util.concurrent.ConcurrentLinkedQueue}, an intrusive node cannot
+ * null a separate item reference while retaining its structural wrapper.
+ * Self-linking each retired timestamp therefore guarantees prompt payload
+ * reclamation. Nodes are deliberately not pooled: pooling would retain heap,
+ * complicate ownership, and introduce ABA risks.</p>
+ *
+ * <p>Like JDK {@link java.util.concurrent.ConcurrentLinkedQueue}, the producer
+ * tail is allowed to lag by one node. Updating the shared tail only after a
+ * producer has traversed away from its initial tail candidate avoids a tail
+ * compare-and-set on every enqueue while preserving the linked-node
+ * compare-and-set as the linearization point.</p>
  *
  * <h2>Usage constraints</h2>
  * <ul>
@@ -225,16 +234,28 @@ public final class TimeStampMpscQueue implements Queue<TimeStampNode> {
             final TimeStampNode next = (TimeStampNode) NEXT.getAcquire(current);
             if (next == null) {
                 if (NEXT.compareAndSet(current, null, newNode)) {
-                    TAIL.weakCompareAndSetRelease(
-                            tailRef, tailNode, newNode);
+                    // JDK-style slack: avoid touching the shared tail when the
+                    // initial tail candidate was already the trailing node.
+                    if (current != tailNode) {
+                        TAIL.weakCompareAndSetRelease(
+                                tailRef, tailNode, newNode);
+                    }
                     return true;
                 }
             } else if (next == current) {
-                final TimeStampNode recoveryHead =
-                        (TimeStampNode) RECOVERY_HEAD.getAcquire(headRef);
-                TAIL.weakCompareAndSetRelease(tailRef, tailNode, recoveryHead);
-                tailNode = recoveryHead;
-                current = recoveryHead;
+                final TimeStampNode latestTail =
+                        (TimeStampNode) TAIL.getAcquire(tailRef);
+                if (tailNode != latestTail) {
+                    tailNode = latestTail;
+                    current = latestTail;
+                } else {
+                    final TimeStampNode recoveryHead =
+                            (TimeStampNode) RECOVERY_HEAD.getAcquire(headRef);
+                    TAIL.weakCompareAndSetRelease(
+                            tailRef, tailNode, recoveryHead);
+                    tailNode = recoveryHead;
+                    current = recoveryHead;
+                }
             } else {
                 final TimeStampNode latestTail =
                         (TimeStampNode) TAIL.getAcquire(tailRef);

--- a/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
+++ b/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueue.java
@@ -51,9 +51,12 @@ import java.util.Objects;
  * from the recovery head. Unlike JDK
  * {@link java.util.concurrent.ConcurrentLinkedQueue}, an intrusive node cannot
  * null a separate item reference while retaining its structural wrapper.
- * Self-linking each retired timestamp therefore guarantees prompt payload
- * reclamation. Nodes are deliberately not pooled: pooling would retain heap,
- * complicate ownership, and introduce ABA risks.</p>
+ * Self-linking removes each retired timestamp from the live queue chain and
+ * enables its payload and node to be reclaimed after stale producer,
+ * tail-hint, consumer, and caller references have also disappeared. It cannot
+ * make an object collectible while any such strong reference remains. Nodes
+ * are deliberately not pooled: pooling would retain heap, complicate
+ * ownership, and introduce ABA risks.</p>
  *
  * <p>Like JDK {@link java.util.concurrent.ConcurrentLinkedQueue}, the producer
  * tail is allowed to lag by one node. Updating the shared tail only after a

--- a/perl/src/test/java/io/perl/api/impl/ElasticWaitTest.java
+++ b/perl/src/test/java/io/perl/api/impl/ElasticWaitTest.java
@@ -108,6 +108,46 @@ public class ElasticWaitTest {
     }
 
     /**
+     * Active processing between idle periods cannot dilute the measured park
+     * rate or carry completed parks into the new idle sample.
+     */
+    @Test
+    public void dataBlipStartsIndependentIdleSample() {
+        final ElasticWait wait =
+                new ElasticWait(1000, 1000, 100, ignored -> { });
+
+        assertTrue(wait.waitAndCheck());
+        wait.updateElastic(1);
+        for (int index = 0; index < 10; index++) {
+            assertFalse(wait.waitAndCheck());
+        }
+
+        wait.startIdle(101);
+
+        assertEquals(899, waitsUntilCheck(wait),
+                "Only parks after the data blip must count toward calibration");
+    }
+
+    /**
+     * An active transition during bootstrap returns to a one-park clock
+     * sample instead of retaining an incomplete exponential batch.
+     */
+    @Test
+    public void dataBlipRestartsUncalibratedSampleConservatively() {
+        final ElasticWait wait =
+                new ElasticWait(1000, 1000, 100, ignored -> { });
+
+        assertTrue(wait.waitAndCheck());
+        wait.updateElastic(0);
+        assertFalse(wait.waitAndCheck());
+
+        wait.startIdle(10);
+
+        assertTrue(wait.waitAndCheck(),
+                "Uncalibrated idle must sample the clock after one park");
+    }
+
+    /**
      * Window rotation retains the measured rate but clears all window-local
      * counters.
      */

--- a/perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java
+++ b/perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java
@@ -84,6 +84,15 @@ public class TimeStampMpscQueueTest {
     }
 
     /**
+     * Verifies that concurrency tests cannot inject an invalid batch size.
+     */
+    @Test
+    public void rejectsNonPositiveRetirementBatchSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TimeStampMpscQueue(0));
+    }
+
+    /**
      * Verifies that the queue array rejects non-intrusive timestamps.
      */
     @Test

--- a/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
@@ -71,7 +71,6 @@ import java.util.concurrent.TimeoutException;
  */
 final public class Sbk {
     final static String BANNERFILE = "banner.txt";
-    final static String CONFIGFILE = "sbk.properties";
 
     /**
      * Creates an SBK bootstrap helper.
@@ -168,8 +167,6 @@ final public class Sbk {
         final StoragePackage packageStore = new StoragePackage(sbkStoragePackageName);
         final RWLoggerPackage loggerStore = new RWLoggerPackage(sbkLoggerPackageName);
         final SbpVersion sbpVersion = Sbp.getVersion();
-        final PerlConfig perlConfig = PerlConfig.build(
-                Sbk.class.getClassLoader().getResourceAsStream(CONFIGFILE));
         final Storage<Object> storageDevice;
         final InputParameterOptions params;
         final RWLogger rwLogger;
@@ -184,7 +181,6 @@ final public class Sbk {
         Printer.log.info("{} Website: " + Config.SBK_WEBSITE_NAME, Config.NAME.toUpperCase());
         Printer.log.info("Arguments List: {}", Arrays.toString(args));
         Printer.log.info("Java Runtime Version: {}", System.getProperty("java.runtime.version"));
-        Printer.log.info("PerL Timestamp Queue: {}", perlConfig.getTimestampQueueName());
         Printer.log.info("SBP Version Major: {}, Minor: {}", sbpVersion.major, sbpVersion.minor);
         Printer.log.info("Storage Drivers Package: {}", sbkStoragePackageName);
         Printer.log.info("Logger Package: {}", sbkLoggerPackageName);
@@ -290,6 +286,18 @@ final public class Sbk {
 
         Printer.log.info("Action : {}", params.getAction().toString());
         Printer.log.info("Threads Type: {}", params.getThreadType().toString());
+        final PerlConfig perlConfig = SbkBenchmark.buildPerlConfig(params);
+        Printer.log.info("PerL Timestamp Queue: {}",
+                perlConfig.getTimestampQueueName());
+        if (perlConfig.maxQs > 0) {
+            Printer.log.info("PerL Timestamp Queue Topology: {} shared queue(s)",
+                    perlConfig.maxQs);
+        } else {
+            Printer.log.info(
+                    "PerL Timestamp Queue Topology: {} queue(s) per worker",
+                    Math.max(PerlConfig.MIN_Q_PER_WORKER,
+                            perlConfig.qPerWorker));
+        }
 
         final DataType<Object> dType = (DataType<Object>) storageDevice.getDataType();
         if (dType == null) {

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
@@ -20,6 +20,7 @@ import io.sbk.api.DataWriter;
 import io.sbk.logger.ReadRequestsLogger;
 import io.sbk.logger.WriteRequestsLogger;
 import io.sbk.params.ParameterOptions;
+import io.sbk.params.impl.SbkParameters;
 import io.sbk.api.Storage;
 import io.sbk.data.DataType;
 import io.sbk.logger.RWLogger;
@@ -68,7 +69,6 @@ import java.util.stream.IntStream;
  * </ul>
  */
 final public class SbkBenchmark implements Benchmark {
-    final private static String CONFIGFILE = "sbk.properties";
     final private static long FORCED_SHUTDOWN_GRACE_SECONDS = 3;
     final private Storage<Object> storage;
     final private DataType<Object> dType;
@@ -123,7 +123,7 @@ final public class SbkBenchmark implements Benchmark {
                 .name("sbk-benchmark-lifecycle").factory());
 
         if (params.getWritersCount() > 0 && params.getAction() == Action.Writing) {
-            PerlConfig wConfig = PerlConfig.build(SbkBenchmark.class.getClassLoader().getResourceAsStream(CONFIGFILE));
+            PerlConfig wConfig = buildPerlConfig(params);
             wConfig.workers = params.getWritersCount();
             wConfig.sleepMS = params.getIdleSleepMilliSeconds();
             wConfig.csv = false;
@@ -133,7 +133,7 @@ final public class SbkBenchmark implements Benchmark {
         }
 
         if (params.getReadersCount() > 0) {
-            PerlConfig rConfig = PerlConfig.build(SbkBenchmark.class.getClassLoader().getResourceAsStream(CONFIGFILE));
+            PerlConfig rConfig = buildPerlConfig(params);
             rConfig.workers = params.getReadersCount();
             rConfig.sleepMS = params.getIdleSleepMilliSeconds();
             rConfig.csv = false;
@@ -149,6 +149,32 @@ final public class SbkBenchmark implements Benchmark {
         readers = new ArrayList<>();
         state = State.BEGIN;
         shutdownRequested = false;
+    }
+
+    /**
+     * Build the bundled PerL configuration and apply command-line queue
+     * overrides.
+     *
+     * @param params parsed SBK parameters
+     * @return effective PerL configuration
+     * @throws IOException if the bundled configuration cannot be loaded
+     */
+    static PerlConfig buildPerlConfig(ParameterOptions params)
+            throws IOException {
+        final PerlConfig config = SbkParameters.loadPerlConfig();
+        applyMpscQueueOption(params, config);
+        return config;
+    }
+
+    /**
+     * Apply the optional timestamp queue implementation override.
+     *
+     * @param params parsed SBK parameters
+     * @param config PerL configuration to update
+     */
+    static void applyMpscQueueOption(ParameterOptions params,
+                                     PerlConfig config) {
+        config.mpscQueueEnable = params.isMpscQueueEnabled();
     }
 
     /**

--- a/sbk-api/src/main/java/io/sbk/params/Parameters.java
+++ b/sbk-api/src/main/java/io/sbk/params/Parameters.java
@@ -113,4 +113,12 @@ public interface Parameters extends ActionParameter, ThreadTypeParameter {
      * @return get idle sleep in milliseconds .
      */
     int getIdleSleepMilliSeconds();
+
+    /**
+     * Return whether PerL uses the intrusive timestamp MPSC queue.
+     *
+     * @return {@code true} for {@code TimeStampMpscQueue}; {@code false}
+     *         for the JDK concurrent linked queue
+     */
+    boolean isMpscQueueEnabled();
 }

--- a/sbk-api/src/main/java/io/sbk/params/impl/SbkParameters.java
+++ b/sbk-api/src/main/java/io/sbk/params/impl/SbkParameters.java
@@ -19,6 +19,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.ParseException;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * Parses and exposes common SBK benchmark parameters.
  *
@@ -37,6 +40,11 @@ import org.apache.commons.cli.ParseException;
 @Slf4j
 public sealed class SbkParameters extends SbkInputOptions implements InputParameterOptions
         permits SbkDriversParameters {
+
+    /** CLI option selecting the intrusive or JDK timestamp queue. */
+    public static final String MPSC_QUEUE_OPTION = "mpscqueue";
+
+    private static final String CONFIG_FILE = "sbk.properties";
 
     @Getter
     final private int timeoutMS;
@@ -83,6 +91,8 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
     @Getter
     private int idleSleepMilliSeconds;
 
+    @Getter
+    private boolean mpscQueueEnabled;
 
     /**
      * Construct parameters with the given benchmark name and description.
@@ -95,6 +105,9 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
         super(name, desc);
         this.timeoutMS = PerlConfig.DEFAULT_TIMEOUT_MS;
         this.action = Action.Reading;
+        final PerlConfig perlDefaults = loadPerlDefaults();
+        this.mpscQueueEnabled = perlDefaults.mpscQueueEnable;
+        validatePerlQueueTopology(perlDefaults);
 
         addOption("writers", true, "Number of writers");
         addOption("readers", true, "Number of readers");
@@ -132,6 +145,10 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
         addOption("millisecsleep", true, "Idle sleep in milliseconds; default: 0 ms");
         addOption("thread", true,
                 "Thread Type [p: platform, f: fork-join, v: virtual], default: v");
+        addOption(MPSC_QUEUE_OPTION, true,
+                ("PerL timestamp queue [true: TimeStampMpscQueue,%n"
+                        + "false: JDK ConcurrentLinkedQueue];%n"
+                        + "default: %s").formatted(this.mpscQueueEnabled));
     }
 
     /**
@@ -189,6 +206,7 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
         readersStep = Integer.parseInt(getOptionValue("rstep", "1"));
         readersStepSeconds = Integer.parseInt(getOptionValue("rsec", "0"));
         idleSleepMilliSeconds = Integer.parseInt(getOptionValue("millisecsleep", "0"));
+        parseMpscQueueOption();
 
         int workersCnt = writersCount;
         if (workersCnt == 0) {
@@ -230,5 +248,56 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
             default -> ThreadType.Platform;
         };
 
+    }
+
+    private void parseMpscQueueOption() {
+        final String queueEnabled = getOptionValue(MPSC_QUEUE_OPTION,
+                Boolean.toString(mpscQueueEnabled));
+        if (!"true".equalsIgnoreCase(queueEnabled)
+                && !"false".equalsIgnoreCase(queueEnabled)) {
+            throw new IllegalArgumentException("Error: The option '-"
+                    + MPSC_QUEUE_OPTION + "' must be true or false");
+        }
+        mpscQueueEnabled = Boolean.parseBoolean(queueEnabled);
+    }
+
+    private static void validatePerlQueueTopology(PerlConfig config) {
+        if (config.maxQs < 0) {
+            throw new IllegalArgumentException(
+                    "Error: sbk.properties maxQs must be zero or greater");
+        }
+
+        if (config.qPerWorker < PerlConfig.MIN_Q_PER_WORKER) {
+            throw new IllegalArgumentException(
+                    "Error: sbk.properties qPerWorker must be at least "
+                    + PerlConfig.MIN_Q_PER_WORKER);
+        }
+    }
+
+    private static PerlConfig loadPerlDefaults() {
+        try {
+            return loadPerlConfig();
+        } catch (IOException exception) {
+            throw new IllegalStateException(
+                    "Unable to load PerL defaults from " + CONFIG_FILE,
+                    exception);
+        }
+    }
+
+    /**
+     * Load the PerL defaults bundled with the SBK application.
+     *
+     * @return property-backed PerL configuration
+     * @throws IOException if {@code sbk.properties} is missing or invalid
+     */
+    public static PerlConfig loadPerlConfig() throws IOException {
+        final InputStream inputStream = SbkParameters.class.getClassLoader()
+                .getResourceAsStream(CONFIG_FILE);
+        if (inputStream == null) {
+            throw new IOException("Missing classpath resource: " + CONFIG_FILE);
+        }
+        try (inputStream) {
+            return PerlConfig.build(inputStream);
+        }
     }
 }

--- a/sbk-api/src/main/java/io/sbk/params/impl/SbkParameters.java
+++ b/sbk-api/src/main/java/io/sbk/params/impl/SbkParameters.java
@@ -160,13 +160,17 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
         this(name, Config.DESC);
     }
 
-
-    @Override
     /**
      * Parse SBK core options and compute derived values (e.g., recordsPerSec, totalSecondsToRun).
      * Validates required combinations (e.g., at least one of writers/readers must be > 0).
      * May throw {@link HelpException} via the superclass when help is requested.
+     *
+     * @param args command-line arguments to parse
+     * @throws ParseException if an option cannot be parsed
+     * @throws IllegalArgumentException if an option value or combination is invalid
+     * @throws HelpException if help was requested
      */
+    @Override
     public void parseArgs(String[] args) throws ParseException, IllegalArgumentException, HelpException {
         super.parseArgs(args);
         final boolean writeReadOnly = Boolean.parseBoolean(getOptionValue("ro", "false"));
@@ -179,6 +183,10 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
 
         totalRecords = Long.parseLong(getOptionValue("records", "0"));
         recordSize = Integer.parseInt(getOptionValue("size", "0"));
+        if (recordSize <= 0) {
+            throw new IllegalArgumentException(
+                    "Error: The record 'size' must be greater than zero");
+        }
         int syncRecords = Integer.parseInt(getOptionValue("sync", "0"));
         if (syncRecords > 0) {
             recordsPerSync = syncRecords;
@@ -223,12 +231,6 @@ public sealed class SbkParameters extends SbkInputOptions implements InputParame
             recordsPerSec = (int) (((throughput * 1024 * 1024) / recordSize) / workersCnt);
         } else {
             recordsPerSec = 0;
-        }
-
-        if (workersCnt > 0) {
-            if (recordSize == 0) {
-                throw new IllegalArgumentException("Error: Must specify the record 'size'");
-            }
         }
 
         if (writersCount > 0 && readersCount > 0) {

--- a/sbk-api/src/test/java/io/sbk/api/impl/SbkPerlConfigTest.java
+++ b/sbk-api/src/test/java/io/sbk/api/impl/SbkPerlConfigTest.java
@@ -11,11 +11,14 @@
 package io.sbk.api.impl;
 
 import io.perl.config.PerlConfig;
+import io.sbk.params.impl.SbkParameters;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,5 +41,54 @@ public class SbkPerlConfigTest {
             assertTrue(PerlConfig.build(inputStream).mpscQueueEnable,
                     "SBK must enable the optimized timestamp MPSC queue");
         }
+    }
+
+    /**
+     * Verifies that command-line options override all timestamp queue
+     * properties for one benchmark without rebuilding the distribution.
+     *
+     * @throws Exception if parameters or configuration cannot be parsed
+    */
+    @Test
+    public void commandLineOverridesTimestampQueueImplementation()
+            throws Exception {
+        final PerlConfig expected = SbkParameters.loadPerlConfig();
+        final SbkParameters parameters =
+                new SbkParameters("queue-config-test");
+        parameters.parseArgs(new String[]{
+                "-writers", "1", "-size", "1",
+                "-mpscqueue", "false"
+        });
+
+        final PerlConfig config = SbkBenchmark.buildPerlConfig(parameters);
+
+        assertFalse(config.mpscQueueEnable);
+        assertEquals(expected.maxQs, config.maxQs);
+        assertEquals(expected.qPerWorker, config.qPerWorker);
+        assertEquals("ConcurrentLinkedQueue (JDK)",
+                config.getTimestampQueueName());
+    }
+
+    /**
+     * Verifies that omitting queue options preserves every value loaded from
+     * {@code sbk.properties} in the effective benchmark configuration.
+     *
+     * @throws Exception if parameters or configuration cannot be loaded
+     */
+    @Test
+    public void propertyDefaultsReachBenchmarkConfiguration()
+            throws Exception {
+        final PerlConfig expected = SbkParameters.loadPerlConfig();
+        final SbkParameters parameters =
+                new SbkParameters("queue-default-test");
+        parameters.parseArgs(new String[]{
+                "-writers", "1", "-size", "1"
+        });
+
+        final PerlConfig actual = SbkBenchmark.buildPerlConfig(parameters);
+
+        assertEquals(expected.mpscQueueEnable, actual.mpscQueueEnable);
+        assertEquals(expected.maxQs, actual.maxQs);
+        assertEquals(expected.qPerWorker, actual.qPerWorker);
     }
 }

--- a/sbk-api/src/test/java/io/sbk/params/impl/SbkParametersPerlQueueTest.java
+++ b/sbk-api/src/test/java/io/sbk/params/impl/SbkParametersPerlQueueTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.params.impl;
+
+import io.perl.config.PerlConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests common command-line options controlling the PerL timestamp queue.
+ */
+public final class SbkParametersPerlQueueTest {
+
+    /**
+     * Accept the JDK queue implementation as an explicit override.
+     *
+     * @throws Exception if the valid option cannot be parsed
+    */
+    @Test
+    public void parsesTimestampQueueOverride() throws Exception {
+        final SbkParameters parameters = parse(
+                "-mpscqueue", "false");
+
+        assertEquals("false", parameters.getOptionValue("mpscqueue"));
+        assertFalse(parameters.isMpscQueueEnabled());
+    }
+
+    /**
+     * Load initial option values from sbk.properties and include the concrete
+     * values in CLI help.
+     *
+     * @throws Exception if the property-backed defaults cannot be parsed
+     */
+    @Test
+    public void usesPropertyBackedDefaultsInParametersAndHelp()
+            throws Exception {
+        final PerlConfig expected = SbkParameters.loadPerlConfig();
+        final SbkParameters parameters = parse();
+
+        assertEquals(expected.mpscQueueEnable,
+                parameters.isMpscQueueEnabled());
+
+        final String helpText = parameters.getHelpText()
+                .replaceAll("\\s+", " ");
+        assertTrue(helpText.contains("default: "
+                + expected.mpscQueueEnable), helpText);
+        assertFalse(helpText.contains("-timestampqueues"), helpText);
+        assertFalse(helpText.contains("-qperworker"), helpText);
+    }
+
+    /**
+     * Reject values that Boolean.parseBoolean would otherwise silently map
+     * to false.
+     */
+    @Test
+    public void rejectsInvalidQueueSelection() {
+        assertThrows(IllegalArgumentException.class,
+                () -> parse("-mpscqueue", "yes"));
+    }
+
+    private static SbkParameters parse(String... queueArgs)
+            throws Exception {
+        final String[] args = new String[queueArgs.length + 4];
+        args[0] = "-writers";
+        args[1] = "1";
+        args[2] = "-size";
+        args[3] = "1";
+        System.arraycopy(queueArgs, 0, args, 4, queueArgs.length);
+        final SbkParameters parameters =
+                new SbkParameters("perl-queue-test");
+        parameters.parseArgs(args);
+        return parameters;
+    }
+}

--- a/sbk-api/src/test/java/io/sbk/params/impl/SbkParametersRecordSizeTest.java
+++ b/sbk-api/src/test/java/io/sbk/params/impl/SbkParametersRecordSizeTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.params.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests validation of the common SBK record-size option.
+ */
+public final class SbkParametersRecordSizeTest {
+
+    /**
+     * Reject zero before a driver or throughput calculation uses the size.
+     */
+    @Test
+    public void rejectsZeroRecordSize() {
+        assertInvalidSize("0");
+    }
+
+    /**
+     * Reject negative sizes as parameter errors rather than allowing a later
+     * {@link NegativeArraySizeException}.
+     */
+    @Test
+    public void rejectsNegativeRecordSize() {
+        assertInvalidSize("-1");
+    }
+
+    /**
+     * Continue accepting positive record sizes.
+     *
+     * @throws Exception if valid arguments cannot be parsed
+     */
+    @Test
+    public void acceptsPositiveRecordSize() throws Exception {
+        final SbkParameters parameters = new SbkParameters("record-size-test");
+
+        parameters.parseArgs(arguments("128"));
+
+        assertEquals(128, parameters.getRecordSize());
+    }
+
+    private static void assertInvalidSize(String size) {
+        final SbkParameters parameters = new SbkParameters("record-size-test");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> parameters.parseArgs(arguments(size)));
+    }
+
+    private static String[] arguments(String size) {
+        return new String[]{
+            "-writers", "1", "-size", size, "-records", "1"
+        };
+    }
+}

--- a/settings-drivers.gradle
+++ b/settings-drivers.gradle
@@ -35,6 +35,7 @@ include 'drivers:rocksdb'
 include 'drivers:couchdb'
 include 'drivers:hive'
 include 'drivers:null'
+include 'drivers:perlbench'
 include 'drivers:sqlite'
 include 'drivers:mysql'
 include 'drivers:mariadb'
@@ -66,4 +67,3 @@ include 'drivers:chromadb'
 include 'drivers:solr'
 /* include 'drivers:sbktemplate' */
 /* above line is a signature */
-


### PR DESCRIPTION
## Summary
- add a research-oriented TimeStampMpscQueue architecture guide with 16 Mermaid diagrams
- explain intrusive TimeStampNode representation, producer and consumer algorithms, linearization points, VarHandle memory ordering, batched retirement, and stale-producer recovery
- compare TimeStampMpscQueue with JDK 25 ConcurrentLinkedQueue by allocation model, API scope, progress properties, reclamation, and workload fit
- document correctness evidence, experimental methodology, limitations, threats to validity, and 17 primary/platform references
- cross-link the guide from the documentation index, SBK internals, and PerL README

## Performance evidence
Measured on a 16-vCPU VMware VM with JDK 25.0.2, JMH 1.37, ZGC, and compact object headers:
- round-trip latency: 34.208 ns/op versus 47.107 ns/op (27.38% lower)
- allocation: 40 B/op versus 56 B/op (28.57% lower)
- contended producer throughput: 5,406,094 versus 5,557,486 ops/s

The producer-throughput confidence intervals overlapped and the local point estimate was 2.72% lower, so the guide explicitly avoids claiming universal throughput superiority. The dedicated performance task collected the evidence but did not satisfy its 2% throughput-win policy gate on this host.

## Validation
- all 16 Mermaid diagrams rendered with Mermaid CLI 11.12.0
- `./gradlew check`
- `./gradlew installDist`
- installed Null-driver smoke benchmark
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-mpscqueue true|false` to select the intrusive timestamp MPSC queue or the JDK concurrent queue.
  * Introduced the `PerlBench` synthetic driver for end-to-end queue pipeline comparison (no storage I/O).
* **Documentation**
  * Published expanded research/benchmark and usage guides for queue selection, topology behavior, and `PerlBench`.
* **Bug Fixes**
  * Improved timestamp-queue recovery/retirement behavior and refined idle/data-blip calibration for more reliable measurements.
* **Tests**
  * Added/extended unit, stress, and configuration-override tests covering `-mpscqueue` selection, recovery scenarios, and retirement-batch validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->