### PR TITLE
Update core dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ buildscript {
 
 plugins {
     id 'org.jreleaser' version  "${jReleaserPluginVersion}"
-    id 'com.github.ben-manes.versions' version "${gradleVersionsPluginVersion}"
+    id 'io.github.ben-manes.versions' version "${gradleVersionsPluginVersion}"
 }
 
 /*
@@ -150,13 +150,13 @@ allprojects {
         tasks.matching { it.name == 'dependencyUpdates' }.configureEach { enabled = false }
     } else if (project.path.startsWith(':drivers')) {
         if (includeDriversDeps) {
-            apply plugin: 'com.github.ben-manes.versions'
+            apply plugin: 'io.github.ben-manes.versions'
         } else {
             // Ensure the task is disabled if applied elsewhere
             tasks.matching { it.name == 'dependencyUpdates' }.configureEach { enabled = false }
         }
     } else {
-        apply plugin: 'com.github.ben-manes.versions'
+        apply plugin: 'io.github.ben-manes.versions'
     }
 
     application {

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -110,12 +110,7 @@
             <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
         </module>
         <module name="AvoidNestedBlocks"/>
-        <module name="JavadocStyle">
-            <property name="scope" value="protected"/>
-            <property name="checkFirstSentence" value="true"/>
-            <property name="checkEmptyJavadoc" value="true"/>
-            <property name="checkHtml" value="true"/>
-        </module>
+        <module name="SummaryJavadoc"/>
         <module name="MissingOverride"/>
         <module name="MissingDeprecated"/>
         <module name="AnnotationLocation">

--- a/drivers/bookkeeper/src/test/java/io/sbk/driver/BookKeeper/BookKeeperTest.java
+++ b/drivers/bookkeeper/src/test/java/io/sbk/driver/BookKeeper/BookKeeperTest.java
@@ -20,8 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 //create the test Class for Bookkeeper Benchmarking
 public class BookKeeperTest {
     /**
-     * .
-     * * Initializing variable
+     * BookKeeper configuration file name.
      */
     private final static String CONFIGFILE = "BookKeeper.properties";
     final String[] drivers = {"BookKeeper"};

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,39 +32,39 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 # gradle dependency package updates to check
 # command : ./gradlew dependencyUpdates -Drevision=release --no-parallel
-gradleVersionsPluginVersion=0.53.0
+gradleVersionsPluginVersion=0.56.0
 
 # gradle plugins
 graalvmPluginVersion=0.10.0
-spotbugsPluginVersion=6.1.7
-jibVersion=3.4.5
+spotbugsPluginVersion=6.5.9
+jibVersion=3.5.4
 sshPluginVersion=2.10.1
 mkdocsPluginVersion=2.1.1
 jReleaserPluginVersion=1.23.0
 
 #Dependencies
-spotbugsVersion=4.9.8
-grpcVersion=1.79.0
-protobufGradlePlugin=0.9.6
-protobufProtocVersion=4.34.0
-checkstyleToolVersion=10.23.0
+spotbugsVersion=4.10.3
+grpcVersion=1.83.0
+protobufGradlePlugin=0.10.0
+protobufProtocVersion=4.35.1
+checkstyleToolVersion=13.9.0
 apacheRatVersion=0.8.1
 jacocoVersion=0.8.14
-slf4jVersion=2.0.17
+slf4jVersion=2.0.18
 javaxAnnotationVersion=3.0.0
-junitVersion=6.0.3
-mockitoVersion=5.22.0
-lombokVersion=1.18.42
+junitVersion=6.1.2
+mockitoVersion=5.23.0
+lombokVersion=1.18.46
 commonsCliVersion=1.11.0
-apacheCommonsConfigVersion=2.13.0
+apacheCommonsConfigVersion=2.15.1
 apacheCommonsCsvVersion=1.14.1
 apacheCommonsLang3Version=3.20.0
 reflectionsVersion=0.10.2
-micrometerVersion=1.16.4
-guavaVersion=33.5.0-jre
-jacksonVersion=3.1.0
+micrometerVersion=1.16.6
+guavaVersion=33.6.0-jre
+jacksonVersion=3.1.5
 fasterxmlVersion=2.21
-sshdVersion=2.17.1
+sshdVersion=2.19.0
 HdrHistogramVersion=2.2.2
 jetbrainVersion=26.1.0
 jmxPrometheusVersion=1.0.1

--- a/sbk-api/src/test/java/io/sbk/api/AsyncOperationTimingTest.java
+++ b/sbk-api/src/test/java/io/sbk/api/AsyncOperationTimingTest.java
@@ -9,6 +9,7 @@
  */
 package io.sbk.api;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.perl.api.PerlChannel;
 import io.sbk.data.impl.ByteArray;
 import io.time.NanoSeconds;
@@ -56,6 +57,8 @@ final class AsyncOperationTimingTest {
         CompletableFuture<byte[]> completion = new CompletableFuture<>();
         AsyncReader<byte[]> reader = new AsyncReader<>() {
             @Override
+            @SuppressFBWarnings(value = "EI_EXPOSE_REP",
+                    justification = "The shared future is the callback-completion signal under test")
             public CompletableFuture<byte[]> readAsync(int size) {
                 return completion;
             }


### PR DESCRIPTION
## Summary

Update SBK's core build plugins and runtime/test dependencies to their current compatible releases while preserving the existing module and driver behavior.

## Dependency updates

- Micrometer `1.16.4` -> `1.16.6`
- gRPC `1.79.0` -> `1.83.0`
- Protobuf Gradle plugin `0.9.6` -> `0.10.0`
- Protobuf compiler `4.34.0` -> `4.35.1`
- SpotBugs plugin `6.1.7` -> `6.5.9`
- SpotBugs annotations/tooling `4.9.8` -> `4.10.3`
- Checkstyle `10.23.0` -> `13.9.0`
- Jib `3.4.5` -> `3.5.4`
- SLF4J `2.0.17` -> `2.0.18`
- JUnit `6.0.3` -> `6.1.2`
- Mockito `5.22.0` -> `5.23.0`
- Lombok `1.18.42` -> `1.18.46`
- Apache Commons Configuration `2.13.0` -> `2.15.1`
- Guava `33.5.0-jre` -> `33.6.0-jre`
- Jackson `3.1.0` -> `3.1.5`
- Apache MINA SSHD `2.17.1` -> `2.19.0`
- Gradle Versions plugin `0.53.0` -> `0.56.0`, including migration to its new `io.github.ben-manes.versions` plugin ID

The MinIO SDK remains pinned at `8.5.17` to preserve compatibility with Dell ECS/ObjectScale and other S3-compatible backends.

## Compatibility changes

- Replace the removed Checkstyle `JavadocStyle` check with `SummaryJavadoc` for Checkstyle 13 compatibility.
- Correct the BookKeeper test field documentation so it satisfies the updated Javadoc rule.
- Annotate the intentional shared completion future in `AsyncOperationTimingTest` for the updated SpotBugs analysis.

## Micrometer, Prometheus, and Grafana validation

Validated the complete live-metrics path using the repository's `grafana/docker-compose.yml` stack:

`SBK -> PrometheusLogger -> Prometheus 3.10.0 -> Grafana 12.4.1`

The installed SBK distribution contained:

- `micrometer-core-1.16.6.jar`
- `micrometer-registry-prometheus-1.16.6.jar`
- `prometheus-metrics-core-1.4.3.jar`

A 45-second local file-write benchmark was run with:

```bash
./build/install/sbk/bin/sbk \
  -class file \
  -file /tmp/sbk-prometheus-micrometer.dat \
  -writers 1 \
  -size 100 \
  -seconds 45 \
  -time ns \
  -out PrometheusLogger \
  -context 9718/metrics
```

Observed benchmark result:

- 40,353,149 records
- 896,736.6 records/second
- 85.52 MB/second
- 1,015.5 ns average latency
- Zero invalid latencies
- Zero discarded lower/higher latencies
- Clean PrometheusLogger startup and shutdown

Prometheus successfully scraped `host.docker.internal:9718`. Live queries returned non-zero values for `SBK_Writing_RecordsPerSec` and `SBK_Writing_MBPerSec`, with `SBK_Writing_InvalidLatencyRecords_total` remaining zero.

Grafana successfully loaded the provisioned `SBK Dashboard` and queried the live `SBK_Writing_RecordsPerSec` series through the provisioned Prometheus datasource. This verifies endpoint creation, meter registration, metric updates, Prometheus serialization/scraping, datasource connectivity, and dashboard query compatibility with Micrometer 1.16.6.

## Verification

- Full Gradle checks completed for the dependency update
- Installable distribution generated successfully
- SBK file-system benchmark completed successfully
- SBK PerlBench validation completed successfully
- SBK-GEM-YAL file-system write/read validation completed successfully
- Prometheus and Grafana containers started and passed health checks
- Live Prometheus scrape and query verified
- Live Grafana datasource query and provisioned dashboard verified

## Notes

The Linux Docker validation used a temporary Compose override mapping `host.docker.internal` to Docker's host gateway. No monitoring configuration or generated benchmark files are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling and library versions to newer releases.
  * Updated dependency version checking configuration for improved compatibility.
* **Quality**
  * Refined documentation checks to enforce clearer summary descriptions.
  * Improved test code quality and static analysis compatibility.
* **Documentation**
  * Clarified the description of the BookKeeper configuration file setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->