### PR TITLE
Add typed timestamp queue insertion path

### DIFF
--- a/perl/src/main/java/io/perl/api/impl/CQueuePerl.java
+++ b/perl/src/main/java/io/perl/api/impl/CQueuePerl.java
@@ -282,7 +282,7 @@ final public class CQueuePerl implements Perl {
          */
         @Override
         public void sendEndTime(long endTime) {
-            add(0, new TimeStampNode(endTime));
+            addNode(0, new TimeStampNode(endTime));
         }
 
         @Override
@@ -316,7 +316,7 @@ final public class CQueuePerl implements Perl {
                 if (this.wIndex >= maxQs) {
                     this.wIndex = 0;
                 }
-                add(this.wIndex,
+                addNode(this.wIndex,
                         new TimeStampNode(
                                 startTime, endTime, records, bytes));
             }

--- a/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueueArray.java
+++ b/perl/src/main/java/io/perl/api/impl/TimeStampMpscQueueArray.java
@@ -16,9 +16,11 @@ import io.perl.api.TimeStampNode;
 /**
  * Array of intrusive MPSC queues used by optimized PerL channels.
  *
- * <p>Every element supplied to {@link #add(int, TimeStamp)} must be a
- * single-use {@link TimeStampNode}. Each indexed queue accepts multiple
- * producers and has exactly one consumer.</p>
+ * <p>The measurement hot path supplies single-use nodes through
+ * {@link #addNode(int, TimeStampNode)}. The generic
+ * {@link #add(int, TimeStamp)} method retains the {@link QueueArray}
+ * compatibility contract and validates its input type. Each indexed queue
+ * accepts multiple producers and has exactly one consumer.</p>
  */
 public class TimeStampMpscQueueArray implements QueueArray<TimeStamp> {
     private final TimeStampMpscQueue[] queues;
@@ -61,6 +63,21 @@ public class TimeStampMpscQueueArray implements QueueArray<TimeStamp> {
             throw new IllegalArgumentException(
                     "TimeStampMpscQueueArray accepts only TimeStampNode");
         }
+        return addNode(index, node);
+    }
+
+    /**
+     * Adds a timestamp node without a runtime type check.
+     *
+     * <p>PerL measurement producers use this typed path because they construct
+     * {@link TimeStampNode} instances directly.</p>
+     *
+     * @param index index of the queue receiving the node
+     * @param node single-use timestamp node to enqueue
+     * @return {@code true} after the node is linked
+     * @throws NullPointerException if {@code node} is {@code null}
+     */
+    public boolean addNode(int index, TimeStampNode node) {
         return queues[index].add(node);
     }
 

--- a/perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java
+++ b/perl/src/test/java/io/perl/api/impl/TimeStampMpscQueueTest.java
@@ -105,6 +105,20 @@ public class TimeStampMpscQueueTest {
     }
 
     /**
+     * Verifies that the typed queue-array path accepts and returns the same
+     * intrusive timestamp node.
+     */
+    @Test
+    public void queueArrayTypedPathReturnsSameNode() {
+        final TimeStampMpscQueueArray queues =
+                new TimeStampMpscQueueArray(1);
+        final TimeStampNode node = node(1, 2);
+
+        assertTrue(queues.addNode(0, node));
+        assertSame(node, queues.poll(0));
+    }
+
+    /**
      * Verifies that the fallback channel retains the JDK queue data path.
      */
     @Test


### PR DESCRIPTION
## Summary

- Add `TimeStampMpscQueueArray.addNode(int, TimeStampNode)` as a typed intrusive-queue insertion path.
- Route regular PerL measurements and benchmark end markers through the typed method.
- Retain `QueueArray<TimeStamp>.add(...)` for compatibility and validation of external callers.
- Add a focused identity test for the typed path.

## Performance rationale

The optimized PerL producer already creates a `TimeStampNode`. Previously, every measurement passed it through `add(int, TimeStamp)`, which executed an `instanceof TimeStampNode` check before enqueueing. The typed path removes that redundant runtime type check from the measurement hot path while preserving the checked generic API.

## Validation

- `./gradlew :perl:test --tests io.perl.api.impl.TimeStampMpscQueueTest`
- `./gradlew :perl:check`
- `./gradlew check installDist`
- `./build/install/sbk/bin/sbk -class perlbench -writers 2 -records 100000 -size 100 -out SystemLogger`

The PerlBench smoke test completed exactly 100,000 records with zero invalid latencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved timestamp queue insertion efficiency by using a typed insertion path for internal timestamp nodes.

* **Bug Fixes**
  * Preserved timestamp node identity when adding and retrieving entries through the queue array.

* **Tests**
  * Added coverage confirming typed queue insertion returns the original node instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->