### PR TITLE
Optimize sparse latency recording and percentile extraction

### DIFF
--- a/docs/LATENCY_RECORDERS.md
+++ b/docs/LATENCY_RECORDERS.md
@@ -567,9 +567,9 @@ The boxed representation retains:
 
 It additionally allocates temporary wrappers during updates. Exact retained
 bytes depend on JVM object layout, compressed references, table capacity,
-counts, and whether wrapper-cache values are reused. The JMH allocation result
-of 47.858 B/update is therefore a stronger observed statement than a universal
-retained-byte formula.
+counts, and whether wrapper-cache values are reused. The documented JMH run's
+allocation result of 47.855 B/update is therefore a stronger observed
+statement than a universal retained-byte formula.
 
 ### 9.4 Configured budget versus actual heap
 

--- a/docs/LATENCY_RECORDERS.md
+++ b/docs/LATENCY_RECORDERS.md
@@ -1,0 +1,845 @@
+<!--
+Copyright (c) KMG. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Exact latency recorders in PerL: architecture, memory, and performance
+
+- **System:** Storage Benchmark Kit (SBK) 10.4, Performance Logger (PerL)
+- **Runtime:** JDK 25
+- **Evaluation date:** 2026-07-29
+- **Implementations:** `ArrayLatencyRecorder`, `HashMapLatencyRecorder`,
+  `LongHashMapLatencyRecorder`
+- **Keywords:** exact percentiles, dense histogram, sparse histogram,
+  primitive hash map, boxing, garbage collection, JMH, latency benchmarking
+
+## Abstract
+
+PerL retains every valid integer latency as an exact frequency distribution.
+It does not sample observations. The storage structure behind that
+distribution therefore affects the benchmarker's own CPU consumption, heap
+footprint, garbage production, cache locality, and the delay required to
+produce periodic percentiles.
+
+This paper studies PerL's three exact recorders:
+
+- `ArrayLatencyRecorder` is a dense histogram. A latency is translated
+  directly into an array index.
+- `HashMapLatencyRecorder` is a sparse reference implementation backed by JDK
+  `HashMap<Long, Long>`. It is retained for equivalence tests and performance
+  comparison, but is no longer selected by the production builder.
+- `LongHashMapLatencyRecorder` is the production sparse implementation backed
+  by Eclipse Collections `LongLongHashMap`. It stores primitive keys and
+  counts, and reuses its percentile sorting buffer.
+
+On the measured 16-vCPU Intel Xeon Platinum 8462Y+ virtual machine, JDK 25.0.2
+with ZGC and compact object headers, a 4,096-value update workload produced:
+
+| Recorder | Updates/second | Allocation/update |
+|---|---:|---:|
+| `ArrayLatencyRecorder` | 561.9 million | effectively 0 B |
+| `LongHashMapLatencyRecorder` | 439.0 million | 0.001 B |
+| `HashMapLatencyRecorder` | 64.6 million | 47.855 B |
+
+The array delivered 28.0% higher throughput than the primitive map for this
+dense bounded workload. The primitive map delivered 580.0% higher throughput
+than the boxed map and removed
+effectively all hot-path allocation. These are measurements of one controlled
+environment, not universal constants. The portable conclusions are
+structural: array indexing avoids hashing; primitive storage avoids boxing;
+and a reusable primitive sorting buffer avoids a large allocation on every
+percentile extraction.
+
+## 1. Research questions
+
+This study answers six questions:
+
+1. How does each recorder represent the exact latency distribution?
+2. Which work happens for every completed storage operation?
+3. Which work happens only at a reporting-window boundary?
+4. How do latency range and number of distinct observed values affect memory?
+5. When should PerL select a dense array or sparse primitive map?
+6. Which performance statements are architectural facts, and which are
+   environment-sensitive measurements?
+
+The authoritative source files are:
+
+- [`ArrayLatencyRecorder.java`](../perl/src/main/java/io/perl/api/impl/ArrayLatencyRecorder.java)
+- [`MapLatencyRecorder.java`](../perl/src/main/java/io/perl/api/impl/MapLatencyRecorder.java)
+- [`HashMapLatencyRecorder.java`](../perl/src/main/java/io/perl/api/impl/HashMapLatencyRecorder.java)
+- [`LongHashMapLatencyRecorder.java`](../perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java)
+- [`PerlBuilder.java`](../perl/src/main/java/io/perl/api/impl/PerlBuilder.java)
+
+## 2. Position in the SBK measurement pipeline
+
+Benchmark workers do not update the latency distribution directly. They send
+completed timestamps through a PerL channel. One recorder thread consumes the
+timestamps and owns both the periodic and whole-run latency windows.
+
+```mermaid
+flowchart LR
+    W1["Writer or reader 1"] --> Q["PerL timestamp queues"]
+    W2["Writer or reader 2"] --> Q
+    WN["Writer or reader N"] --> Q
+    Q --> C["Single PerL consumer"]
+    C --> V{"Latency valid and<br/>inside configured range?"}
+    V -->|no| D["Increment invalid or<br/>discard counter"]
+    V -->|yes| R["Exact latency recorder"]
+    R --> P["Periodic percentile extraction"]
+    P --> L["System, CSV, Prometheus,<br/>Web, or gRPC logger"]
+
+    classDef producer fill:#dbeafe,stroke:#1d4ed8,color:#000
+    classDef consumer fill:#dcfce7,stroke:#166534,color:#000
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#000
+    class W1,W2,WN producer
+    class C,R,P consumer
+    class V decision
+```
+
+This ownership model is essential: all three recorders are deliberately
+`@NotThreadSafe`. The queues provide cross-thread publication; the consumer
+alone mutates a recorder. Adding atomic counters or locks inside the recorder
+would add overhead without improving correctness under the intended topology.
+
+## 3. Shared semantics
+
+All three classes extend `LatencyRecordWindow`. They share the same validation
+and accounting implemented by the `LatencyRecorder`/`LatencyWindow` hierarchy:
+
+- total records and bytes;
+- total accumulated latency;
+- minimum and maximum valid latency;
+- invalid latency records;
+- records below `lowLatency`;
+- records above `highLatency`;
+- overflow based on configured total limits.
+
+The normal call is:
+
+```text
+recordLatency(startTime, events, bytes, latency)
+    |
+    +-- record(events, bytes, latency)
+    |       |
+    |       +-- update totals
+    |       +-- classify invalid / lower / higher
+    |       +-- return true only for a valid in-range latency
+    |
+    +-- reportLatency(latency, events)
+            |
+            +-- update exact frequency bucket
+```
+
+`events` is the frequency increment. A single timing observation can represent
+more than one record, so the distribution stores `latency -> record count`,
+not merely `latency -> number of method calls`.
+
+### 3.1 Exact percentile calculation
+
+At the end of a window, each implementation emits latency/count pairs in
+ascending latency order. `LatencyPercentiles` walks their cumulative counts:
+
+```mermaid
+flowchart TB
+    B1["100 ns x 4 records"] --> C1["Cumulative interval 0..4"]
+    B2["105 ns x 7 records"] --> C2["Cumulative interval 4..11"]
+    B3["110 ns x 6 records"] --> C3["Cumulative interval 11..17"]
+    C1 --> X["Locate configured percentile indexes"]
+    C2 --> X
+    C3 --> X
+    X --> O["Exact integer-bucket percentile values"]
+```
+
+No recorder approximates an accepted integer latency. Precision is determined
+by the configured time unit and the inclusive `[lowLatency, highLatency]`
+range. Values outside that range are counted explicitly but do not enter the
+percentile distribution.
+
+### 3.2 Lifecycle invariant
+
+The production lifecycle is:
+
+```text
+startWindow -> record many values -> copyPercentiles -> reset -> startWindow
+```
+
+`copyPercentiles()` consumes the current distribution. The array implementation
+zeros each visited non-empty slot during extraction. The map implementations
+clear their maps after extraction. `reset()` resets common counters and window
+time.
+
+This order matters. `ArrayLatencyRecorder.reset()` does not scan and clear its
+entire backing array; doing so would turn every reset into an `O(range)` memory
+write. Code that bypasses the production lifecycle must extract before reusing
+the array window.
+
+## 4. `ArrayLatencyRecorder`
+
+### 4.1 Representation
+
+For inclusive bounds `L` and `H`, the recorder allocates:
+
+```text
+slot count R = H - L + 1
+counter bytes = 8R
+index(latency) = latency - L
+```
+
+```mermaid
+flowchart LR
+    LAT["Observed latency = 105"] --> SUB["105 - lowLatency 100"]
+    SUB --> IDX["index = 5"]
+    IDX --> A["latencies[5] += count"]
+    A --> RANGE["Update minIndex / maxIndex"]
+```
+
+The dense layout contains no keys. The array position is the key:
+
+```text
+lowLatency = 100
+
+array index       0    1    2    3    4    5    6   ...   10
+latency value   100  101  102  103  104  105  106   ...  110
+record count      4    0    0    0    0    7    0   ...    6
+```
+
+### 4.2 Hot path
+
+For each valid measurement:
+
+1. subtract `lowLatency`;
+2. update `minIndex` and `maxIndex`;
+3. increment one `long` array element.
+
+There is no hash calculation, collision probe, object allocation, pointer
+chase, or resize.
+
+### 4.3 Extraction
+
+The recorder scans from the smallest observed index to the largest observed
+index. For each non-zero slot it:
+
+1. reconstructs the latency as `index + lowLatency`;
+2. feeds the bucket into `LatencyPercentiles`;
+3. optionally copies it to another recorder;
+4. zeros that slot.
+
+The `minIndex`/`maxIndex` bounds avoid scanning unused prefixes and suffixes.
+They do not avoid holes inside the observed span.
+
+### 4.4 Best use cases
+
+Use the array when:
+
+- the configured latency range is small enough to allocate safely;
+- values are dense or the observed minimum-to-maximum span is narrow;
+- update latency is more important than minimizing fixed memory;
+- the time unit is milliseconds or another naturally bounded unit;
+- predictable zero-allocation updates are required.
+
+Avoid it when:
+
+- nanosecond bounds span millions or billions of possible values;
+- observed values are sparse across a very wide range;
+- the fixed array would consume a large fraction of heap;
+- empty holes between minimum and maximum would dominate extraction time.
+
+### 4.5 Important API constraint
+
+`recordLatency()` validates the configured bounds before indexing and is the
+normal safe API. Direct callers of `reportLatency()` must provide an in-range
+value. The current direct method checks the upper index but not a negative
+index; a latency below `lowLatency` can therefore cause a negative array
+access. Production input reaches it only after validation or through
+compatible recorder-to-recorder aggregation.
+
+## 5. `HashMapLatencyRecorder`
+
+### 5.1 Representation
+
+`HashMapLatencyRecorder` supplies `new HashMap<Long, Long>()` to
+`MapLatencyRecorder`:
+
+```mermaid
+flowchart LR
+    L["primitive latency"] --> BK["box Long key"]
+    BK --> H["HashMap bucket / node"]
+    C["primitive count"] --> BV["box Long value"]
+    BV --> H
+    H --> E["Long key -> Long count"]
+```
+
+JDK `HashMap` provides expected constant-time `get` and `put` with a suitable
+hash distribution. Iteration costs are proportional to capacity plus size,
+and its default load factor is 0.75. See the
+[JDK 25 `HashMap` specification](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/HashMap.html).
+
+### 5.2 Hot path
+
+```java
+Long value = latencies.get(latency);
+if (value == null) {
+    latencies.put(latency, count);
+} else {
+    latencies.replace(latency, value + count);
+}
+```
+
+Generic `Map<Long, Long>` requires boxing. For latencies and counts outside
+the small wrapper cache, an update can allocate temporary key wrappers and a
+replacement value wrapper. The map also retains a node and key object for
+each distinct latency.
+
+The measured steady update workload allocated 47.855 bytes per operation.
+At 64.6 million updates/second this corresponded to approximately 2.9 GB/s of
+allocation in JMH, producing 36 observed ZGC collections across the measured
+forks.
+
+Compact object headers reduce the size of many Java objects, but do not remove
+the wrappers or map nodes. SBK enables the JDK 25 product feature
+`-XX:+UseCompactObjectHeaders`; see
+[JEP 519](https://openjdk.org/jeps/519).
+
+### 5.3 Extraction
+
+The boxed map creates a sorted stream over its key set:
+
+```text
+key set -> boxed stream -> sort -> iterator -> map lookup per key
+```
+
+This produces ascending exact buckets, but sorting is `O(D log D)` for `D`
+distinct latencies and creates temporary stream/sorting machinery. The map is
+cleared after extraction.
+
+### 5.4 Current role
+
+`HashMapLatencyRecorder` is useful as:
+
+- a readable correctness oracle;
+- an equivalence-test baseline;
+- a benchmark baseline demonstrating boxing cost;
+- a compatibility reference for the primitive implementation.
+
+It is not selected by `PerlBuilder` in production. For a sparse exact window,
+the builder selects `LongHashMapLatencyRecorder`.
+
+## 6. `LongHashMapLatencyRecorder`
+
+### 6.1 Representation
+
+The recorder uses Eclipse Collections 13.0.0 `LongLongHashMap`. Keys and
+values reside in one interleaved primitive array:
+
+```text
+keysValues:
++--------+--------+--------+--------+--------+--------+
+| key 0  | value 0| key 1  | value 1| key 2  | value 2|
++--------+--------+--------+--------+--------+--------+
+```
+
+The implementation uses open addressing and linear probing. It grows before
+the table exceeds approximately 50% occupancy. Latencies `0` and `1` are
+handled as sentinel keys by the collection implementation.
+
+```mermaid
+flowchart LR
+    L["primitive long latency"] --> HASH["spread and mask"]
+    HASH --> SLOT{"table slot"}
+    SLOT -->|same key| ADD["addToValue(count)"]
+    SLOT -->|empty| PUT["write primitive key and count"]
+    SLOT -->|collision| PROBE["linear probe"]
+    PROBE --> SLOT
+```
+
+No `Long` wrapper, entry node, or replacement value object is required.
+
+### 6.2 Hot path
+
+```java
+long value = latencies.get(latency);
+if (value == 0) {
+    latencies.put(latency, count);
+} else {
+    latencies.addToValue(latency, count);
+}
+```
+
+SBK supplies positive record counts. Under that invariant, zero means
+"missing" for the recorder's update path. A general-purpose caller that stores
+zero or negative bucket counts would violate this assumption.
+
+The measured update path reached 438.8 million operations/second and allocated
+0.001 B/op, effectively eliminating the boxed map's hot-path garbage.
+
+### 6.3 Reusable percentile sorting buffer
+
+Hash iteration is not ordered, so exact percentile calculation still needs
+sorted keys. The recorder keeps a `long[] sortedLatencies`:
+
+```mermaid
+flowchart TB
+    M["Primitive hash table with D keys"] --> SIZE["Read D"]
+    SIZE --> CAP{"sorting buffer capacity >= D?"}
+    CAP -->|no| GROW["Allocate one larger long array"]
+    CAP -->|yes| REUSE["Reuse existing array"]
+    GROW --> COPY["Copy primitive keys"]
+    REUSE --> COPY
+    COPY --> SORT["Arrays.sort(buffer, 0, D)"]
+    SORT --> WALK["Walk sorted keys and cumulative counts"]
+    WALK --> CLEAR["Clear primitive table; retain capacity"]
+```
+
+The buffer grows only when a window exceeds the previous high-water mark. It
+is reused by later windows. This converts extraction from repeated
+`O(D)` temporary allocation to retained `O(Dmax)` storage.
+
+For 65,536 keys, the measured comparison was:
+
+| Extraction mechanism | Time | Allocation |
+|---|---:|---:|
+| Allocating primitive sorted list | 320.282 us | 524,379 B |
+| Reusable primitive array | 173.992 us | 49.701 B |
+
+The reusable array reduced measured extraction time by 45.7% and allocation
+by 99.99% in this environment.
+
+### 6.4 Clear and retention behavior
+
+`LongLongHashMap.clear()` fills its complete backing array with zeros. It does
+not shrink the table. This has two intentional effects:
+
+- later windows reuse capacity without rehash/resizing allocation;
+- a single unusually large window establishes a retained memory high-water
+  mark.
+
+`copyPercentiles()` clears the map. The subsequent `reset()` checks
+`notEmpty()` before clearing, avoiding a second full-array fill over an
+already-empty large table.
+
+### 6.5 Best use cases
+
+Use the primitive map when:
+
+- the configured latency range is too large for a dense array;
+- nanosecond or microsecond measurements produce sparse exact values;
+- the whole-run window may contain a large but sparse distribution;
+- fixed memory proportional to the entire theoretical range is unacceptable;
+- exact values are required and approximate histograms are not acceptable.
+
+## 7. Builder selection and production roles
+
+`PerlBuilder.buildLatencyRecordWindow()` estimates the dense-array payload:
+
+```text
+estimated bytes = (highLatency - lowLatency) * 8
+```
+
+If the estimate is below `maxArraySizeMB` and the range is indexable by an
+integer, it chooses `ArrayLatencyRecorder`. Otherwise it chooses
+`LongHashMapLatencyRecorder`.
+
+```mermaid
+flowchart TD
+    INPUT["lowLatency, highLatency,<br/>maxArraySizeMB"] --> RANGE["range = high - low"]
+    RANGE --> FIT{"range x 8 fits array budget<br/>and range < Integer.MAX_VALUE?"}
+    FIT -->|yes| ARRAY["Periodic window:<br/>ArrayLatencyRecorder"]
+    FIT -->|no| PRIMITIVE["Periodic window:<br/>LongHashMapLatencyRecorder"]
+    TOTAL["Whole-run window"] --> PRIMITIVE_TOTAL["Always LongHashMapLatencyRecorder"]
+
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#000
+    classDef dense fill:#dcfce7,stroke:#166534,color:#000
+    classDef sparse fill:#dbeafe,stroke:#1d4ed8,color:#000
+    class FIT decision
+    class ARRAY dense
+    class PRIMITIVE,PRIMITIVE_TOTAL sparse
+```
+
+Default memory configuration:
+
+```properties
+maxArraySizeMB=64
+maxHashMapSizeMB=192
+totalMaxHashMapSizeMB=256
+```
+
+The periodic window may therefore use an array, while the whole-run window
+uses the primitive map to avoid reserving memory for the full theoretical
+latency range.
+
+### 7.1 Selection examples
+
+| Range | Inclusive slots | Dense counter payload | Likely choice |
+|---|---:|---:|---|
+| 0..180,000 ms | 180,001 | 1.37 MiB | Array |
+| 0..5,000,000 ns | 5,000,001 | 38.15 MiB | Array |
+| 0..180,000,000 ns | 180,000,001 | 1.34 GiB | Primitive map |
+| 0..180,000,000,000 ns | 180,000,000,001 | 1.31 TiB | Primitive map |
+
+These examples describe storage feasibility, not measurement quality.
+Operators should choose bounds that include meaningful expected latencies
+without allowing rare pathological values to dominate memory.
+
+## 8. Algorithmic complexity
+
+Let:
+
+- `R = highLatency - lowLatency + 1`, the inclusive range size;
+- `D`, the number of distinct observed valid latency values;
+- `S = maxObservedIndex - minObservedIndex + 1`, the observed array span;
+- `C`, the current hash-table capacity.
+
+| Operation | Array | Boxed HashMap | Primitive LongLongHashMap |
+|---|---|---|---|
+| Construct | `O(R)` zeroing | `O(1)` | `O(1)` small initial table |
+| Record existing latency | `O(1)` worst case | expected `O(1)` | expected `O(1)` |
+| Record new latency | `O(1)` worst case | expected `O(1)`, occasional resize | expected `O(1)`, occasional rehash |
+| Additional allocation per normal update | none | wrapper garbage, possibly nodes | none |
+| Extract ordered buckets | `O(S)` | `O(C + D log D)` | `O(C + D log D)` |
+| Extraction temporary storage | `O(1)` | `O(D)` plus stream machinery | `O(Dmax)` retained reusable buffer |
+| Clear during extraction | included in `O(S)` | `O(C + D)` implementation-dependent | `O(C)` array fill |
+| Reset after extraction | `O(1)` | normally `O(C)` clear | `O(1)` when already empty |
+| Fixed/retained distribution memory | `O(R)` | `O(C + D)` objects/references | `O(C + Dmax)` primitives |
+
+Worst-case hash-table operations can degrade under excessive collisions.
+The expected constant-time classification assumes a suitable hash spread.
+
+## 9. Memory analysis
+
+### 9.1 Array
+
+The recorder reports exactly `8R` bytes for counter payload:
+
+```text
+R = 5,096 slots in the JMH configuration
+payload = 5,096 x 8 = 40,768 bytes
+```
+
+The Java array header and small recorder object are additional but do not
+scale with observations. No per-distinct-latency object exists.
+
+### 9.2 Primitive map
+
+Eclipse Collections stores key/value pairs in an interleaved `long[]` and
+maintains a maximum occupancy of roughly 50%. Around a stable power-of-two
+capacity, the backing table therefore requires approximately:
+
+```text
+2 table slots per distinct key
+x 2 longs per slot
+x 8 bytes per long
+= approximately 32 bytes per distinct latency
+```
+
+The reusable sorting buffer adds up to 8 bytes per high-water distinct key.
+Consequently, a stable large recorder is approximately 40 bytes per distinct
+latency plus small object/array headers, with step changes at power-of-two
+resizes.
+
+For 4,096 distinct latencies:
+
+```text
+interleaved hash table: approximately 128 KiB
+reusable sorted keys:                    32 KiB
+combined primitive payload:             160 KiB
+```
+
+### 9.3 Boxed map
+
+The boxed representation retains:
+
+- a HashMap table reference per capacity slot;
+- one HashMap node per distinct latency;
+- a `Long` key per distinct latency outside the wrapper cache;
+- a current boxed `Long` value where the count is not cached;
+- table and recorder objects.
+
+It additionally allocates temporary wrappers during updates. Exact retained
+bytes depend on JVM object layout, compressed references, table capacity,
+counts, and whether wrapper-cache values are reused. The JMH allocation result
+of 47.858 B/update is therefore a stronger observed statement than a universal
+retained-byte formula.
+
+### 9.4 Configured budget versus actual heap
+
+Both map recorders increment `mapBytesCount` by 16 bytes for each distinct
+latency, representing one primitive key and one primitive count. This is a
+logical payload estimate used by `isFull()`, not a measurement of the backing
+collection's full retained heap.
+
+For the primitive map, open-addressing capacity and the sorting buffer make
+actual retained primitive storage closer to roughly 40 bytes per distinct key
+at stable capacity. For the boxed map, nodes, references, wrappers, and
+temporary garbage increase the difference further.
+
+Therefore:
+
+```text
+maxHashMapSizeMB is a recorder payload policy,
+not a strict JVM heap or RSS limit.
+```
+
+Capacity is retained after `clear()`, so heap use follows the largest observed
+window rather than the current empty-window size.
+
+### 9.5 Approximate dense-versus-sparse memory crossover
+
+Using only the dominant primitive payloads:
+
+```text
+array memory         ~= 8R
+primitive-map memory ~= 40D
+```
+
+The approximate equality is:
+
+```text
+8R = 40D
+D / R = 0.20
+```
+
+If more than roughly 20% of a bounded range becomes populated, the dense array
+can use less retained primitive storage than the map plus sorting buffer. If
+only a small fraction is populated, the primitive map can save substantial
+memory. Power-of-two table growth, array/object headers, and high-water
+retention shift the exact crossover, so 20% is a design estimate rather than
+a runtime guarantee.
+
+| Range slots `R` | Distinct values `D` | Density | Array payload | Approx. primitive-map payload | Memory-oriented choice |
+|---:|---:|---:|---:|---:|---|
+| 1,000,000 | 1,000 | 0.1% | 7.63 MiB | 39 KiB | Primitive map |
+| 1,000,000 | 100,000 | 10% | 7.63 MiB | 3.81 MiB | Primitive map |
+| 1,000,000 | 250,000 | 25% | 7.63 MiB | 9.54 MiB | Array |
+| 1,000,000 | 1,000,000 | 100% | 7.63 MiB | 38.15 MiB | Array |
+
+Memory is not the only criterion. The array extraction cost follows observed
+span `S`, while map extraction sorts `D` keys. A sparse distribution clustered
+inside a narrow span can still favor the array; a few values spread across the
+entire range can favor the map even when the array fits.
+
+## 10. Experimental method
+
+The reproducible benchmark is
+[`LatencyMapBenchmark.java`](../perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java).
+Run:
+
+```bash
+./gradlew :perl:latencyMapPerformanceTest
+```
+
+The task:
+
+- builds with JDK 25;
+- uses JMH 1.37;
+- runs three independent forks;
+- performs three one-second warmup iterations per fork;
+- performs five one-second measurement iterations per fork;
+- uses one thread because a recorder has one production owner;
+- enables the JMH GC profiler;
+- writes raw JSON to
+  `perl/build/reports/jmh/latency-map-performance.json`.
+
+The benchmark cycles across 4,096 exact values beginning at latency 1,000.
+Values are outside the small boxed-`Long` cache. It measures:
+
+1. individual frequency updates;
+2. complete 4,096-value record-and-extract windows;
+3. allocating versus reusable primitive key extraction for 65,536 keys.
+
+### 10.1 Environment
+
+| Component | Measured value |
+|---|---|
+| CPU | Intel Xeon Platinum 8462Y+, 16 vCPUs |
+| Topology | VMware VM, 1 NUMA node |
+| Memory | 61 GiB |
+| OS | Ubuntu Linux, kernel 5.15.0-181 |
+| JVM | Oracle JDK 25.0.2+10-LTS-69 |
+| GC | ZGC |
+| Object headers | `-XX:+UseCompactObjectHeaders` |
+| JMH | 1.37 |
+
+JMH is the OpenJDK harness for JVM nano-, micro-, milli-, and macrobenchmarks;
+see the [OpenJDK JMH project](https://openjdk.org/projects/code-tools/jmh/).
+
+## 11. Performance results
+
+### 11.1 Update hot path
+
+| Recorder | Mean throughput | 99.9% confidence interval | Allocation |
+|---|---:|---:|---:|
+| Array | 561.874 M ops/s | 552.030..571.719 M | effectively 0 B/op |
+| Primitive map | 439.011 M ops/s | 435.194..442.828 M | 0.001 B/op |
+| Boxed map | 64.560 M ops/s | 38.833..90.287 M | 47.855 B/op |
+
+Derived comparisons:
+
+- Array versus primitive map: **28.0% higher mean throughput**.
+- Primitive versus boxed map: **580.0% higher mean throughput**.
+- Primitive versus boxed allocation: effectively **100% reduction**.
+- Array versus boxed map: **770.3% higher mean throughput**.
+
+The boxed result has a wide confidence interval because its high allocation
+rate introduced GC-dependent bimodality. Even its upper confidence bound is
+well below the primitive map's lower bound in this run.
+
+### 11.2 Complete window
+
+The complete-window benchmark records 4,096 distinct values and then
+calculates percentiles while clearing the distribution. Results are populated
+from the same raw JMH report and include both hot-path and boundary work:
+
+| Recorder | Time/window | Allocation/window |
+|---|---:|---:|
+| Array | 9.531 us | 0.093 B |
+| Primitive map | 32.346 us | 48.317 B |
+| Boxed map | 213.952 us | 429,058.098 B |
+
+This measure is more representative of PerL than update throughput alone.
+The update benchmark isolates the cost paid for every record; the window
+benchmark includes ordering, percentile traversal, and clearing. For this
+dense window, the array completed in 29.5% of the primitive-map time. The
+primitive map completed in 15.1% of the boxed-map time and avoided about
+419 KiB of allocation per window.
+
+### 11.3 Primitive extraction optimization
+
+| Mechanism, 65,536 keys | Mean time | Allocation |
+|---|---:|---:|
+| Allocating sorted primitive list | 320.282 us | 524,379.133 B/op |
+| Reusable primitive array | 173.992 us | 49.701 B/op |
+
+The reusable implementation required 45.7% less time and avoided approximately
+512 KiB of allocation per extraction.
+
+## 12. Correctness evidence
+
+The recorders are tested for exact equivalence rather than approximate
+tolerance.
+
+[`ArrayLatencyRecorderTest.java`](../perl/src/test/java/io/perl/test/ArrayLatencyRecorderTest.java)
+compares array and primitive-map behavior for:
+
+- non-zero lower bounds;
+- inclusive minimum and maximum;
+- lower and higher discarded values;
+- invalid negative latency;
+- duplicate latency values;
+- batched record counts;
+- empty windows;
+- growing and shrinking windows;
+- repeated reset/extract cycles;
+- deterministic random distributions;
+- exact ordered latency/count pairs;
+- every configured percentile and its bucket count;
+- median;
+- valid, invalid, lower-discard, and higher-discard counters.
+
+[`LatencyMapRecorderTest.java`](../perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java)
+compares primitive and boxed map behavior, verifies production builder
+selection, exercises reusable sorting-buffer growth, and tests repeated
+windows.
+
+These tests establish semantic equivalence for the supported lifecycle. JMH
+establishes performance observations, not correctness.
+
+## 13. Decision guide
+
+```mermaid
+flowchart TD
+    START["Need exact integer latency buckets"] --> FIT{"Inclusive range safely fits<br/>within dense-array budget?"}
+    FIT -->|no| PRIMITIVE["Use LongHashMapLatencyRecorder"]
+    FIT -->|yes| DENSE{"Expected observations dense or<br/>observed span narrow?"}
+    DENSE -->|yes| ARRAY["Use ArrayLatencyRecorder"]
+    DENSE -->|no| TEST["Benchmark array scan versus<br/>primitive map on target workload"]
+    TEST -->|array wins| ARRAY
+    TEST -->|map wins or memory matters| PRIMITIVE
+    BASELINE["Need a correctness/reference baseline"] --> BOXED["Use HashMapLatencyRecorder<br/>only in tests/benchmarks"]
+
+    classDef decision fill:#fef3c7,stroke:#a16207,color:#000
+    classDef recommended fill:#dcfce7,stroke:#166534,color:#000
+    classDef baseline fill:#fee2e2,stroke:#991b1b,color:#000
+    class FIT,DENSE decision
+    class ARRAY,PRIMITIVE recommended
+    class BOXED baseline
+```
+
+| Workload | Recommended recorder | Reason |
+|---|---|---|
+| Small bounded millisecond range | Array | fastest direct indexing, small fixed array |
+| Dense microsecond range below budget | Array | cache-friendly exact counters |
+| Nanosecond range spanning billions | Primitive map | memory proportional to observed values |
+| Sparse values separated by large holes | Primitive map | avoids scanning/reserving holes |
+| Whole-run aggregation | Primitive map | theoretical range can be enormous |
+| Correctness oracle or regression baseline | Boxed map | simple JDK representation |
+
+## 14. Limitations and threats to validity
+
+1. Microbenchmarks do not include timestamp queue traffic, logger formatting,
+   storage SDK calls, or operating-system I/O.
+2. Results apply to the declared CPU, JVM, GC, and flags. Different CPUs,
+   collectors, heap sizes, or JDK builds can change throughput.
+3. The benchmark has one recorder thread because production ownership is
+   single-threaded. It does not measure unsupported concurrent mutation.
+4. The update workload has 4,096 repeating values. Different cardinality,
+   hash distribution, and density change cache behavior.
+5. `gc.alloc.rate.norm` values near zero are profiler/harness noise and should
+   be interpreted as "no structural per-operation allocation," not literally
+   a fractional object.
+6. Reported array memory is counter payload; reported map budgets are logical
+   payload estimates, not complete retained-heap measurements.
+7. The reusable sorting buffer trades lower repeated allocation for retained
+   high-water memory.
+8. Exact percentile retention can require much more memory than an approximate
+   histogram. That is a deliberate precision tradeoff.
+
+## 15. Conclusions
+
+The three recorders occupy distinct architectural roles:
+
+- `ArrayLatencyRecorder` is the preferred dense-window implementation. It has
+  the simplest hot path, deterministic fixed memory, and the highest measured
+  update throughput.
+- `LongHashMapLatencyRecorder` is the preferred sparse and whole-run
+  implementation. It preserves exact values while avoiding boxed-map garbage
+  and reserving memory only as distinct values appear.
+- `HashMapLatencyRecorder` is a valuable reference implementation but is not
+  suitable for PerL's production hot path because wrapper and node allocation
+  consume CPU, memory bandwidth, and GC capacity.
+
+The production policy—array when the range fits, primitive map otherwise—is
+sound. A future density-aware policy could improve decisions for ranges that
+fit in memory but contain very sparse observations. Such a change should be
+driven by end-to-end PerL measurements, not by data-structure theory alone.
+
+The most durable result is not a single throughput number. It is the mapping
+between workload shape and representation:
+
+```text
+dense bounded domain  -> direct primitive array
+sparse large domain   -> primitive open-addressed map
+boxed object graph    -> reference/testing baseline
+```
+
+## References
+
+1. SBK PerL source:
+   [`perl/src/main/java/io/perl`](../perl/src/main/java/io/perl).
+2. OpenJDK, [Java Microbenchmark Harness](https://openjdk.org/projects/code-tools/jmh/).
+3. Oracle, [JDK 25 `HashMap` API](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/HashMap.html).
+4. OpenJDK, [JEP 519: Compact Object Headers](https://openjdk.org/jeps/519).
+5. Eclipse Collections,
+   [`LongLongHashMap`](https://github.com/eclipse/eclipse-collections/blob/master/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/primitive/LongLongHashMap.java).
+6. Gil Tene, [HdrHistogram](https://github.com/HdrHistogram/HdrHistogram)
+   for the optional approximate whole-run extension used by PerL.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,9 @@ This directory contains the authoritative engineering documentation for Storage 
 2. [Internal design](sbk-internals.md): detailed PerL measurement flow,
    `ElasticWait`, timestamp queues, SBM, and SBP design.
 3. [TimeStampMpscQueue research guide](TIMESTAMP_MPSC_QUEUE.md): intrusive MPSC queue architecture, correctness evidence, JDK comparison, and reproducible performance methodology.
-4. [Documentation maintenance](DOCUMENTATION_GUIDE.md): how to keep examples and links current.
-5. [Agent-documentation distribution](AGENT_DOCUMENTATION_DISTRIBUTION.md): how documentation enters release artifacts.
+4. [Exact latency recorders research guide](LATENCY_RECORDERS.md): dense-array, boxed-map, and primitive-map algorithms, memory models, correctness, and JDK 25 JMH results.
+5. [Documentation maintenance](DOCUMENTATION_GUIDE.md): how to keep examples and links current.
+6. [Agent-documentation distribution](AGENT_DOCUMENTATION_DISTRIBUTION.md): how documentation enters release artifacts.
 
 ### Coding agent
 
@@ -65,6 +66,7 @@ This directory contains the authoritative engineering documentation for Storage 
 | [WEB_LOGGER.md](WEB_LOGGER.md) | Local live dashboard usage, lifecycle, options, security, and troubleshooting |
 | [sbk-internals.md](sbk-internals.md) | Detailed design rationale and research-oriented treatment |
 | [TIMESTAMP_MPSC_QUEUE.md](TIMESTAMP_MPSC_QUEUE.md) | Intrusive timestamp queue architecture, JDK comparison, correctness evidence, and research methodology |
+| [LATENCY_RECORDERS.md](LATENCY_RECORDERS.md) | Exact array and sparse-map latency storage, complexity, memory accounting, correctness, and reproducible JMH results |
 | [PerlBench driver](../drivers/perlbench/README.md) | End-to-end timestamp-queue comparison using exact-count, timed, and rate-controlled SBK workloads |
 | Component READMEs | Component operation and component-specific examples |
 | Driver READMEs | Backend prerequisites, properties, limitations, and example commands |

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -189,8 +189,8 @@ In practice that means:
 
 1. **Operations are recorded without reservoir sampling.** Each completed
    operation submitted to PerL contributes its latency and record count to a
-   latency distribution. Array and HashMap windows preserve exact integer
-   latency values within the configured range; the optional HdrHistogram
+   latency distribution. Array and primitive-map windows preserve exact
+   integer latency values within the configured range; the optional HdrHistogram
    extension trades exact values for bounded, three-significant-digit
    precision. Invalid and out-of-range values are counted separately rather
    than silently treated as valid samples (§3).
@@ -270,7 +270,7 @@ flowchart TB
 
 | Module | Full name | Purpose |
 |---|---|---|
-| `perl` | **PerL** — Performance Logger | Storage-agnostic latency-recording library: lock-free queues, sliding windows, HdrHistogram / HashMap / Array storage backends. |
+| `perl` | **PerL** — Performance Logger | Storage-agnostic latency-recording library: lock-free queues, sliding windows, and exact primitive-map / array latency recorders. |
 | `sbk-api` | **SBK** — Storage Benchmark Kit (harness layer) | The benchmarking harness: defines the `Storage<T>` SPI for drivers, orchestrates writers and readers, parses CLI args, integrates loggers. |
 | `sbk-yal` | **SBK-YAL** — SBK YML Arguments Loader | YML-driven launcher; converts a `.yml` benchmark spec into `sbk-api` args. |
 | `sbm` | **SBM** — Storage Benchmark Monitor | Standalone gRPC server that *aggregates* latency histograms from many SBK clients into a cluster-wide view. Listens on port 9717. Speaks the **SBP** (Storage Benchmark Protocol). |
@@ -913,19 +913,22 @@ sequenceDiagram
 #### Pillar 4 — Memory-aware latency storage
 
 The recorder writes to a `LatencyRecordWindow`. For each periodic window,
-`PerlBuilder.buildLatencyRecordWindow()` chooses either an array or a HashMap
-from the configured latency range and memory budget. The whole-run window is
-a HashMap buffer with an optional HDR or CSV overflow/extension strategy.
+`PerlBuilder.buildLatencyRecordWindow()` chooses either a dense primitive
+array or a sparse primitive long-to-long map from the configured latency range
+and memory budget. The whole-run window is a primitive-map buffer with an
+optional HDR or CSV overflow/extension strategy. The boxed
+`HashMapLatencyRecorder` remains only as a correctness and benchmark baseline;
+see the complete [latency-recorder research guide](LATENCY_RECORDERS.md).
 
 ```mermaid
 flowchart LR
     CFG["Latency range + memory limits"] --> PERIODIC{"Periodic window<br/>range * 8 bytes fits?"}
     PERIODIC -->|yes| ARRAY["ArrayLatencyRecorder<br/>direct integer index<br/>exact values in range"]
-    PERIODIC -->|no| MAP["HashMapLatencyRecorder<br/>stores observed values<br/>bounded by configured estimate"]
+    PERIODIC -->|no| MAP["LongHashMapLatencyRecorder<br/>primitive exact keys/counts<br/>bounded by configured estimate"]
 
-    CFG --> TOTAL["Total-window HashMap buffer"]
+    CFG --> TOTAL["Total-window primitive-map buffer"]
     TOTAL --> MODE{"Optional extension"}
-    MODE -->|histogram=false, csv=false| MAPTOTAL["HashMap total<br/>prints/resets when full"]
+    MODE -->|histogram=false, csv=false| MAPTOTAL["Primitive-map total<br/>prints/resets when full"]
     MODE -->|histogram=true| HDR["HdrExtendedLatencyRecorder<br/>flushes a full buffer into HDR<br/>3 significant digits"]
     MODE -->|csv=true| CSV["CSVExtendedLatencyRecorder<br/>streams extension data to file<br/>bounded by csvFileSizeGB"]
 
@@ -945,8 +948,8 @@ the optional `-mpscqueue` override:
 
 ```properties
 maxArraySizeMB=64           # Use Array backend if latency range fits
-maxHashMapSizeMB=192        # Periodic window HashMap budget
-totalMaxHashMapSizeMB=256   # Total window HashMap budget
+maxHashMapSizeMB=192        # Periodic primitive-map logical budget
+totalMaxHashMapSizeMB=256   # Total primitive-map logical budget
 MpscQueueEnable=true        # One-object intrusive MPSC timestamp hand-off
 histogram=false             # Optional HdrHistogram for total window
 csv=false                   # Optional raw-CSV total backend
@@ -961,9 +964,10 @@ to accidental configuration drift.
 
 **How available memory changes the design:** an array has predictable memory
 and direct indexing, but its size is proportional to the configured latency
-range, whether or not every value occurs. A HashMap stores only observed
-integer latency values, but each distinct value has object/table overhead and
-its configured limit is an estimate rather than an exact heap cap. Increasing
+range, whether or not every value occurs. The primitive map stores only
+observed integer latency values without boxing, but open-addressed table
+capacity and the reusable sorting buffer still add overhead. Its configured
+limit is a logical payload estimate rather than an exact heap cap. Increasing
 `maxArraySizeMB`, `maxHashMapSizeMB`, or `totalMaxHashMapSizeMB` lets PerL keep
 larger exact-value distributions before a window must be printed/reset or an
 extension must absorb it.
@@ -1036,7 +1040,7 @@ Six concrete reasons, traceable to specific code:
 5. **Clock-query amortisation via `ElasticWait`.** The recorder reuses
    `TimeStamp.endTime` while processing and checks the clock only after an
    adaptive batch of empty-queue parks.
-6. **Configurable memory and precision.** Array, HashMap, HDR, and CSV modes
+6. **Configurable memory and precision.** Array, primitive-map, HDR, and CSV modes
    let operators choose between direct indexing, sparse exact values, bounded
    approximate histograms, and offline raw output.
 
@@ -2109,8 +2113,9 @@ PerL's storage strategy turns heap capacity into a tunable measurement
 resource:
 
 - A wider exact array range consumes more memory even for unobserved values.
-- A HashMap consumes memory with the number of distinct observed integer
-  latency values and has per-entry overhead.
+- A primitive map consumes memory with the number of distinct observed
+  integer latency values and has table-capacity plus reusable-sort-buffer
+  overhead.
 - A larger periodic/total map budget reduces how often full windows must be
   printed and reset.
 - HdrHistogram bounds a wide distribution with three-significant-digit
@@ -2126,11 +2131,11 @@ and lower/higher discard counts with the benchmark result.
 ```mermaid
 flowchart TD
     HEAP["Available JVM heap"] --> QUEUE["Queue objects<br/>in-flight TimeStamp records"]
-    HEAP --> PERIODIC["Periodic window<br/>array or HashMap"]
-    HEAP --> TOTAL["Total-window<br/>HashMap buffer"]
+    HEAP --> PERIODIC["Periodic window<br/>array or primitive map"]
+    HEAP --> TOTAL["Total-window<br/>primitive-map buffer"]
     DISK["Available disk"] --> CSV["Optional CSV extension"]
     TOTAL --> MODE{"When exact buffer fills"}
-    MODE -->|plain HashMap| FLUSH["Print / reset total segment"]
+    MODE -->|plain primitive map| FLUSH["Print / reset total segment"]
     MODE -->|HDR enabled| HDR["Fold counts into<br/>3-digit HDR representation"]
     MODE -->|CSV enabled| CSV
     QUEUE --> PRESSURE["If recorder falls behind:<br/>backlog + allocation + GC pressure"]
@@ -2174,7 +2179,8 @@ The memory-strategy diagrams in §3.3 Pillar 4 and §8.5 show where exact
 integer buckets end and optional HDR quantization begins.
 
 PerL does not reservoir-sample completed records submitted to it. Exact array
-and HashMap modes retain integer latency buckets within the configured range.
+and primitive-map modes retain integer latency buckets within the configured
+range.
 HdrHistogram deliberately quantizes to three significant digits. Values below
 or above the configured range and invalid latencies are counted separately.
 Therefore, “no sampling” is accurate; “zero approximation under every
@@ -2924,7 +2930,7 @@ SBK is the right substrate.
 
 | Property | What it gives you | Code evidence |
 |---|---|---|
-| **No reservoir sampling** | Every completed operation submitted to PerL contributes its count; invalid and out-of-range values remain visible as counters. Precision still depends on time unit, range, and backend. | `HashMapLatencyRecorder` and `ArrayLatencyRecorder` implement exact integer buckets; HDR uses three significant digits. |
+| **No reservoir sampling** | Every completed operation submitted to PerL contributes its count; invalid and out-of-range values remain visible as counters. Precision still depends on time unit, range, and backend. | `LongHashMapLatencyRecorder` and `ArrayLatencyRecorder` implement exact integer buckets; HDR uses three significant digits. |
 | **Non-blocking measurement hand-off** | Workers do not wait for an application mutex to hand a record to PerL. Queue operations can still allocate and retry under contention. | `TimeStampMpscQueueChannel` uses `TimeStampMpscQueueArray`; the original `CQueueChannel` uses `ConcurrentLinkedQueueArray`. |
 | **Single-owner recording** | One consumer owns each direction's non-thread-safe windows, avoiding concurrent bucket updates. Its drain rate remains a capacity limit to monitor. | `PerformanceRecorderElasticWait.run()` reads all channels for one PerL instance. |
 | **Amortised recorder clock checks** | Records carry worker timestamps; the empty path parks and checks time after an adaptive batch instead of on every poll. | `ElasticWait` plus `PerformanceRecorderElasticWait`. |
@@ -3017,7 +3023,7 @@ Being explicit about scope strengthens any methodology section:
 
 | Tradeoff | Why SBK chooses this |
 |---|---|
-| **Memory grows with range or distinct latency values** | Array memory follows configured range; HashMap memory follows distinct values. Configured budgets bound selection/flush behavior. HDR offers bounded approximate precision when enabled; it is not an automatic exact fallback under every configuration. |
+| **Memory grows with range or distinct latency values** | Array memory follows configured range; primitive-map memory follows distinct values and retained table/sort-buffer capacity. Configured budgets control selection/flush policy but are not strict retained-heap limits. HDR offers bounded approximate precision when enabled; it is not an automatic exact fallback under every configuration. |
 | **One consumer owns each direction's windows** | This avoids synchronization in bucket updates but caps recorder throughput. Benchmark the intended event rate and watch CPU, GC, and queue growth instead of assuming a fixed operations/second limit. |
 | **JVM warm-up is workload- and JVM-dependent** | Use explicit warm-up runs or discard documented initial windows based on observed stabilization; do not assume a fixed 1–2-second warm-up. |
 | **End-to-end latency is per-driver** | The harness cannot know whether a driver's payload format supports embedding a timestamp. Drivers that do (e.g. Kafka, Pravega) measure true E2E; others measure per-operation. The driver README should make this explicit. |

--- a/perl/build.gradle
+++ b/perl/build.gradle
@@ -370,7 +370,9 @@ tasks.register('latencyMapPerformanceTest') {
         def compareHigher = { left, right, String unit ->
             def winner = left.score >= right.score ? left : right
             def loser = left.score >= right.score ? right : left
-            def gain = (winner.score - loser.score) * 100.0 / loser.score
+            def gain = loser.score == 0.0d
+                    ? 0.0d
+                    : (winner.score - loser.score) * 100.0 / loser.score
             String.format('%s is %.2f%% higher than %s (+%,.0f %s)',
                     winner['name'], gain, loser['name'],
                     winner.score - loser.score, unit)
@@ -378,8 +380,9 @@ tasks.register('latencyMapPerformanceTest') {
         def compareLower = { left, right, String unit ->
             def winner = left.score <= right.score ? left : right
             def loser = left.score <= right.score ? right : left
-            def reduction =
-                    (loser.score - winner.score) * 100.0 / loser.score
+            def reduction = loser.score == 0.0d
+                    ? 0.0d
+                    : (loser.score - winner.score) * 100.0 / loser.score
             def reductionText = unit.startsWith('memory')
                     ? String.format('%.6f', reduction)
                     : String.format('%.2f', reduction)
@@ -497,9 +500,11 @@ tasks.register('latencyMapPerformanceTest') {
                 '  Extraction allocation reduction: %,.3f B/op (%.2f%%)',
                 allocatedExtractionAllocation.score
                         - reusableExtractionAllocation.score,
-                (allocatedExtractionAllocation.score
-                        - reusableExtractionAllocation.score) * 100.0
-                        / allocatedExtractionAllocation.score))
+                allocatedExtractionAllocation.score == 0.0d
+                        ? 0.0d
+                        : (allocatedExtractionAllocation.score
+                                - reusableExtractionAllocation.score) * 100.0
+                                / allocatedExtractionAllocation.score))
         logger.lifecycle(
                 "JMH report: ${latencyMapPerformanceReport.get().asFile}")
 

--- a/perl/build.gradle
+++ b/perl/build.gradle
@@ -233,7 +233,7 @@ tasks.register('timeStampQueuePerformanceTest') {
 
 tasks.register('runLatencyMapPerformanceBenchmark', JavaExec) {
     group = 'verification'
-    description = 'Benchmarks primitive and boxed sparse latency maps on JDK 25.'
+    description = 'Benchmarks dense-array, primitive-map, and boxed-map latency recorders on JDK 25.'
     dependsOn tasks.named('jmhJar')
     classpath = files(tasks.named('jmhJar').flatMap { it.archiveFile })
     mainClass = 'org.openjdk.jmh.Main'
@@ -257,7 +257,7 @@ tasks.register('runLatencyMapPerformanceBenchmark', JavaExec) {
 
 tasks.register('latencyMapPerformanceTest') {
     group = 'verification'
-    description = 'Compares primitive-map throughput and allocation with the boxed map.'
+    description = 'Compares dense-array and primitive-map performance with the boxed map.'
     dependsOn tasks.named('runLatencyMapPerformanceBenchmark')
 
     doLast {
@@ -284,11 +284,23 @@ tasks.register('latencyMapPerformanceTest') {
         def boxed = result(
                 'io.perl.benchmark.LatencyMapBenchmark'
                         + '.boxedRecordLatency')
+        def array = result(
+                'io.perl.benchmark.LatencyMapBenchmark'
+                        + '.arrayRecordLatency')
         def primitiveThroughput = primitive.primaryMetric
         def boxedThroughput = boxed.primaryMetric
+        def arrayThroughput = array.primaryMetric
         def primitiveAllocation =
                 primitive.secondaryMetrics['gc.alloc.rate.norm']
         def boxedAllocation = boxed.secondaryMetrics['gc.alloc.rate.norm']
+        def arrayAllocation =
+                array.secondaryMetrics['gc.alloc.rate.norm']
+        def arrayWindow = result(
+                'io.perl.benchmark.LatencyMapBenchmark.arrayWindow')
+        def boxedWindow = result(
+                'io.perl.benchmark.LatencyMapBenchmark.boxedWindow')
+        def primitiveWindow = result(
+                'io.perl.benchmark.LatencyMapBenchmark.primitiveWindow')
         def allocatedExtraction = result(
                 'io.perl.benchmark.LatencyMapBenchmark'
                         + '.allocatedSortedListExtraction')
@@ -301,56 +313,176 @@ tasks.register('latencyMapPerformanceTest') {
                 allocatedExtraction.secondaryMetrics['gc.alloc.rate.norm']
         def reusableExtractionAllocation =
                 reusableExtraction.secondaryMetrics['gc.alloc.rate.norm']
-        def throughputDifference = (primitiveThroughput.score
-                - boxedThroughput.score)
-        def throughputChange = (throughputDifference * 100.0) /
-                boxedThroughput.score
-        def allocationDifference = (boxedAllocation.score
-                - primitiveAllocation.score)
-        def allocationReduction = (boxedAllocation.score
-                - primitiveAllocation.score) * 100.0 / boxedAllocation.score
-        def confidenceConclusion
-        if (primitiveThroughput.scoreConfidence[0]
-                > boxedThroughput.scoreConfidence[1]) {
-            confidenceConclusion = (
-                    'LongHashMapLatencyRecorder is faster; '
-                            + 'the 99.9% confidence intervals do not overlap')
-        } else if (boxedThroughput.scoreConfidence[0]
-                > primitiveThroughput.scoreConfidence[1]) {
-            confidenceConclusion = (
-                    'HashMapLatencyRecorder is faster; '
-                            + 'the 99.9% confidence intervals do not overlap')
-        } else {
-            confidenceConclusion = (
-                    'inconclusive; the 99.9% confidence intervals overlap')
+        def arrayWindowAllocation =
+                arrayWindow.secondaryMetrics['gc.alloc.rate.norm']
+        def primitiveWindowAllocation =
+                primitiveWindow.secondaryMetrics['gc.alloc.rate.norm']
+        def boxedWindowAllocation =
+                boxedWindow.secondaryMetrics['gc.alloc.rate.norm']
+        def recorderResults = [
+                [
+                        name: 'ArrayLatencyRecorder',
+                        throughput: arrayThroughput,
+                        updateAllocation: arrayAllocation,
+                        windowTime: arrayWindow.primaryMetric,
+                        windowAllocation: arrayWindowAllocation
+                ],
+                [
+                        name: 'LongHashMapLatencyRecorder',
+                        throughput: primitiveThroughput,
+                        updateAllocation: primitiveAllocation,
+                        windowTime: primitiveWindow.primaryMetric,
+                        windowAllocation: primitiveWindowAllocation
+                ],
+                [
+                        name: 'HashMapLatencyRecorder',
+                        throughput: boxedThroughput,
+                        updateAllocation: boxedAllocation,
+                        windowTime: boxedWindow.primaryMetric,
+                        windowAllocation: boxedWindowAllocation
+                ]
+        ]
+        def rankHigher = { String label, String unit, String metricName ->
+            logger.lifecycle("${label} (higher is better):")
+            recorderResults.toSorted {
+                left, right ->
+                    right[metricName].score <=> left[metricName].score
+                }.eachWithIndex { entry, index ->
+                    logger.lifecycle(String.format(
+                            '  %d. %-26s : %,.0f %s',
+                            index + 1, entry['name'],
+                            entry[metricName].score, unit))
+                }
         }
+        def rankLower = {
+            String label, String unit, String format, String metricName ->
+                logger.lifecycle("${label} (lower is better):")
+                recorderResults.toSorted {
+                    left, right ->
+                        left[metricName].score <=> right[metricName].score
+                }.eachWithIndex { entry, index ->
+                    logger.lifecycle(String.format(
+                            "  %d. %-26s : ${format} %s",
+                            index + 1, entry['name'],
+                            entry[metricName].score, unit))
+                }
+        }
+        def compareHigher = { left, right, String unit ->
+            def winner = left.score >= right.score ? left : right
+            def loser = left.score >= right.score ? right : left
+            def gain = (winner.score - loser.score) * 100.0 / loser.score
+            String.format('%s is %.2f%% higher than %s (+%,.0f %s)',
+                    winner['name'], gain, loser['name'],
+                    winner.score - loser.score, unit)
+        }
+        def compareLower = { left, right, String unit ->
+            def winner = left.score <= right.score ? left : right
+            def loser = left.score <= right.score ? right : left
+            def reduction =
+                    (loser.score - winner.score) * 100.0 / loser.score
+            def reductionText = unit.startsWith('memory')
+                    ? String.format('%.6f', reduction)
+                    : String.format('%.2f', reduction)
+            String.format('%s requires %s%% less %s than %s '
+                    + '(%,.3f vs %,.3f)',
+                    winner['name'], reductionText, unit, loser['name'],
+                    winner.score, loser.score)
+        }
+        def compareConfidence = { left, right, boolean higherIsBetter ->
+            def leftWins = higherIsBetter
+                    ? left.metric.scoreConfidence[0]
+                    > right.metric.scoreConfidence[1]
+                    : left.metric.scoreConfidence[1]
+                    < right.metric.scoreConfidence[0]
+            def rightWins = higherIsBetter
+                    ? right.metric.scoreConfidence[0]
+                    > left.metric.scoreConfidence[1]
+                    : right.metric.scoreConfidence[1]
+                    < left.metric.scoreConfidence[0]
+            if (leftWins) {
+                return String.format(
+                        '%s is statistically better than %s '
+                                + '(non-overlapping 99.9%% CIs)',
+                        left['name'], right['name'])
+            }
+            if (rightWins) {
+                return String.format(
+                        '%s is statistically better than %s '
+                                + '(non-overlapping 99.9%% CIs)',
+                        right['name'], left['name'])
+            }
+            String.format(
+                    '%s versus %s is INCONCLUSIVE '
+                            + '(overlapping 99.9%% CIs)',
+                    left['name'], right['name'])
+        }
+        def namedMetric = { entry, String metricName ->
+            [name: entry['name'], score: entry[metricName].score,
+             metric: entry[metricName]]
+        }
+        def arrayResult = recorderResults[0]
+        def primitiveResult = recorderResults[1]
+        def boxedResult = recorderResults[2]
+        def pairs = [
+                [arrayResult, primitiveResult],
+                [arrayResult, boxedResult],
+                [primitiveResult, boxedResult]
+        ]
 
         logger.lifecycle(
-                'Sparse latency-map JMH comparison:')
-        logger.lifecycle(String.format(
-                '  LongHashMapLatencyRecorder : %,.0f ops/s, %.3f B/op',
-                primitiveThroughput.score, primitiveAllocation.score))
-        logger.lifecycle(String.format(
-                '  HashMapLatencyRecorder     : %,.0f ops/s, %.3f B/op',
-                boxedThroughput.score, boxedAllocation.score))
-        if (throughputDifference >= 0) {
-            logger.lifecycle(String.format(
-                    '  Throughput result          : LongHashMapLatencyRecorder'
-                            + ' is %.2f%% faster (+%,.0f ops/s)',
-                    throughputChange, throughputDifference))
-        } else {
-            logger.lifecycle(String.format(
-                    '  Throughput result          : LongHashMapLatencyRecorder'
-                            + ' is %.2f%% slower (%,.0f ops/s)',
-                    Math.abs(throughputChange), throughputDifference))
+                'Latency-recorder JMH comparison (4,096 exact values)')
+        rankHigher('Hot-path throughput ranking', 'ops/s', 'throughput')
+        logger.lifecycle('  Pairwise mean-throughput comparison:')
+        pairs.each { pair ->
+            logger.lifecycle('    - ' + compareHigher(
+                    namedMetric(pair[0], 'throughput'),
+                    namedMetric(pair[1], 'throughput'), 'ops/s'))
         }
-        logger.lifecycle(String.format(
-                '  Allocation result          : LongHashMapLatencyRecorder'
-                        + ' uses %.3f fewer B/op (%.2f%% reduction)',
-                allocationDifference,
-                allocationReduction))
+        logger.lifecycle('  99.9% confidence-interval comparison:')
+        pairs.each { pair ->
+            logger.lifecycle('    - ' + compareConfidence(
+                    namedMetric(pair[0], 'throughput'),
+                    namedMetric(pair[1], 'throughput'), true))
+        }
+        rankLower('Hot-path allocation ranking', 'B/op', '%,.3f',
+                'updateAllocation')
         logger.lifecycle(
-                "  Statistical conclusion     : ${confidenceConclusion}")
+                '  Interpretation: ArrayLatencyRecorder and '
+                        + 'LongHashMapLatencyRecorder are effectively '
+                        + 'zero-allocation at JMH resolution.')
+        logger.lifecycle('  Material allocation comparisons:')
+        logger.lifecycle('    - ' + compareLower(
+                namedMetric(arrayResult, 'updateAllocation'),
+                namedMetric(boxedResult, 'updateAllocation'), 'memory/op'))
+        logger.lifecycle('    - ' + compareLower(
+                namedMetric(primitiveResult, 'updateAllocation'),
+                namedMetric(boxedResult, 'updateAllocation'), 'memory/op'))
+
+        logger.lifecycle(
+                'Complete 4,096-value window: record + percentile extraction')
+        rankLower('Window-time ranking', 'us/window', '%,.3f',
+                'windowTime')
+        logger.lifecycle('  Pairwise mean window-time comparison:')
+        pairs.each { pair ->
+            logger.lifecycle('    - ' + compareLower(
+                    namedMetric(pair[0], 'windowTime'),
+                    namedMetric(pair[1], 'windowTime'), 'time/window'))
+        }
+        logger.lifecycle('  99.9% confidence-interval comparison:')
+        pairs.each { pair ->
+            logger.lifecycle('    - ' + compareConfidence(
+                    namedMetric(pair[0], 'windowTime'),
+                    namedMetric(pair[1], 'windowTime'), false))
+        }
+        rankLower('Window-allocation ranking', 'B/window', '%,.3f',
+                'windowAllocation')
+        logger.lifecycle('  Pairwise mean window-allocation comparison:')
+        pairs.each { pair ->
+            logger.lifecycle('    - ' + compareLower(
+                    namedMetric(pair[0], 'windowAllocation'),
+                    namedMetric(pair[1], 'windowAllocation'),
+                    'memory/window'))
+        }
         logger.lifecycle(
                 'Percentile key-extraction JMH comparison (65,536 keys):')
         logger.lifecycle(String.format(

--- a/perl/build.gradle
+++ b/perl/build.gradle
@@ -92,6 +92,8 @@ def cqueuePerformanceReport = layout.buildDirectory.file(
         "reports/jmh/cqueue-performance.json")
 def timeStampQueuePerformanceReport = layout.buildDirectory.file(
         "reports/jmh/timestamp-queue-performance.json")
+def latencyMapPerformanceReport = layout.buildDirectory.file(
+        "reports/jmh/latency-map-performance.json")
 
 tasks.register('runTimeStampQueuePerformanceBenchmark', JavaExec) {
     group = 'verification'
@@ -226,6 +228,126 @@ tasks.register('timeStampQueuePerformanceTest') {
         }
         logger.lifecycle('Timestamp queue latency and allocation '
                 + 'verification: PASSED; throughput is classified, not gated')
+    }
+}
+
+tasks.register('runLatencyMapPerformanceBenchmark', JavaExec) {
+    group = 'verification'
+    description = 'Benchmarks primitive and boxed sparse latency maps on JDK 25.'
+    dependsOn tasks.named('jmhJar')
+    classpath = files(tasks.named('jmhJar').flatMap { it.archiveFile })
+    mainClass = 'org.openjdk.jmh.Main'
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+    jvmArgs rootProject.ext.sbkRuntimeJvmArgs
+    args 'io.perl.benchmark.LatencyMapBenchmark.*',
+            '-prof', 'gc',
+            '-jvmArgs', (rootProject.ext.sbkRuntimeJvmArgs
+                    + ['-Djmh.blackhole.autoDetect=false']).join(' '),
+            '-rf', 'json',
+            '-rff', latencyMapPerformanceReport.get().asFile.absolutePath
+    outputs.file(latencyMapPerformanceReport)
+    outputs.upToDateWhen { false }
+    doFirst {
+        latencyMapPerformanceReport.get().asFile.parentFile.mkdirs()
+        delete latencyMapPerformanceReport
+    }
+}
+
+tasks.register('latencyMapPerformanceTest') {
+    group = 'verification'
+    description = 'Compares primitive-map throughput and allocation with the boxed map.'
+    dependsOn tasks.named('runLatencyMapPerformanceBenchmark')
+
+    doLast {
+        def results = new groovy.json.JsonSlurper().parse(
+                latencyMapPerformanceReport.get().asFile)
+        def byBenchmark = results.collectEntries { [(it.benchmark): it] }
+        def result = { String benchmark ->
+            def value = byBenchmark[benchmark]
+            if (value == null) {
+                throw new GradleException(
+                        "Missing latency-map JMH result: ${benchmark}")
+            }
+            if (!value.jdkVersion.toString().startsWith('25')) {
+                throw new GradleException(
+                        "Latency-map comparison requires JDK 25; found "
+                                + value.jdkVersion)
+            }
+            value
+        }
+
+        def primitive = result(
+                'io.perl.benchmark.LatencyMapBenchmark'
+                        + '.primitiveRecordLatency')
+        def boxed = result(
+                'io.perl.benchmark.LatencyMapBenchmark'
+                        + '.boxedRecordLatency')
+        def primitiveThroughput = primitive.primaryMetric
+        def boxedThroughput = boxed.primaryMetric
+        def primitiveAllocation =
+                primitive.secondaryMetrics['gc.alloc.rate.norm']
+        def boxedAllocation = boxed.secondaryMetrics['gc.alloc.rate.norm']
+        def throughputDifference = (primitiveThroughput.score
+                - boxedThroughput.score)
+        def throughputChange = (throughputDifference * 100.0) /
+                boxedThroughput.score
+        def allocationDifference = (boxedAllocation.score
+                - primitiveAllocation.score)
+        def allocationReduction = (boxedAllocation.score
+                - primitiveAllocation.score) * 100.0 / boxedAllocation.score
+        def confidenceConclusion
+        if (primitiveThroughput.scoreConfidence[0]
+                > boxedThroughput.scoreConfidence[1]) {
+            confidenceConclusion = (
+                    'LongHashMapLatencyRecorder is faster; '
+                            + 'the 99.9% confidence intervals do not overlap')
+        } else if (boxedThroughput.scoreConfidence[0]
+                > primitiveThroughput.scoreConfidence[1]) {
+            confidenceConclusion = (
+                    'HashMapLatencyRecorder is faster; '
+                            + 'the 99.9% confidence intervals do not overlap')
+        } else {
+            confidenceConclusion = (
+                    'inconclusive; the 99.9% confidence intervals overlap')
+        }
+
+        logger.lifecycle(
+                'Sparse latency-map JMH comparison:')
+        logger.lifecycle(String.format(
+                '  LongHashMapLatencyRecorder : %,.0f ops/s, %.3f B/op',
+                primitiveThroughput.score, primitiveAllocation.score))
+        logger.lifecycle(String.format(
+                '  HashMapLatencyRecorder     : %,.0f ops/s, %.3f B/op',
+                boxedThroughput.score, boxedAllocation.score))
+        if (throughputDifference >= 0) {
+            logger.lifecycle(String.format(
+                    '  Throughput result          : LongHashMapLatencyRecorder'
+                            + ' is %.2f%% faster (+%,.0f ops/s)',
+                    throughputChange, throughputDifference))
+        } else {
+            logger.lifecycle(String.format(
+                    '  Throughput result          : LongHashMapLatencyRecorder'
+                            + ' is %.2f%% slower (%,.0f ops/s)',
+                    Math.abs(throughputChange), throughputDifference))
+        }
+        logger.lifecycle(String.format(
+                '  Allocation result          : LongHashMapLatencyRecorder'
+                        + ' uses %.3f fewer B/op (%.2f%% reduction)',
+                allocationDifference,
+                allocationReduction))
+        logger.lifecycle(
+                "  Statistical conclusion     : ${confidenceConclusion}")
+        logger.lifecycle(
+                "JMH report: ${latencyMapPerformanceReport.get().asFile}")
+
+        if (primitiveAllocation.score >= boxedAllocation.score) {
+            throw new GradleException(String.format(
+                    'Primitive latency map allocation %.3f B/op is not below '
+                            + 'boxed map allocation %.3f B/op',
+                    primitiveAllocation.score, boxedAllocation.score))
+        }
     }
 }
 

--- a/perl/build.gradle
+++ b/perl/build.gradle
@@ -289,6 +289,18 @@ tasks.register('latencyMapPerformanceTest') {
         def primitiveAllocation =
                 primitive.secondaryMetrics['gc.alloc.rate.norm']
         def boxedAllocation = boxed.secondaryMetrics['gc.alloc.rate.norm']
+        def allocatedExtraction = result(
+                'io.perl.benchmark.LatencyMapBenchmark'
+                        + '.allocatedSortedListExtraction')
+        def reusableExtraction = result(
+                'io.perl.benchmark.LatencyMapBenchmark'
+                        + '.reusableArrayExtraction')
+        def allocatedExtractionTime = allocatedExtraction.primaryMetric
+        def reusableExtractionTime = reusableExtraction.primaryMetric
+        def allocatedExtractionAllocation =
+                allocatedExtraction.secondaryMetrics['gc.alloc.rate.norm']
+        def reusableExtractionAllocation =
+                reusableExtraction.secondaryMetrics['gc.alloc.rate.norm']
         def throughputDifference = (primitiveThroughput.score
                 - boxedThroughput.score)
         def throughputChange = (throughputDifference * 100.0) /
@@ -340,6 +352,23 @@ tasks.register('latencyMapPerformanceTest') {
         logger.lifecycle(
                 "  Statistical conclusion     : ${confidenceConclusion}")
         logger.lifecycle(
+                'Percentile key-extraction JMH comparison (65,536 keys):')
+        logger.lifecycle(String.format(
+                '  Allocating sorted list : %,.3f us/op, %,.3f B/op',
+                allocatedExtractionTime.score,
+                allocatedExtractionAllocation.score))
+        logger.lifecycle(String.format(
+                '  Reusable primitive array: %,.3f us/op, %,.3f B/op',
+                reusableExtractionTime.score,
+                reusableExtractionAllocation.score))
+        logger.lifecycle(String.format(
+                '  Extraction allocation reduction: %,.3f B/op (%.2f%%)',
+                allocatedExtractionAllocation.score
+                        - reusableExtractionAllocation.score,
+                (allocatedExtractionAllocation.score
+                        - reusableExtractionAllocation.score) * 100.0
+                        / allocatedExtractionAllocation.score))
+        logger.lifecycle(
                 "JMH report: ${latencyMapPerformanceReport.get().asFile}")
 
         if (primitiveAllocation.score >= boxedAllocation.score) {
@@ -347,6 +376,14 @@ tasks.register('latencyMapPerformanceTest') {
                     'Primitive latency map allocation %.3f B/op is not below '
                             + 'boxed map allocation %.3f B/op',
                     primitiveAllocation.score, boxedAllocation.score))
+        }
+        if (reusableExtractionAllocation.score
+                >= allocatedExtractionAllocation.score) {
+            throw new GradleException(String.format(
+                    'Reusable extraction allocation %.3f B/op is not below '
+                            + 'sorted-list extraction allocation %.3f B/op',
+                    reusableExtractionAllocation.score,
+                    allocatedExtractionAllocation.score))
         }
     }
 }

--- a/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
+++ b/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.perl.benchmark;
+
+import io.perl.api.impl.HashMapLatencyRecorder;
+import io.perl.api.impl.LongHashMapLatencyRecorder;
+import io.time.NanoSeconds;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares sparse-latency recording through primitive and boxed maps.
+ *
+ * <p>The workload cycles over 4,096 exact latency values outside the JVM's
+ * small boxed-{@link Long} cache. The GC profiler therefore exposes allocation
+ * caused by boxing keys and updated counts in the reference implementation,
+ * while throughput measures the complete frequency-update path.</p>
+ */
+@Fork(value = 3)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Timeout(time = 30, timeUnit = TimeUnit.SECONDS)
+public class LatencyMapBenchmark {
+    private static final long BASE_LATENCY = 1_000;
+    private static final long LATENCY_MASK = 4_095;
+    private static final double[] PERCENTILES =
+            new double[]{0.5, 0.9, 0.99};
+
+    /**
+     * Thread-private recorder state.
+     */
+    @State(Scope.Thread)
+    public static class RecorderState {
+        private HashMapLatencyRecorder boxed;
+        private LongHashMapLatencyRecorder primitive;
+        private long boxedSequence;
+        private long primitiveSequence;
+
+        /**
+         * Creates empty recorders before each measurement iteration.
+         */
+        @Setup(Level.Iteration)
+        public void setUp() {
+            boxed = new HashMapLatencyRecorder(0, Long.MAX_VALUE,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds(), 64);
+            primitive = new LongHashMapLatencyRecorder(0, Long.MAX_VALUE,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds(), 64);
+            boxedSequence = 0;
+            primitiveSequence = 0;
+        }
+    }
+
+    /**
+     * Measures the primitive frequency-update path.
+     *
+     * @param state thread-private recorder state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void primitiveRecordLatency(RecorderState state) {
+        final long latency = BASE_LATENCY
+                + (state.primitiveSequence++ & LATENCY_MASK);
+        state.primitive.reportLatency(latency, 1);
+    }
+
+    /**
+     * Measures the boxed frequency-update reference path.
+     *
+     * @param state thread-private recorder state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void boxedRecordLatency(RecorderState state) {
+        final long latency = BASE_LATENCY
+                + (state.boxedSequence++ & LATENCY_MASK);
+        state.boxed.reportLatency(latency, 1);
+    }
+}

--- a/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
+++ b/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
@@ -19,12 +19,16 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Timeout;
 import org.openjdk.jmh.annotations.Warmup;
+import org.eclipse.collections.api.iterator.MutableLongIterator;
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -72,6 +76,38 @@ public class LatencyMapBenchmark {
     }
 
     /**
+     * Thread-private state comparing transient sorted-list extraction with a
+     * reusable primitive sorting array.
+     */
+    @State(Scope.Thread)
+    public static class ExtractionState {
+        /**
+         * Number of distinct latency keys copied and sorted per extraction.
+         */
+        @Param({"65536"})
+        public int distinctLatencies;
+
+        private LongLongHashMap allocatedMap;
+        private LongLongHashMap reusableMap;
+        private long[] reusableBuffer;
+
+        /**
+         * Populates identical primitive maps and allocates the reusable buffer.
+         */
+        @Setup(Level.Trial)
+        public void setUp() {
+            allocatedMap = new LongLongHashMap(distinctLatencies);
+            reusableMap = new LongLongHashMap(distinctLatencies);
+            reusableBuffer = new long[distinctLatencies];
+            for (int index = 0; index < distinctLatencies; index++) {
+                final long latency = BASE_LATENCY + index;
+                allocatedMap.put(latency, index + 1L);
+                reusableMap.put(latency, index + 1L);
+            }
+        }
+    }
+
+    /**
      * Measures the primitive frequency-update path.
      *
      * @param state thread-private recorder state
@@ -97,5 +133,47 @@ public class LatencyMapBenchmark {
         final long latency = BASE_LATENCY
                 + (state.boxedSequence++ & LATENCY_MASK);
         state.boxed.reportLatency(latency, 1);
+    }
+
+    /**
+     * Measures the former extraction mechanism that allocates a sorted list.
+     *
+     * @param state thread-private extraction state
+     * @return checksum that consumes all sorted keys and counts
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public long allocatedSortedListExtraction(ExtractionState state) {
+        final MutableLongIterator keys =
+                state.allocatedMap.keySet().toSortedList().longIterator();
+        long checksum = 0;
+        while (keys.hasNext()) {
+            final long latency = keys.next();
+            checksum += latency ^ state.allocatedMap.get(latency);
+        }
+        return checksum;
+    }
+
+    /**
+     * Measures extraction through a retained primitive sorting array.
+     *
+     * @param state thread-private extraction state
+     * @return checksum that consumes all sorted keys and counts
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public long reusableArrayExtraction(ExtractionState state) {
+        final int size = state.reusableMap.size();
+        state.reusableBuffer =
+                state.reusableMap.keySet().toArray(state.reusableBuffer);
+        Arrays.sort(state.reusableBuffer, 0, size);
+        long checksum = 0;
+        for (int index = 0; index < size; index++) {
+            final long latency = state.reusableBuffer[index];
+            checksum += latency ^ state.reusableMap.get(latency);
+        }
+        return checksum;
     }
 }

--- a/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
+++ b/perl/src/jmh/java/io/perl/benchmark/LatencyMapBenchmark.java
@@ -9,6 +9,8 @@
  */
 package io.perl.benchmark;
 
+import io.perl.api.LatencyPercentiles;
+import io.perl.api.impl.ArrayLatencyRecorder;
 import io.perl.api.impl.HashMapLatencyRecorder;
 import io.perl.api.impl.LongHashMapLatencyRecorder;
 import io.time.NanoSeconds;
@@ -32,7 +34,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Compares sparse-latency recording through primitive and boxed maps.
+ * Compares dense-array, primitive-map, and boxed-map latency recording.
  *
  * <p>The workload cycles over 4,096 exact latency values outside the JVM's
  * small boxed-{@link Long} cache. The GC profiler therefore exposes allocation
@@ -56,8 +58,10 @@ public class LatencyMapBenchmark {
     public static class RecorderState {
         private HashMapLatencyRecorder boxed;
         private LongHashMapLatencyRecorder primitive;
+        private ArrayLatencyRecorder array;
         private long boxedSequence;
         private long primitiveSequence;
+        private long arraySequence;
 
         /**
          * Creates empty recorders before each measurement iteration.
@@ -70,8 +74,13 @@ public class LatencyMapBenchmark {
             primitive = new LongHashMapLatencyRecorder(0, Long.MAX_VALUE,
                     Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
                     PERCENTILES, new NanoSeconds(), 64);
+            array = new ArrayLatencyRecorder(0,
+                    BASE_LATENCY + LATENCY_MASK,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds());
             boxedSequence = 0;
             primitiveSequence = 0;
+            arraySequence = 0;
         }
     }
 
@@ -108,6 +117,46 @@ public class LatencyMapBenchmark {
     }
 
     /**
+     * Thread-private state for a complete record-and-extract window.
+     */
+    @State(Scope.Thread)
+    public static class WindowState {
+        /**
+         * Number of distinct exact latency values in each window.
+         */
+        @Param({"4096"})
+        public int distinctLatencies;
+
+        private ArrayLatencyRecorder array;
+        private HashMapLatencyRecorder boxed;
+        private LongHashMapLatencyRecorder primitive;
+        private LatencyPercentiles arrayPercentiles;
+        private LatencyPercentiles boxedPercentiles;
+        private LatencyPercentiles primitivePercentiles;
+
+        /**
+         * Creates reusable recorders and percentile result holders.
+         */
+        @Setup(Level.Trial)
+        public void setUp() {
+            final long highLatency =
+                    BASE_LATENCY + distinctLatencies - 1L;
+            array = new ArrayLatencyRecorder(0, highLatency,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds());
+            boxed = new HashMapLatencyRecorder(0, highLatency,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds(), 64);
+            primitive = new LongHashMapLatencyRecorder(0, highLatency,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    PERCENTILES, new NanoSeconds(), 64);
+            arrayPercentiles = new LatencyPercentiles(PERCENTILES);
+            boxedPercentiles = new LatencyPercentiles(PERCENTILES);
+            primitivePercentiles = new LatencyPercentiles(PERCENTILES);
+        }
+    }
+
+    /**
      * Measures the primitive frequency-update path.
      *
      * @param state thread-private recorder state
@@ -133,6 +182,67 @@ public class LatencyMapBenchmark {
         final long latency = BASE_LATENCY
                 + (state.boxedSequence++ & LATENCY_MASK);
         state.boxed.reportLatency(latency, 1);
+    }
+
+    /**
+     * Measures the dense-array frequency-update path.
+     *
+     * @param state thread-private recorder state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void arrayRecordLatency(RecorderState state) {
+        final long latency = BASE_LATENCY
+                + (state.arraySequence++ & LATENCY_MASK);
+        state.array.reportLatency(latency, 1);
+    }
+
+    /**
+     * Measures one complete dense-array window: record every distinct value,
+     * calculate percentiles, and clear the used counters.
+     *
+     * @param state thread-private window state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void arrayWindow(WindowState state) {
+        for (int index = 0; index < state.distinctLatencies; index++) {
+            state.array.reportLatency(BASE_LATENCY + index, 1);
+        }
+        state.array.copyPercentiles(state.arrayPercentiles, null);
+    }
+
+    /**
+     * Measures one complete boxed-map window.
+     *
+     * @param state thread-private window state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void boxedWindow(WindowState state) {
+        for (int index = 0; index < state.distinctLatencies; index++) {
+            state.boxed.reportLatency(BASE_LATENCY + index, 1);
+        }
+        state.boxed.copyPercentiles(state.boxedPercentiles, null);
+    }
+
+    /**
+     * Measures one complete primitive-map window.
+     *
+     * @param state thread-private window state
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public void primitiveWindow(WindowState state) {
+        for (int index = 0; index < state.distinctLatencies; index++) {
+            state.primitive.reportLatency(BASE_LATENCY + index, 1);
+        }
+        state.primitive.copyPercentiles(
+                state.primitivePercentiles, null);
     }
 
     /**

--- a/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
@@ -56,6 +56,12 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
     }
 
 
+    /**
+     * Resets counters and clears any latency buckets retained from the
+     * preceding reporting window.
+     *
+     * @param startTime start time of the new reporting window
+     */
     @Override
     public void reset(long startTime) {
         super.reset(startTime);
@@ -76,6 +82,13 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
     }
 
 
+    /**
+     * Calculates exact percentiles from the sorted primitive latency keys and
+     * clears the recorded buckets for reuse.
+     *
+     * @param percentiles   destination percentile values and bucket counts
+     * @param copyLatencies optional destination for aggregate and bucket data
+     */
     @Override
     public void copyPercentiles(LatencyPercentiles percentiles, ReportLatencies copyLatencies) {
         if (copyLatencies != null) {

--- a/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
@@ -17,17 +17,20 @@ import io.perl.api.ReportLatencies;
 import io.perl.config.LatencyConfig;
 import io.perl.data.Bytes;
 import io.time.Time;
-import org.eclipse.collections.api.iterator.MutableLongIterator;
 import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+
+import java.util.Arrays;
 
 /**
  * Records latency frequencies in a primitive long-to-long hash map.
  */
 final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
+    private static final long[] EMPTY_SORTED_LATENCIES = new long[0];
     final private LongLongHashMap latencies;
     final private long maxMapSizeBytes;
     final private int incBytes;
     private long mapBytesCount;
+    private long[] sortedLatencies;
 
     /**
      * Constructor  LongHashMapLatencyRecorder initializing all values.
@@ -49,6 +52,7 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
         this.maxMapSizeBytes = (long) maxMapSizeMB * Bytes.BYTES_PER_MB;
         this.incBytes = LatencyConfig.LATENCY_VALUE_SIZE_BYTES * 2;
         this.mapBytesCount = 0;
+        this.sortedLatencies = EMPTY_SORTED_LATENCIES;
     }
 
 
@@ -78,10 +82,15 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
             copyLatencies.reportLatencyRecord(this);
         }
         percentiles.reset(validLatencyRecords);
-        MutableLongIterator keys = latencies.keySet().toSortedList().longIterator();
+        final int size = latencies.size();
+        if (sortedLatencies.length < size) {
+            sortedLatencies = new long[size];
+        }
+        sortedLatencies = latencies.keySet().toArray(sortedLatencies);
+        Arrays.sort(sortedLatencies, 0, size);
         long curIndex = 0;
-        while (keys.hasNext()) {
-            final long latency = keys.next();
+        for (int index = 0; index < size; index++) {
+            final long latency = sortedLatencies[index];
             final long count = latencies.get(latency);
             final long nextIndex = curIndex + count;
 

--- a/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
@@ -55,7 +55,9 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
     @Override
     public void reset(long startTime) {
         super.reset(startTime);
-        this.latencies.clear();
+        if (this.latencies.notEmpty()) {
+            this.latencies.clear();
+        }
         this.mapBytesCount = 0;
     }
 

--- a/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/LongHashMapLatencyRecorder.java
@@ -88,8 +88,8 @@ final public class LongHashMapLatencyRecorder extends LatencyRecordWindow  {
             }
             percentiles.copyLatency(latency, count, curIndex, nextIndex);
             curIndex = nextIndex;
-            latencies.remove(latency);
         }
+        latencies.clear();
         mapBytesCount = 0;
     }
 

--- a/perl/src/main/java/io/perl/api/impl/MapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/MapLatencyRecorder.java
@@ -76,6 +76,13 @@ public sealed class MapLatencyRecorder extends LatencyRecordWindow permits HashM
     }
 
 
+    /**
+     * Calculates exact percentiles from the sorted boxed latency keys and
+     * clears the recorded buckets for reuse.
+     *
+     * @param percentiles   destination percentile values and bucket counts
+     * @param copyLatencies optional destination for aggregate and bucket data
+     */
     @Override
     public void copyPercentiles(LatencyPercentiles percentiles, ReportLatencies copyLatencies) {
         if (copyLatencies != null) {

--- a/perl/src/main/java/io/perl/api/impl/MapLatencyRecorder.java
+++ b/perl/src/main/java/io/perl/api/impl/MapLatencyRecorder.java
@@ -94,8 +94,8 @@ public sealed class MapLatencyRecorder extends LatencyRecordWindow permits HashM
             }
             percentiles.copyLatency(latency, count, curIndex, nextIndex);
             curIndex = nextIndex;
-            latencies.remove(latency);
         }
+        latencies.clear();
         mapBytesCount = 0;
     }
 

--- a/perl/src/main/java/io/perl/api/impl/PerlBuilder.java
+++ b/perl/src/main/java/io/perl/api/impl/PerlBuilder.java
@@ -86,10 +86,10 @@ public final class PerlBuilder {
             PerlPrinter.log.info("Window Latency Store: Array, Size: " +
                     window.getMaxMemoryBytes() / Bytes.BYTES_PER_MB + " MB");
         } else {
-            window = new HashMapLatencyRecorder(minLatency, maxLatency,
+            window = new LongHashMapLatencyRecorder(minLatency, maxLatency,
                     LatencyConfig.TOTAL_LATENCY_MAX, LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX, percentileFractions,
                     time, config.maxHashMapSizeMB);
-            PerlPrinter.log.info("Window Latency Store: HashMap, Size: " +
+            PerlPrinter.log.info("Window Latency Store: PrimitiveLongMap, Size: " +
                     window.getMaxMemoryBytes() / Bytes.BYTES_PER_MB + " MB");
         }
         return window;
@@ -123,10 +123,10 @@ public final class PerlBuilder {
 
         window = buildLatencyRecordWindow(config, time, minLatency, maxLatency, percentileFractions);
 
-        totalWindow = new HashMapLatencyRecorder(minLatency, maxLatency,
+        totalWindow = new LongHashMapLatencyRecorder(minLatency, maxLatency,
                 LatencyConfig.TOTAL_LATENCY_MAX, LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX, percentileFractions,
                 time, config.totalMaxHashMapSizeMB);
-        PerlPrinter.log.info("Total Window Latency Store: HashMap, Size: " +
+        PerlPrinter.log.info("Total Window Latency Store: PrimitiveLongMap, Size: " +
                 totalWindow.getMaxMemoryBytes() / Bytes.BYTES_PER_MB + " MB");
 
         if (config.histogram) {

--- a/perl/src/test/java/io/perl/test/ArrayLatencyRecorderTest.java
+++ b/perl/src/test/java/io/perl/test/ArrayLatencyRecorderTest.java
@@ -10,18 +10,31 @@
 package io.perl.test;
 
 import io.perl.api.LatencyPercentiles;
+import io.perl.api.LatencyRecord;
 import io.perl.api.LatencyRecordWindow;
+import io.perl.api.ReportLatencies;
+import io.perl.api.impl.ArrayLatencyRecorder;
+import io.perl.api.impl.LongHashMapLatencyRecorder;
 import io.perl.api.impl.PerlBuilder;
 import io.perl.config.LatencyConfig;
 import io.time.NanoSeconds;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests for the array-backed latency recorder.
  */
 public class ArrayLatencyRecorderTest {
+    private static final double[] FRACTIONS = new double[]{0.1, 0.5, 0.9, 0.99};
+    private static final long LOW_LATENCY = 100;
+    private static final long HIGH_LATENCY = 4_195;
 
     /**
      * Verify that the inclusive maximum latency has a dedicated array slot.
@@ -39,5 +52,221 @@ public class ArrayLatencyRecorderTest {
 
         assertEquals(10, percentiles.latencies[0]);
         assertEquals(1, percentiles.latenciesCount[0]);
+    }
+
+    /**
+     * Verifies that the builder selects the array recorder when its inclusive
+     * range fits within the configured array-memory limit.
+     */
+    @Test
+    public void builderSelectsArrayRecorderForDenseRange() {
+        final LatencyConfig config = new LatencyConfig();
+        config.maxArraySizeMB = 1;
+
+        final LatencyRecordWindow window = PerlBuilder.buildLatencyRecordWindow(
+                config, new NanoSeconds(), LOW_LATENCY, HIGH_LATENCY,
+                FRACTIONS);
+
+        assertInstanceOf(ArrayLatencyRecorder.class, window);
+    }
+
+    /**
+     * Compares exact array and primitive-map results for non-zero bounds,
+     * inclusive endpoints, discarded values, duplicates, and batched counts.
+     */
+    @Test
+    public void matchesPrimitiveMapForBoundsDiscardsAndBatchedCounts() {
+        final RecorderPair pair = newRecorderPair(100, 110);
+
+        recordBoth(pair, 1, 2, 200, -1);
+        recordBoth(pair, 2, 3, 300, 99);
+        recordBoth(pair, 3, 4, 400, 100);
+        recordBoth(pair, 4, 5, 500, 105);
+        recordBoth(pair, 5, 2, 200, 105);
+        recordBoth(pair, 6, 6, 600, 110);
+        recordBoth(pair, 7, 7, 700, 111);
+
+        final Extraction extraction = assertEquivalentExtraction(pair);
+
+        assertEquals(List.of(100L, 105L, 110L),
+                extraction.arrayLatencies.latencies);
+        assertEquals(List.of(4L, 7L, 6L),
+                extraction.arrayLatencies.counts);
+        assertArrayEquals(new long[]{100, 105, 110, 110},
+                extraction.arrayPercentiles.latencies);
+        assertArrayEquals(new long[]{4, 7, 6, 6},
+                extraction.arrayPercentiles.latenciesCount);
+        assertEquals(105, extraction.arrayPercentiles.medianLatency);
+        assertEquals(29, pair.array.getTotalRecords());
+        assertEquals(17, pair.array.getValidLatencyRecords());
+        assertEquals(2, pair.array.getInvalidLatencyRecords());
+        assertEquals(3, pair.array.getLowerLatencyDiscardRecords());
+        assertEquals(7, pair.array.getHigherLatencyDiscardRecords());
+    }
+
+    /**
+     * Verifies that extracting an empty array window produces exactly the same
+     * zeroed percentile and counter state as the primitive-map recorder.
+     */
+    @Test
+    public void emptyWindowMatchesPrimitiveMap() {
+        final RecorderPair pair = newRecorderPair(LOW_LATENCY, HIGH_LATENCY);
+
+        final Extraction extraction = assertEquivalentExtraction(pair);
+
+        assertEquals(List.of(), extraction.arrayLatencies.latencies);
+        assertEquals(List.of(), extraction.arrayLatencies.counts);
+        assertArrayEquals(new long[FRACTIONS.length],
+                extraction.arrayPercentiles.latencies);
+        assertArrayEquals(new long[FRACTIONS.length],
+                extraction.arrayPercentiles.latenciesCount);
+        assertEquals(0, extraction.arrayPercentiles.medianLatency);
+    }
+
+    /**
+     * Exercises the production extract-then-reset lifecycle over growing,
+     * shrinking, duplicate-heavy, and empty windows.
+     */
+    @Test
+    public void repeatedGrowingAndShrinkingWindowsMatchPrimitiveMap() {
+        final RecorderPair pair = newRecorderPair(LOW_LATENCY, HIGH_LATENCY);
+        final Random random = new Random(8_613_407L);
+        final int[] windowSizes =
+                new int[]{1, 17, 257, 31, 1_024, 3, 0, 513, 2};
+
+        for (int window = 0; window < windowSizes.length; window++) {
+            pair.array.reset(window);
+            pair.primitive.reset(window);
+            for (int sample = 0; sample < windowSizes[window]; sample++) {
+                final long latency = latencyForSample(random, sample);
+                final int records = random.nextInt(8) + 1;
+                recordBoth(pair, sample, records, records * 100, latency);
+            }
+            assertEquivalentExtraction(pair);
+        }
+    }
+
+    /**
+     * Verifies repeated empty resets before extraction and subsequent normal
+     * record/extract cycles without changing production reset semantics.
+     */
+    @Test
+    public void repeatedEmptyResetsAndExtractionMatchPrimitiveMap() {
+        final RecorderPair pair = newRecorderPair(LOW_LATENCY, HIGH_LATENCY);
+
+        for (int window = 0; window < 10; window++) {
+            pair.array.reset(window);
+            pair.primitive.reset(window);
+        }
+        assertEquivalentExtraction(pair);
+
+        for (int window = 0; window < 20; window++) {
+            pair.array.reset(window);
+            pair.primitive.reset(window);
+            final long latency = LOW_LATENCY + window;
+            recordBoth(pair, window, window + 1, (window + 1) * 10,
+                    latency);
+            assertEquivalentExtraction(pair);
+        }
+    }
+
+    private long latencyForSample(Random random, int sample) {
+        return switch (sample) {
+            case 0 -> LOW_LATENCY;
+            case 1 -> HIGH_LATENCY;
+            case 2, 3 -> LOW_LATENCY + 17;
+            default -> LOW_LATENCY
+                    + random.nextInt((int) (HIGH_LATENCY - LOW_LATENCY + 1));
+        };
+    }
+
+    private RecorderPair newRecorderPair(long lowLatency, long highLatency) {
+        final NanoSeconds time = new NanoSeconds();
+        final LatencyRecordWindow array = new ArrayLatencyRecorder(
+                lowLatency, highLatency, LatencyConfig.TOTAL_LATENCY_MAX,
+                LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX, FRACTIONS,
+                time);
+        final LatencyRecordWindow primitive = new LongHashMapLatencyRecorder(
+                lowLatency, highLatency, LatencyConfig.TOTAL_LATENCY_MAX,
+                LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX, FRACTIONS,
+                time, 16);
+        return new RecorderPair(array, primitive);
+    }
+
+    private void recordBoth(RecorderPair pair, long startTime, int events,
+                            int bytes, long latency) {
+        pair.array.recordLatency(startTime, events, bytes, latency);
+        pair.primitive.recordLatency(startTime, events, bytes, latency);
+    }
+
+    private Extraction assertEquivalentExtraction(RecorderPair pair) {
+        final LatencyPercentiles arrayPercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyPercentiles primitivePercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyCollector arrayLatencies = new LatencyCollector();
+        final LatencyCollector primitiveLatencies = new LatencyCollector();
+
+        pair.array.copyPercentiles(arrayPercentiles, arrayLatencies);
+        pair.primitive.copyPercentiles(primitivePercentiles,
+                primitiveLatencies);
+
+        assertRecordEquals(pair.array, pair.primitive);
+        assertEquals(arrayLatencies.recordsReported,
+                primitiveLatencies.recordsReported);
+        assertEquals(arrayLatencies.latencies, primitiveLatencies.latencies);
+        assertEquals(arrayLatencies.counts, primitiveLatencies.counts);
+        assertArrayEquals(arrayPercentiles.latencies,
+                primitivePercentiles.latencies);
+        assertArrayEquals(arrayPercentiles.latenciesCount,
+                primitivePercentiles.latenciesCount);
+        assertEquals(arrayPercentiles.medianLatency,
+                primitivePercentiles.medianLatency);
+        assertArrayEquals(arrayPercentiles.latencyIndexes,
+                primitivePercentiles.latencyIndexes);
+
+        return new Extraction(arrayPercentiles, arrayLatencies);
+    }
+
+    private void assertRecordEquals(LatencyRecordWindow expected,
+                                    LatencyRecordWindow actual) {
+        assertEquals(expected.getTotalRecords(), actual.getTotalRecords());
+        assertEquals(expected.getValidLatencyRecords(),
+                actual.getValidLatencyRecords());
+        assertEquals(expected.getInvalidLatencyRecords(),
+                actual.getInvalidLatencyRecords());
+        assertEquals(expected.getLowerLatencyDiscardRecords(),
+                actual.getLowerLatencyDiscardRecords());
+        assertEquals(expected.getHigherLatencyDiscardRecords(),
+                actual.getHigherLatencyDiscardRecords());
+        assertEquals(expected.getTotalBytes(), actual.getTotalBytes());
+        assertEquals(expected.getTotalLatency(), actual.getTotalLatency());
+        assertEquals(expected.getMinLatency(), actual.getMinLatency());
+        assertEquals(expected.getMaxLatency(), actual.getMaxLatency());
+    }
+
+    private record RecorderPair(LatencyRecordWindow array,
+                                LatencyRecordWindow primitive) {
+    }
+
+    private record Extraction(LatencyPercentiles arrayPercentiles,
+                              LatencyCollector arrayLatencies) {
+    }
+
+    private static final class LatencyCollector implements ReportLatencies {
+        private final List<Long> latencies = new ArrayList<>();
+        private final List<Long> counts = new ArrayList<>();
+        private int recordsReported;
+
+        @Override
+        public void reportLatencyRecord(LatencyRecord record) {
+            recordsReported++;
+        }
+
+        @Override
+        public void reportLatency(long latency, long count) {
+            latencies.add(latency);
+            counts.add(count);
+        }
     }
 }

--- a/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
+++ b/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -120,6 +121,99 @@ public class LatencyMapRecorderTest {
                 primitivePercentiles.latencies);
         assertArrayEquals(boxedPercentiles.latenciesCount,
                 primitivePercentiles.latenciesCount);
+    }
+
+    /**
+     * Verifies that growing and reusing the primitive sorting buffer does not
+     * retain stale latency keys from a larger preceding window.
+     */
+    @Test
+    public void primitiveRecorderReusesSortingBufferWithoutStaleLatencies() {
+        final LongHashMapLatencyRecorder primitive =
+                (LongHashMapLatencyRecorder) newRecorder(false);
+        final LatencyPercentiles percentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyCollector firstWindow = new LatencyCollector();
+        final LatencyCollector secondWindow = new LatencyCollector();
+
+        primitive.recordLatency(0, 1, 100, 9);
+        primitive.recordLatency(0, 2, 200, 1);
+        primitive.recordLatency(0, 3, 300, 5);
+        primitive.recordLatency(0, 4, 400, 0);
+        primitive.copyPercentiles(percentiles, firstWindow);
+
+        assertEquals(List.of(0L, 1L, 5L, 9L), firstWindow.latencies);
+        assertEquals(List.of(4L, 2L, 3L, 1L), firstWindow.counts);
+        assertArrayEquals(new long[]{1, 9, 9}, percentiles.latencies);
+        assertArrayEquals(new long[]{2, 1, 1}, percentiles.latenciesCount);
+        assertEquals(1, percentiles.medianLatency);
+
+        primitive.reset(1);
+        primitive.recordLatency(1, 2, 200, 7);
+        primitive.recordLatency(1, 1, 100, 2);
+        primitive.copyPercentiles(percentiles, secondWindow);
+
+        assertEquals(List.of(2L, 7L), secondWindow.latencies);
+        assertEquals(List.of(1L, 2L), secondWindow.counts);
+        assertArrayEquals(new long[]{7, 7, 7}, percentiles.latencies);
+        assertArrayEquals(new long[]{2, 2, 2}, percentiles.latenciesCount);
+        assertEquals(7, percentiles.medianLatency);
+    }
+
+    /**
+     * Compares repeated empty, growing, and shrinking windows against the
+     * boxed reference implementation using deterministic random samples.
+     */
+    @Test
+    public void reusableSortingBufferMatchesBoxedRecorderAcrossWindows() {
+        final LatencyRecordWindow boxed = newRecorder(true);
+        final LatencyRecordWindow primitive = newRecorder(false);
+        final Random random = new Random(7_241_993L);
+        final int[] windowSizes =
+                new int[]{0, 1, 2, 17, 257, 31, 1_024, 3, 0, 513};
+
+        for (int window = 0; window < windowSizes.length; window++) {
+            boxed.reset(window);
+            primitive.reset(window);
+            for (int sample = 0; sample < windowSizes[window]; sample++) {
+                final long latency;
+                if (sample == 0) {
+                    latency = 0;
+                } else if (sample == 1) {
+                    latency = 1;
+                } else {
+                    latency = random.nextInt(1_000_000);
+                }
+                final int records = random.nextInt(7) + 1;
+                final int bytes = records * 100;
+                boxed.recordLatency(sample, records, bytes, latency);
+                primitive.recordLatency(sample, records, bytes, latency);
+            }
+            assertExtractionEquals(boxed, primitive);
+        }
+    }
+
+    private void assertExtractionEquals(LatencyRecordWindow boxed,
+                                        LatencyRecordWindow primitive) {
+        final LatencyPercentiles boxedPercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyPercentiles primitivePercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyCollector boxedLatencies = new LatencyCollector();
+        final LatencyCollector primitiveLatencies = new LatencyCollector();
+
+        boxed.copyPercentiles(boxedPercentiles, boxedLatencies);
+        primitive.copyPercentiles(primitivePercentiles, primitiveLatencies);
+
+        assertRecordEquals(boxed, primitive);
+        assertEquals(boxedLatencies.latencies, primitiveLatencies.latencies);
+        assertEquals(boxedLatencies.counts, primitiveLatencies.counts);
+        assertArrayEquals(boxedPercentiles.latencies,
+                primitivePercentiles.latencies);
+        assertArrayEquals(boxedPercentiles.latenciesCount,
+                primitivePercentiles.latenciesCount);
+        assertEquals(boxedPercentiles.medianLatency,
+                primitivePercentiles.medianLatency);
     }
 
     private LatencyRecordWindow newRecorder(boolean boxed) {

--- a/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
+++ b/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.perl.test;
+
+import io.perl.api.LatencyPercentiles;
+import io.perl.api.LatencyRecord;
+import io.perl.api.LatencyRecordWindow;
+import io.perl.api.ReportLatencies;
+import io.perl.api.impl.HashMapLatencyRecorder;
+import io.perl.api.impl.LongHashMapLatencyRecorder;
+import io.perl.api.impl.PerlBuilder;
+import io.perl.config.LatencyConfig;
+import io.time.NanoSeconds;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Verifies that the primitive sparse latency recorder preserves the behavior
+ * of the boxed reference implementation.
+ */
+public class LatencyMapRecorderTest {
+    private static final double[] FRACTIONS =
+            new double[]{0.5, 0.9, 0.99};
+
+    /**
+     * Compares counters, ordered latency buckets, and percentiles for valid,
+     * discarded, invalid, repeated, and zero-valued latency samples.
+     */
+    @Test
+    public void primitiveRecorderMatchesBoxedRecorder() {
+        final LatencyRecordWindow boxed = newRecorder(true);
+        final LatencyRecordWindow primitive = newRecorder(false);
+        final long[] latencies = new long[]{
+                500, 0, 999_999, 500, 42, -1, 1_000_001, 7
+        };
+        final int[] records = new int[]{2, 1, 3, 4, 2, 1, 2, 3};
+
+        for (int index = 0; index < latencies.length; index++) {
+            boxed.recordLatency(index, records[index], records[index] * 100,
+                    latencies[index]);
+            primitive.recordLatency(index, records[index],
+                    records[index] * 100, latencies[index]);
+        }
+
+        assertRecordEquals(boxed, primitive);
+
+        final LatencyPercentiles boxedPercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyPercentiles primitivePercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyCollector boxedLatencies = new LatencyCollector();
+        final LatencyCollector primitiveLatencies = new LatencyCollector();
+
+        boxed.copyPercentiles(boxedPercentiles, boxedLatencies);
+        primitive.copyPercentiles(primitivePercentiles, primitiveLatencies);
+
+        assertEquals(boxedLatencies.latencies, primitiveLatencies.latencies);
+        assertEquals(boxedLatencies.counts, primitiveLatencies.counts);
+        assertArrayEquals(boxedPercentiles.latencies,
+                primitivePercentiles.latencies);
+        assertArrayEquals(boxedPercentiles.latenciesCount,
+                primitivePercentiles.latenciesCount);
+        assertEquals(boxedPercentiles.medianLatency,
+                primitivePercentiles.medianLatency);
+    }
+
+    /**
+     * Confirms that sparse-window selection now returns the primitive map.
+     */
+    @Test
+    public void builderSelectsPrimitiveRecorderForSparseRange() {
+        final LatencyConfig config = new LatencyConfig();
+        config.maxArraySizeMB = 0;
+
+        final LatencyRecordWindow recorder =
+                PerlBuilder.buildLatencyRecordWindow(config, new NanoSeconds(),
+                        0, 1_000_000, FRACTIONS);
+
+        assertInstanceOf(LongHashMapLatencyRecorder.class, recorder);
+    }
+
+    /**
+     * Confirms that extraction clears both implementations for window reuse.
+     */
+    @Test
+    public void primitiveAndBoxedRecordersRemainEquivalentAfterExtraction() {
+        final LatencyRecordWindow boxed = newRecorder(true);
+        final LatencyRecordWindow primitive = newRecorder(false);
+        final LatencyPercentiles boxedPercentiles =
+                new LatencyPercentiles(FRACTIONS);
+        final LatencyPercentiles primitivePercentiles =
+                new LatencyPercentiles(FRACTIONS);
+
+        boxed.recordLatency(0, 1, 100, 1_000);
+        primitive.recordLatency(0, 1, 100, 1_000);
+        boxed.copyPercentiles(boxedPercentiles, null);
+        primitive.copyPercentiles(primitivePercentiles, null);
+        boxed.reset(1);
+        primitive.reset(1);
+        boxed.recordLatency(1, 3, 300, 2_000);
+        primitive.recordLatency(1, 3, 300, 2_000);
+        boxed.copyPercentiles(boxedPercentiles, null);
+        primitive.copyPercentiles(primitivePercentiles, null);
+
+        assertRecordEquals(boxed, primitive);
+        assertArrayEquals(boxedPercentiles.latencies,
+                primitivePercentiles.latencies);
+        assertArrayEquals(boxedPercentiles.latenciesCount,
+                primitivePercentiles.latenciesCount);
+    }
+
+    private LatencyRecordWindow newRecorder(boolean boxed) {
+        if (boxed) {
+            return new HashMapLatencyRecorder(0, 1_000_000,
+                    Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                    FRACTIONS, new NanoSeconds(), 16);
+        }
+        return new LongHashMapLatencyRecorder(0, 1_000_000,
+                Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE,
+                FRACTIONS, new NanoSeconds(), 16);
+    }
+
+    private void assertRecordEquals(LatencyRecord expected,
+                                    LatencyRecord actual) {
+        assertEquals(expected.getTotalRecords(), actual.getTotalRecords());
+        assertEquals(expected.getValidLatencyRecords(),
+                actual.getValidLatencyRecords());
+        assertEquals(expected.getLowerLatencyDiscardRecords(),
+                actual.getLowerLatencyDiscardRecords());
+        assertEquals(expected.getHigherLatencyDiscardRecords(),
+                actual.getHigherLatencyDiscardRecords());
+        assertEquals(expected.getInvalidLatencyRecords(),
+                actual.getInvalidLatencyRecords());
+        assertEquals(expected.getTotalBytes(), actual.getTotalBytes());
+        assertEquals(expected.getTotalLatency(), actual.getTotalLatency());
+        assertEquals(expected.getMinLatency(), actual.getMinLatency());
+        assertEquals(expected.getMaxLatency(), actual.getMaxLatency());
+    }
+
+    private static final class LatencyCollector implements ReportLatencies {
+        private final List<Long> latencies = new ArrayList<>();
+        private final List<Long> counts = new ArrayList<>();
+
+        @Override
+        public void reportLatencyRecord(LatencyRecord record) {
+            // Aggregate counters are compared directly by the enclosing test.
+        }
+
+        @Override
+        public void reportLatency(long latency, long count) {
+            latencies.add(latency);
+            counts.add(count);
+        }
+    }
+}

--- a/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
+++ b/perl/src/test/java/io/perl/test/LatencyMapRecorderTest.java
@@ -109,6 +109,14 @@ public class LatencyMapRecorderTest {
         primitive.recordLatency(0, 1, 100, 1_000);
         boxed.copyPercentiles(boxedPercentiles, null);
         primitive.copyPercentiles(primitivePercentiles, null);
+        final LatencyCollector boxedAfterExtraction = new LatencyCollector();
+        final LatencyCollector primitiveAfterExtraction =
+                new LatencyCollector();
+        boxed.copyPercentiles(boxedPercentiles, boxedAfterExtraction);
+        primitive.copyPercentiles(primitivePercentiles,
+                primitiveAfterExtraction);
+        assertEquals(List.of(), boxedAfterExtraction.latencies);
+        assertEquals(List.of(), primitiveAfterExtraction.latencies);
         boxed.reset(1);
         primitive.reset(1);
         boxed.recordLatency(1, 3, 300, 2_000);
@@ -248,11 +256,22 @@ public class LatencyMapRecorderTest {
         private final List<Long> latencies = new ArrayList<>();
         private final List<Long> counts = new ArrayList<>();
 
+        /**
+         * Accepts aggregate recorder counters.
+         *
+         * @param record aggregate latency record
+         */
         @Override
         public void reportLatencyRecord(LatencyRecord record) {
             // Aggregate counters are compared directly by the enclosing test.
         }
 
+        /**
+         * Collects one exact latency bucket.
+         *
+         * @param latency latency value
+         * @param count   number of records with the latency
+         */
         @Override
         public void reportLatency(long latency, long count) {
             latencies.add(latency);

--- a/sbm/src/main/java/io/sbm/api/impl/SbmBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmBenchmark.java
@@ -16,7 +16,7 @@ import io.perl.data.Bytes;
 import io.perl.config.LatencyConfig;
 import io.perl.api.LatencyRecordWindow;
 import io.perl.api.impl.CSVExtendedLatencyRecorder;
-import io.perl.api.impl.HashMapLatencyRecorder;
+import io.perl.api.impl.LongHashMapLatencyRecorder;
 import io.perl.api.impl.HdrExtendedLatencyRecorder;
 import io.perl.api.impl.PerlBuilder;
 import io.sbk.api.Benchmark;
@@ -122,10 +122,10 @@ final public class SbmBenchmark implements Benchmark {
         final LatencyRecordWindow totalWindowExtension;
         final Random random = new Random();
 
-        totalWindow = new HashMapLatencyRecorder(logger.getMinLatency(), logger.getMaxLatency(),
+        totalWindow = new LongHashMapLatencyRecorder(logger.getMinLatency(), logger.getMaxLatency(),
                 LatencyConfig.TOTAL_LATENCY_MAX, LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX, percentileFractions,
                 time, sbmConfig.totalMaxHashMapSizeMB);
-        Printer.log.info("Total Window Latency Store: HashMap, Size: " +
+        Printer.log.info("Total Window Latency Store: PrimitiveLongMap, Size: " +
                 totalWindow.getMaxMemoryBytes() / Bytes.BYTES_PER_MB + " MB");
 
         if (sbmConfig.histogram) {

--- a/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
@@ -24,6 +24,8 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.concurrent.GuardedBy;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 
@@ -36,6 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<MessageLatenciesRecord> implements Benchmark,
         SbmRegistry {
+    static final String CONSUMER_THREAD_NAME = "sbm-latency-consumer";
     private final int maxQs;
     private final int idleMS;
     private final Time time;
@@ -43,6 +46,7 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
     private final SbmPeriodicRecorder window;
     private final AtomicLong counter;
     private final CompletableFuture<Void> retFuture;
+    private final ExecutorService executor;
 
     @GuardedBy("this")
     private State state;
@@ -68,6 +72,8 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
         this.reportingIntervalMS = reportingIntervalMS;
         this.counter = new AtomicLong(BASE_CLIENT_ID_VALUE);
         this.retFuture = new CompletableFuture<>();
+        this.executor = Executors.newSingleThreadExecutor(
+                Thread.ofPlatform().name(CONSUMER_THREAD_NAME).factory());
         this.state = State.BEGIN;
         this.qFuture = null;
     }
@@ -147,6 +153,7 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
                 }
                 qFuture = null;
             }
+            executor.shutdown();
             if (ex != null) {
                 Printer.log.warn("SbmLatencyBenchmark with Exception:" + ex);
                 retFuture.completeExceptionally(ex);
@@ -169,7 +176,7 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-            });
+            }, executor);
             qFuture.whenComplete((ret, ex) -> {
                 shutdown(ex);
             });
@@ -183,5 +190,4 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
     }
 
 }
-
 

--- a/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
@@ -141,19 +141,29 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
     private void shutdown(Throwable ex) {
         if (state != State.END) {
             state = State.END;
+            boolean interrupted = false;
             if (qFuture != null) {
                 if (!qFuture.isDone()) {
                     try {
                         add(0, MessageLatenciesRecord.newBuilder().setSequenceNumber(-1).build());
-                        qFuture.get();
-                        clear();
-                    } catch (ExecutionException | InterruptedException e) {
+                        while (!qFuture.isDone()) {
+                            try {
+                                qFuture.get();
+                            } catch (InterruptedException e) {
+                                interrupted = true;
+                            }
+                        }
+                    } catch (ExecutionException e) {
                         e.printStackTrace();
                     }
+                    clear();
                 }
                 qFuture = null;
             }
             executor.shutdown();
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
             if (ex != null) {
                 Printer.log.warn("SbmLatencyBenchmark with Exception:" + ex);
                 retFuture.completeExceptionally(ex);
@@ -165,6 +175,13 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
     }
 
 
+    /**
+     * Starts the SBM latency consumer on its dedicated platform thread.
+     *
+     * @return future completed after the consumer has terminated
+     * @throws IllegalStateException if the benchmark cannot be started from
+     *                               its current state
+     */
     @Override
     @Synchronized
     public CompletableFuture<Void> start() throws IllegalStateException {
@@ -190,4 +207,3 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
     }
 
 }
-

--- a/sbm/src/test/java/io/sbm/api/impl/SbmLatencyBenchmarkTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmLatencyBenchmarkTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbm.api.impl;
+
+import io.sbm.api.SbmPeriodicRecorder;
+import io.sbp.grpc.MessageLatenciesRecord;
+import io.time.MilliSeconds;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the dedicated SBM latency-consumer execution lifecycle.
+ */
+final class SbmLatencyBenchmarkTest {
+
+    /**
+     * Verifies that the queue consumer runs on its named platform thread
+     * instead of the common fork-join pool and exits during shutdown.
+     *
+     * @throws Exception if startup or completion exceeds its timeout
+     */
+    @Test
+    void usesDedicatedPlatformThreadAndStopsIt() throws Exception {
+        final CapturingWindow window = new CapturingWindow();
+        final SbmLatencyBenchmark benchmark = new SbmLatencyBenchmark(
+                1, 1, new MilliSeconds(), window, 5_000);
+
+        final CompletableFuture<Void> completion = benchmark.start();
+
+        assertTrue(window.started.await(2, TimeUnit.SECONDS));
+        final Thread consumer = window.consumer.get();
+        assertNotNull(consumer);
+        assertEquals(SbmLatencyBenchmark.CONSUMER_THREAD_NAME,
+                consumer.getName());
+        assertFalse(consumer.isVirtual());
+        assertFalse(consumer instanceof ForkJoinWorkerThread);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), benchmark::stop);
+        completion.get(2, TimeUnit.SECONDS);
+        awaitThreadExit(consumer);
+        assertFalse(consumer.isAlive());
+    }
+
+    private void awaitThreadExit(Thread thread) throws InterruptedException {
+        final long deadline = System.nanoTime()
+                + TimeUnit.SECONDS.toNanos(2);
+        while (thread.isAlive() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+    }
+
+    private static final class CapturingWindow
+            implements SbmPeriodicRecorder {
+        private final CountDownLatch started = new CountDownLatch(1);
+        private final AtomicReference<Thread> consumer =
+                new AtomicReference<>();
+
+        @Override
+        public void record(long currentTime, MessageLatenciesRecord record) {
+        }
+
+        @Override
+        public void startWindow(long startTime) {
+        }
+
+        @Override
+        public long elapsedMilliSecondsWindow(long currentTime) {
+            return 0;
+        }
+
+        @Override
+        public void stopWindow(long stopTime) {
+        }
+
+        @Override
+        public void start(long startTime) {
+            consumer.set(Thread.currentThread());
+            started.countDown();
+        }
+
+        @Override
+        public void stop(long endTime) {
+        }
+    }
+}

--- a/sbm/src/test/java/io/sbm/api/impl/SbmLatencyBenchmarkTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmLatencyBenchmarkTest.java
@@ -44,16 +44,19 @@ final class SbmLatencyBenchmarkTest {
                 1, 1, new MilliSeconds(), window, 5_000);
 
         final CompletableFuture<Void> completion = benchmark.start();
+        Thread consumer = null;
 
-        assertTrue(window.started.await(2, TimeUnit.SECONDS));
-        final Thread consumer = window.consumer.get();
-        assertNotNull(consumer);
-        assertEquals(SbmLatencyBenchmark.CONSUMER_THREAD_NAME,
-                consumer.getName());
-        assertFalse(consumer.isVirtual());
-        assertFalse(consumer instanceof ForkJoinWorkerThread);
-
-        assertTimeoutPreemptively(Duration.ofSeconds(2), benchmark::stop);
+        try {
+            assertTrue(window.started.await(2, TimeUnit.SECONDS));
+            consumer = window.consumer.get();
+            assertNotNull(consumer);
+            assertEquals(SbmLatencyBenchmark.CONSUMER_THREAD_NAME,
+                    consumer.getName());
+            assertFalse(consumer.isVirtual());
+            assertFalse(consumer instanceof ForkJoinWorkerThread);
+        } finally {
+            assertTimeoutPreemptively(Duration.ofSeconds(2), benchmark::stop);
+        }
         completion.get(2, TimeUnit.SECONDS);
         awaitThreadExit(consumer);
         assertFalse(consumer.isAlive());
@@ -73,29 +76,61 @@ final class SbmLatencyBenchmarkTest {
         private final AtomicReference<Thread> consumer =
                 new AtomicReference<>();
 
+        /**
+         * Accepts a latency record for the current reporting window.
+         *
+         * @param currentTime current time supplied by the consumer
+         * @param record      latency record being aggregated
+         */
         @Override
         public void record(long currentTime, MessageLatenciesRecord record) {
         }
 
+        /**
+         * Starts a reporting window.
+         *
+         * @param startTime reporting-window start time
+         */
         @Override
         public void startWindow(long startTime) {
         }
 
+        /**
+         * Returns the elapsed duration of the current reporting window.
+         *
+         * @param currentTime current time supplied by the consumer
+         * @return elapsed reporting-window duration in milliseconds
+         */
         @Override
         public long elapsedMilliSecondsWindow(long currentTime) {
             return 0;
         }
 
+        /**
+         * Stops the current reporting window.
+         *
+         * @param stopTime reporting-window stop time
+         */
         @Override
         public void stopWindow(long stopTime) {
         }
 
+        /**
+         * Records the consumer thread when aggregation starts.
+         *
+         * @param startTime benchmark start time
+         */
         @Override
         public void start(long startTime) {
             consumer.set(Thread.currentThread());
             started.countDown();
         }
 
+        /**
+         * Stops benchmark-wide aggregation.
+         *
+         * @param endTime benchmark end time
+         */
         @Override
         public void stop(long endTime) {
         }


### PR DESCRIPTION
## Summary
- use `LongHashMapLatencyRecorder` as the default sparse latency store in PerL and SBM
- remove boxed `Long` key/value updates from the default latency-recording path
- clear latency maps once after percentile traversal instead of removing every entry
- avoid clearing an already-empty primitive map during the subsequent window reset
- replace `keySet().toSortedList()` with a reusable primitive `long[]` sorting buffer
- sort and traverse only the active buffer range so smaller later windows cannot consume stale keys
- add equivalence, reset, empty-window, growing-window, shrinking-window, and deterministic randomized percentile tests against `HashMapLatencyRecorder`
- add JMH recording and percentile-extraction comparisons with allocation reporting and confidence intervals

## Why this is required
The boxed `HashMap<Long, Long>` path allocates wrapper objects while recording latency frequencies, which can undermine allocation reductions in SBK’s timestamp queue. Percentile extraction also allocated a new primitive sorted list every reporting interval. With many distinct latency values, that transient allocation increases GC work, consumes memory bandwidth, and can perturb the benchmark being measured.

The primitive map keeps exact sparse latency counts without boxing. The retained primitive sorting array removes per-window list allocation while preserving the existing exact percentile algorithm. It grows only when a window contains more distinct latencies than any prior window and intentionally retains that capacity for reuse.

## Correctness safeguards
- compare primitive-map extraction with the existing boxed implementation as the reference
- validate exact sorted latency keys, frequency counts, percentile values, percentile counts, median, and aggregate record counters
- exercise latency keys `0` and `1`, duplicate counts, empty windows, and repeated grow/shrink cycles
- explicitly verify that stale values beyond the active range of a reused larger array do not affect a smaller later window
- preserve exact, unsampled percentile calculation

## Performance results
On the validation host:

### Sparse latency recording
- `LongHashMapLatencyRecorder`: **442,114,293 ops/s**, **0.001 B/op**
- `HashMapLatencyRecorder`: **66,132,240 ops/s**, **47.857 B/op**
- primitive throughput improvement: **568.53%**
- recording allocation reduction: approximately **100%**
- 99.9% confidence intervals did not overlap

### Percentile key extraction (65,536 distinct keys)
- allocating sorted list: **316.095 us/op**, **524,379.090 B/op**
- reusable primitive array: **176.064 us/op**, **49.721 B/op**
- extraction time reduction: approximately **44.3%**
- extraction allocation reduction: **99.99%**

## Validation
- `./gradlew :perl:test --tests io.perl.test.LatencyMapRecorderTest :perl:checkstyleMain :perl:checkstyleTest :perl:spotbugsMain :perl:spotbugsTest`
- `./gradlew :perl:compileJmhJava :perl:checkstyleJmh :perl:check`
- `./gradlew :perl:latencyMapPerformanceTest`
- `./gradlew check installDist`
- `./build/install/sbk/bin/sbk -class perlbench -writers 2 -size 100 -seconds 6 -time ns -out SystemLogger`

The end-to-end run processed **70,609,082 records**, reported valid periodic and total percentiles, and had **zero invalid latencies**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced sparse and total latency recording and percentile extraction using primitive long-based storage.
  * Added dense-array latency recording plus window-based percentile benchmarking, including throughput measurements.
  * Improved extraction efficiency via reusable sorting buffers.
* **Reliability Improvements**
  * Latency benchmark consumption now runs on a dedicated single platform thread with coordinated shutdown.
* **Bug Fixes**
  * Strengthened percentile post-processing cleanup to prevent stale latency data across extractions/windows.
* **Tests**
  * Added equivalence tests for primitive vs boxed and array vs primitive-map behavior, including reset/grow/shrink scenarios.
  * Added automated JMH latency-map performance verification with allocation-based gating.
* **Documentation**
  * Added detailed documentation for the exact latency recorder architecture and updated related internals notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->