### PR TITLE
Adopt SBP 4 streaming and optimize gRPC latency transport

### DIFF
--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1551,7 +1551,7 @@ flowchart TB
 
 **SBP** — **Storage Benchmark Protocol** — is the wire protocol clients
 use to talk to SBM. It is a gRPC service defined in
-[`sbp.proto`](../sbk-api/src/main/proto/sbp.proto), with six RPCs:
+[`sbp.proto`](../sbk-api/src/main/proto/sbp.proto), with seven RPCs:
 
 | RPC | Request | Response | Purpose |
 |---|---|---|---|
@@ -1559,7 +1559,8 @@ use to talk to SBM. It is a gRPC service defined in
 | `isVersionSupported` | `Version` | `BoolValue` | Explicit version negotiation |
 | `getConfig` | Empty | `Config` | Client fetches SBM's run config |
 | `registerClient` | `Config` | `ClientID` | Returns a unique long ID |
-| `addLatenciesRecord` | `MessageLatenciesRecord` | Empty | **Hot path** — push a batch |
+| `addLatenciesRecord` | `MessageLatenciesRecord` | Empty | SBP 3.0-compatible unary batch submission |
+| `streamLatencies` | stream of `MessageLatenciesRecord` | Empty | **SBP 3.1 hot path** — ordered, flow-controlled batches |
 | `closeClient` | `ClientID` | Empty | Graceful disconnect |
 
 The critical message is `MessageLatenciesRecord`:
@@ -1577,32 +1578,79 @@ message MessageLatenciesRecord {
   int64 totalLatency     = 19;
   int64 minLatency       = 20;
   int64 maxLatency       = 21;
-  map<int64, int64> latency = 22;   // <-- the histogram: latency → count
+  map<int64, int64> latency = 22;   // SBP 3.0 compatibility
+  repeated uint64 latencyValues = 23 [packed = true];
+  repeated uint64 latencyCounts = 24 [packed = true];
 }
 ```
 
-The differentiating design choice is the `latency` map: a client sends one
-entry per **distinct recorded latency value**, with the number of operations
-that observed that value. It also sends totals, valid/invalid/discard counts,
-bytes, active/max reader and writer counts, and request/timeout counters.
-SBM therefore receives enough information to recompute a global percentile
+The differentiating design choice is still one exact count per **distinct
+recorded latency value**. SBP 3.1 represents those keys and counts as two
+same-length packed primitive arrays. This avoids the boxed `Long` keys,
+boxed values, per-entry map objects, and embedded protobuf map-entry messages
+required by field 22. It also sends totals, valid/invalid/discard counts,
+bytes, active/max reader and writer counts, and request/timeout counters. SBM
+therefore receives enough information to recompute a global percentile
 distribution; it does not attempt the mathematically invalid operation of
 averaging client percentiles.
 
-`GrpcLogger` batches this data at periodic logger output and also flushes when
-its estimated latency-map payload reaches `maxRecordSizeMB` (4 MiB by
-default). The network saving depends on the workload:
+`GrpcLogger` first accumulates exact counts in a primitive
+`LongLongHashMap`. It creates a protobuf message only when periodic output or
+the conservative message-size threshold requires a flush. The threshold uses
+75 percent of `maxRecordSizeMB` (4 MiB by default), reserves the worst-case
+varint size for every distinct key/count pair, and verifies the final
+serialized size before transmission. The network saving depends on the
+workload:
+
+SBM applies the same configured value to gRPC's inbound-message limit and
+advertises the byte limit through `getConfig`. SBK uses the smaller of its
+local limit and the server-advertised limit, so the producer cannot build
+batches that the receiving server is configured to reject.
 
 ```text
 raw representation       proportional to number of operations
-SBP latency map           proportional to number of distinct latency values
+SBP packed arrays         proportional to number of distinct latency values
 ```
 
 If a million operations occupy 200 integer latency values, the map is much
 smaller than a million raw samples. If nearly every operation has a distinct
 nanosecond value, the benefit is smaller and the size threshold creates more
-batches. Protobuf map entries also have encoding overhead, so entry count must
-not be described as byte count.
+batches.
+
+SBP 3.1 retains the unary RPC and map field so an updated client can
+interoperate with an SBP 3.0 server. `GrpcLogger` checks the server minor
+version: 3.1 or later uses streaming and packed arrays; 3.0 uses unary RPCs
+and populates the legacy map only while flushing.
+
+#### Client-side allocation and flow-control boundary
+
+```mermaid
+flowchart LR
+    P["PerL consumer<br/>one latency result"] --> A["Primitive LongLongHashMap<br/>exact latency to count"]
+    A -->|"5 s interval or safe size threshold"| B["Immutable protobuf batch<br/>packed primitive arrays"]
+    B --> Q["Bounded sender queue<br/>maximum 8 batches"]
+    Q --> T["Dedicated platform sender"]
+    T -->|"only while HTTP/2 isReady"| S["One client stream to SBM"]
+    S --> ACK["Final Empty acknowledgment<br/>after stream drain"]
+
+    FULL["Queue full"] --> FAIL["Fail benchmark explicitly<br/>never grow memory silently"]
+    Q -. capacity check .-> FULL
+
+    classDef hot fill:#fee2e2,stroke:#991b1b,color:#000
+    classDef batch fill:#fef3c7,stroke:#a16207,color:#000
+    classDef transport fill:#e0e7ff,stroke:#4338ca,color:#000
+    classDef safe fill:#dcfce7,stroke:#166534,color:#000
+    class P,A hot
+    class B,Q batch
+    class T,S transport
+    class ACK,FULL,FAIL safe
+```
+
+The bounded sender isolates network progress from PerL without creating an
+unbounded backlog. When HTTP/2 flow control is not ready, the sender parks;
+it does not spin. If eight completed batches are already pending, the logger
+reports overload through SBK's normal exception handler and initiates normal
+benchmark shutdown.
 
 #### SBP connection and data lifecycle
 
@@ -1623,25 +1671,33 @@ sequenceDiagram
     C->>S: registerClient(config)
     S-->>C: clientID
 
-    loop periodic output or size-triggered flush
-        C->>C: aggregate latency to count + counters
-        C->>S: addLatenciesRecord(clientID, sequence, map, totals)
+    C->>S: streamLatencies()
+
+    loop periodic output or safe size-triggered flush
+        C->>C: aggregate in primitive map
+        C->>C: build packed values and counts
+        C->>S: stream batch(clientID, sequence, packed fields, totals)
+        Note over C,S: sender obeys isReady flow control
         S->>Q: enqueue by clientID modulo maxQueues
         Q->>A: merge accepted record
-        S-->>C: Empty acknowledgment
     end
 
+    C->>S: complete stream after final queued batch
+    S-->>C: final Empty acknowledgment
     C->>S: closeClient(clientID)
     S-->>C: Empty acknowledgment
 ```
 
 The major SBP version is enforced by `GrpcLogger`. Storage name, action, and
 time unit must match the server configuration; latency-range and request-log
-differences currently produce warnings. `sequenceNumber` is populated by the
-client, but the current SBM implementation does not validate it, deduplicate
-records, or retry missing records. SBP therefore provides aggregation
-semantics, not exactly-once delivery. Treat transport failures, client exits,
+differences currently produce warnings. Every SBP 3.1 stream has one client
+ID and strictly increasing sequence numbers beginning at one. SBM rejects a
+client-ID change or sequence gap before the record reaches the aggregation
+queue. The stream preserves order and returns its final acknowledgment only
+after all submitted messages have reached the service. SBP does not retry a
+failed stream, so treat transport failures, client exits,
 invalid/discard counts, and connection logs as part of result validation.
+The retained SBP 3.0 unary endpoint does not promise cross-RPC ordering.
 
 ### 6.3 SBM's internal architecture
 
@@ -1696,12 +1752,13 @@ The important details are:
 
 - **Multiple inbound producers** deposit into the queue array. The queue index
   is `clientID % maxQueues`, so all records from one client use the same queue
-  and different clients are spread over the configured queues. This mapping
-  alone is not an ordering or exactly-once guarantee; the server currently
-  does not inspect `sequenceNumber`.
+  and different clients are spread over the configured queues. The SBP 3.1
+  stream validates client ID and sequence before enqueueing.
 - **A single background thread** drains all queues round-robin and
   feeds them into a `LatencyRecordWindow`, reusing PerL's latency-window
-  machinery. Single ownership means the non-thread-safe window does not need
+  machinery. It drains up to 64 records per queue visit, amortizing clock
+  reads and queue scans without allowing one queue to monopolize the
+  consumer. Single ownership means the non-thread-safe window does not need
   concurrent updates.
 - **Window rotation** — every 5 s by default — produces a combined
   periodic line on stdout and ticks the Prometheus gauges.
@@ -1742,7 +1799,11 @@ Concretely
 ([SbmTotalWindowLatencyPeriodicRecorder.java](../sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java)):
 
 ```java
-record.getLatencyMap().forEach(window::reportLatency);
+for (int index = 0; index < record.getLatencyValuesCount(); index++) {
+    window.reportLatency(
+        record.getLatencyValues(index),
+        record.getLatencyCounts(index));
+}
 ```
 
 `window.reportLatency(latency, count)` increments the bucket count by
@@ -1751,9 +1812,11 @@ from the combined counts exactly as for a single integer-bucket distribution.
 Addition of bucket counts is associative and commutative, so merge order does
 not alter the mathematical result.
 
-SBM tracks registered connections and per-client reader/writer maxima, but it
+SBM tracks registered connections and per-client reader/writer maxima in
+reusable primitive arrays indexed by client ID. It does not allocate boxed
+client IDs or rebuild a `HashMap<Long,RW>` every reporting interval, and it
 does not need each client's precomputed percentile. The merge is lossless
-relative to the latency/count maps that actually arrive. It cannot reconstruct
+relative to the latency/count pairs that actually arrive. It cannot reconstruct
 records lost in transport, discarded outside a configured range, quantized by
 an upstream representation, duplicated, or omitted by a failed client.
 
@@ -1882,8 +1945,8 @@ sequenceDiagram
     end
 
     loop during the run
-        N1-->>SBM: addLatenciesRecord (gRPC)
-        N2-->>SBM: addLatenciesRecord (gRPC)
+        N1-->>SBM: streamLatencies batch (gRPC)
+        N2-->>SBM: streamLatencies batch (gRPC)
     end
 
     Note over SBM: SBM prints aggregated stats every 5s

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1595,11 +1595,13 @@ averaging client percentiles.
 
 `GrpcLogger` first accumulates exact counts in a primitive
 `LongLongHashMap`. It creates a protobuf message only when periodic output or
-the conservative message-size threshold requires a flush. The threshold uses
-75 percent of `maxRecordSizeMB` (16 MiB by default), reserves the worst-case
-varint size for every distinct key/count pair, and verifies the final
-serialized size before transmission. The network saving depends on the
-workload:
+the configured message-size limit requires a flush. The accumulator calculates
+the actual unsigned-varint widths of the packed latency and count arrays. Before
+an addition would make the complete record exceed `maxRecordSizeMB` (16 MiB by
+default), SBK sends the current batch to SBM and starts a new batch. A small
+schema-derived bound covers the non-latency protobuf fields; no percentage of
+the configured capacity is withheld. SBK also verifies the final serialized
+size before transmission. The network saving depends on the workload:
 
 SBM applies the same configured value to gRPC's inbound-message limit and
 advertises the byte limit through `getConfig`. SBK uses the smaller of its
@@ -1626,7 +1628,7 @@ accidentally reused with a different meaning.
 ```mermaid
 flowchart LR
     P["PerL consumer<br/>one latency result"] --> A["Primitive LongLongHashMap<br/>exact latency to count"]
-    A -->|"5 s interval or safe size threshold"| B["Immutable protobuf batch<br/>packed primitive arrays"]
+    A -->|"5 s interval or configured size limit"| B["Immutable protobuf batch<br/>packed primitive arrays"]
     B --> Q["Bounded sender queue<br/>maximum 8 batches"]
     Q --> T["Dedicated platform sender"]
     T -->|"only while HTTP/2 isReady"| S["One client stream to SBM"]

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1596,7 +1596,7 @@ averaging client percentiles.
 `GrpcLogger` first accumulates exact counts in a primitive
 `LongLongHashMap`. It creates a protobuf message only when periodic output or
 the conservative message-size threshold requires a flush. The threshold uses
-75 percent of `maxRecordSizeMB` (4 MiB by default), reserves the worst-case
+75 percent of `maxRecordSizeMB` (16 MiB by default), reserves the worst-case
 varint size for every distinct key/count pair, and verifies the final
 serialized size before transmission. The network saving depends on the
 workload:

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1551,7 +1551,7 @@ flowchart TB
 
 **SBP** — **Storage Benchmark Protocol** — is the wire protocol clients
 use to talk to SBM. It is a gRPC service defined in
-[`sbp.proto`](../sbk-api/src/main/proto/sbp.proto), with seven RPCs:
+[`sbp.proto`](../sbk-api/src/main/proto/sbp.proto), with six RPCs:
 
 | RPC | Request | Response | Purpose |
 |---|---|---|---|
@@ -1559,8 +1559,7 @@ use to talk to SBM. It is a gRPC service defined in
 | `isVersionSupported` | `Version` | `BoolValue` | Explicit version negotiation |
 | `getConfig` | Empty | `Config` | Client fetches SBM's run config |
 | `registerClient` | `Config` | `ClientID` | Returns a unique long ID |
-| `addLatenciesRecord` | `MessageLatenciesRecord` | Empty | SBP 3.0-compatible unary batch submission |
-| `streamLatencies` | stream of `MessageLatenciesRecord` | Empty | **SBP 3.1 hot path** — ordered, flow-controlled batches |
+| `streamLatencies` | stream of `MessageLatenciesRecord` | Empty | **SBP 4.0 hot path** — ordered, flow-controlled batches |
 | `closeClient` | `ClientID` | Empty | Graceful disconnect |
 
 The critical message is `MessageLatenciesRecord`:
@@ -1578,17 +1577,17 @@ message MessageLatenciesRecord {
   int64 totalLatency     = 19;
   int64 minLatency       = 20;
   int64 maxLatency       = 21;
-  map<int64, int64> latency = 22;   // SBP 3.0 compatibility
+  reserved 22;                      // retired pre-SBP-4 map field
   repeated uint64 latencyValues = 23 [packed = true];
   repeated uint64 latencyCounts = 24 [packed = true];
 }
 ```
 
 The differentiating design choice is still one exact count per **distinct
-recorded latency value**. SBP 3.1 represents those keys and counts as two
+recorded latency value**. SBP 4.0 represents those keys and counts as two
 same-length packed primitive arrays. This avoids the boxed `Long` keys,
 boxed values, per-entry map objects, and embedded protobuf map-entry messages
-required by field 22. It also sends totals, valid/invalid/discard counts,
+used by earlier protocol versions. It also sends totals, valid/invalid/discard counts,
 bytes, active/max reader and writer counts, and request/timeout counters. SBM
 therefore receives enough information to recompute a global percentile
 distribution; it does not attempt the mathematically invalid operation of
@@ -1617,10 +1616,10 @@ smaller than a million raw samples. If nearly every operation has a distinct
 nanosecond value, the benefit is smaller and the size threshold creates more
 batches.
 
-SBP 3.1 retains the unary RPC and map field so an updated client can
-interoperate with an SBP 3.0 server. `GrpcLogger` checks the server minor
-version: 3.1 or later uses streaming and packed arrays; 3.0 uses unary RPCs
-and populates the legacy map only while flushing.
+SBP 4.0 is an intentional wire-protocol break. The unary latency RPC and
+protobuf map field from SBP 3.x are removed; SBK and SBM must both use the
+same SBP major version. Field number 22 remains reserved so it cannot be
+accidentally reused with a different meaning.
 
 #### Client-side allocation and flow-control boundary
 
@@ -1690,14 +1689,13 @@ sequenceDiagram
 
 The major SBP version is enforced by `GrpcLogger`. Storage name, action, and
 time unit must match the server configuration; latency-range and request-log
-differences currently produce warnings. Every SBP 3.1 stream has one client
+differences currently produce warnings. Every SBP 4.0 stream has one client
 ID and strictly increasing sequence numbers beginning at one. SBM rejects a
 client-ID change or sequence gap before the record reaches the aggregation
 queue. The stream preserves order and returns its final acknowledgment only
 after all submitted messages have reached the service. SBP does not retry a
 failed stream, so treat transport failures, client exits,
 invalid/discard counts, and connection logs as part of result validation.
-The retained SBP 3.0 unary endpoint does not promise cross-RPC ordering.
 
 ### 6.3 SBM's internal architecture
 
@@ -1716,7 +1714,7 @@ flowchart TB
     end
 
     subgraph SRV["SbmGrpcService"]
-        ENQ["addLatenciesRecord(record)<br/>then registry.enQueue(record)"]
+        ENQ["streamLatencies.onNext(record)<br/>then registry.enQueue(record)"]
     end
 
     subgraph QUEUES["SbmLatencyBenchmark queue array"]
@@ -1752,14 +1750,13 @@ The important details are:
 
 - **Multiple inbound producers** deposit into the queue array. The queue index
   is `clientID % maxQueues`, so all records from one client use the same queue
-  and different clients are spread over the configured queues. The SBP 3.1
+  and different clients are spread over the configured queues. The SBP 4.0
   stream validates client ID and sequence before enqueueing.
 - **A single background thread** drains all queues round-robin and
   feeds them into a `LatencyRecordWindow`, reusing PerL's latency-window
-  machinery. It drains up to 64 records per queue visit, amortizing clock
-  reads and queue scans without allowing one queue to monopolize the
-  consumer. Single ownership means the non-thread-safe window does not need
-  concurrent updates.
+  machinery. It consumes one record per queue visit so that a busy client
+  cannot monopolize the consumer. Single ownership means the non-thread-safe
+  window does not need concurrent updates.
 - **Window rotation** — every 5 s by default — produces a combined
   periodic line on stdout and ticks the Prometheus gauges.
 - **Empty-queue behavior differs from client PerL.** `SbmLatencyBenchmark`

--- a/sbk-api/build.gradle
+++ b/sbk-api/build.gradle
@@ -57,7 +57,7 @@ def grpcLoggerPerformanceReport = layout.buildDirectory.file(
 
 tasks.register('runGrpcLoggerPerformanceBenchmark', JavaExec) {
     group = 'verification'
-    description = 'Benchmarks primitive gRPC latency batching against the protobuf map path.'
+    description = 'Benchmarks primitive gRPC latency batching against a boxed-map baseline.'
     dependsOn tasks.named('jmhJar')
     classpath = files(tasks.named('jmhJar').flatMap { it.archiveFile })
     mainClass = 'org.openjdk.jmh.Main'
@@ -101,19 +101,17 @@ tasks.register('grpcLoggerPerformanceTest') {
                     allocation(result))
         }
         def primitive = byName.recordPrimitive
-        def protobufMap = byName.recordProtobufMap
+        def boxedMap = byName.recordBoxedMap
         def packed = byName.encodePacked
-        def legacy = byName.encodeLegacyMap
         println String.format(
-                "Hot-path observed mean   : primitive accumulation is %.2f%% faster and removes %.3f B/op",
-                (protobufMap.primaryMetric.score - primitive.primaryMetric.score)
-                        * 100.0d / protobufMap.primaryMetric.score,
-                allocation(protobufMap) - allocation(primitive))
+                "Hot-path observed mean   : primitive accumulation is %.2f%% faster and removes %.3f B/op"
+                        + " versus the boxed map",
+                (boxedMap.primaryMetric.score - primitive.primaryMetric.score)
+                        * 100.0d / boxedMap.primaryMetric.score,
+                allocation(boxedMap) - allocation(primitive))
         println String.format(
-                "Batch observed mean      : packed primitive fields are %.2f%% faster and use %.2f%% less allocation",
-                (legacy.primaryMetric.score - packed.primaryMetric.score)
-                        * 100.0d / legacy.primaryMetric.score,
-                (allocation(legacy) - allocation(packed)) * 100.0d / allocation(legacy))
+                "SBP 4 packed encoding    : %,.3f %s; %,.3f B/op",
+                packed.primaryMetric.score, packed.primaryMetric.scoreUnit, allocation(packed))
     }
 }
 

--- a/sbk-api/build.gradle
+++ b/sbk-api/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     dependencies {
         classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufGradlePlugin"
         classpath "org.nosphere.apache:creadur-rat-gradle:$apacheRatVersion"
+        classpath "me.champeau.jmh:jmh-gradle-plugin:$jmhGradleVersion"
     }
 }
 
@@ -27,6 +28,7 @@ apply plugin: 'java-library'
 apply plugin: "com.google.protobuf"
 apply plugin: "maven-publish"
 apply plugin: "com.github.spotbugs"
+apply plugin: "me.champeau.jmh"
 
 apply from: "$rootDir/gradle/protobuf.gradle"
 apply from: "$rootDir/gradle/rat.gradle"
@@ -40,7 +42,79 @@ dependencies {
     api "org.apache.commons:commons-configuration2:$apacheCommonsConfigVersion"
     api "org.apache.commons:commons-lang3:$apacheCommonsLang3Version" // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
     implementation "commons-cli:commons-cli:$commonsCliVersion"
+    implementation "org.eclipse.collections:eclipse-collections:$eclipseCollectionVersion"
     implementation "org.jetbrains:annotations:$jetbrainVersion"
+    testImplementation "io.grpc:grpc-inprocess:$grpcVersion"
+}
+
+jmh {
+    jvmArgs = ["-Djmh.blackhole.autoDetect=false"]
+    includes = ['io.sbk.logger.impl.GrpcLatencyAccumulatorBenchmark.*']
+}
+
+def grpcLoggerPerformanceReport = layout.buildDirectory.file(
+        "reports/jmh/grpc-logger-performance.json")
+
+tasks.register('runGrpcLoggerPerformanceBenchmark', JavaExec) {
+    group = 'verification'
+    description = 'Benchmarks primitive gRPC latency batching against the protobuf map path.'
+    dependsOn tasks.named('jmhJar')
+    classpath = files(tasks.named('jmhJar').flatMap { it.archiveFile })
+    mainClass = 'org.openjdk.jmh.Main'
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+    jvmArgs rootProject.ext.sbkRuntimeJvmArgs
+    args 'io.sbk.logger.impl.GrpcLatencyAccumulatorBenchmark.*',
+            '-prof', 'gc',
+            '-jvmArgs', (rootProject.ext.sbkRuntimeJvmArgs
+                    + ['-Djmh.blackhole.autoDetect=false']).join(' '),
+            '-rf', 'json',
+            '-rff', grpcLoggerPerformanceReport.get().asFile.absolutePath
+    outputs.file(grpcLoggerPerformanceReport)
+    outputs.upToDateWhen { false }
+    doFirst {
+        grpcLoggerPerformanceReport.get().asFile.parentFile.mkdirs()
+        delete grpcLoggerPerformanceReport
+    }
+}
+
+tasks.register('grpcLoggerPerformanceTest') {
+    group = 'verification'
+    description = 'Reports gRPC logger latency-accumulation and protobuf-encoding performance.'
+    dependsOn tasks.named('runGrpcLoggerPerformanceBenchmark')
+    doLast {
+        def results = new groovy.json.JsonSlurper().parse(
+                grpcLoggerPerformanceReport.get().asFile)
+        def byName = results.collectEntries {
+            [(it.benchmark.substring(it.benchmark.lastIndexOf('.') + 1)): it]
+        }
+        def allocation = { result ->
+            result.secondaryMetrics.find { key, value ->
+                key.endsWith('gc.alloc.rate.norm')
+            }?.value?.score ?: 0.0d
+        }
+        byName.each { name, result ->
+            println String.format(
+                    "%-24s : %,.3f %s; %,.3f B/op",
+                    name, result.primaryMetric.score, result.primaryMetric.scoreUnit,
+                    allocation(result))
+        }
+        def primitive = byName.recordPrimitive
+        def protobufMap = byName.recordProtobufMap
+        def packed = byName.encodePacked
+        def legacy = byName.encodeLegacyMap
+        println String.format(
+                "Hot-path observed mean   : primitive accumulation is %.2f%% faster and removes %.3f B/op",
+                (protobufMap.primaryMetric.score - primitive.primaryMetric.score)
+                        * 100.0d / protobufMap.primaryMetric.score,
+                allocation(protobufMap) - allocation(primitive))
+        println String.format(
+                "Batch observed mean      : packed primitive fields are %.2f%% faster and use %.2f%% less allocation",
+                (legacy.primaryMetric.score - packed.primaryMetric.score)
+                        * 100.0d / legacy.primaryMetric.score,
+                (allocation(legacy) - allocation(packed)) * 100.0d / allocation(legacy))
+    }
 }
 
 generateJavadoc {

--- a/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
+++ b/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
@@ -53,7 +53,7 @@ public class GrpcLatencyAccumulatorBenchmark {
         /** Initializes both exact-frequency implementations. */
         @Setup(Level.Trial)
         public void setup() {
-            primitive = new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+            primitive = new GrpcLatencyAccumulator(16L * Bytes.BYTES_PER_MB);
             boxedMap = new HashMap<>();
             sequence = 0;
         }
@@ -74,7 +74,7 @@ public class GrpcLatencyAccumulatorBenchmark {
         /** Creates the same deterministic exact distribution for each encoding. */
         @Setup(Level.Invocation)
         public void setup() {
-            accumulator = new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+            accumulator = new GrpcLatencyAccumulator(16L * Bytes.BYTES_PER_MB);
             builder = MessageLatenciesRecord.newBuilder();
             for (int index = 0; index < DISTINCT_LATENCIES; index++) {
                 accumulator.record(1_000L + index, index + 1L);

--- a/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
+++ b/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
@@ -77,7 +77,7 @@ public class GrpcLatencyAccumulatorBenchmark {
             accumulator = new GrpcLatencyAccumulator(16L * Bytes.BYTES_PER_MB);
             builder = MessageLatenciesRecord.newBuilder();
             for (int index = 0; index < DISTINCT_LATENCIES; index++) {
-                accumulator.record(1_000L + index, index + 1L);
+                accumulator.recordIfFits(1_000L + index, index + 1L);
             }
         }
     }
@@ -90,7 +90,7 @@ public class GrpcLatencyAccumulatorBenchmark {
      */
     @Benchmark
     public int recordPrimitive(RecordState state) {
-        state.primitive.record(state.nextLatency(), 1);
+        state.primitive.recordIfFits(state.nextLatency(), 1);
         return state.primitive.size();
     }
 

--- a/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
+++ b/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
@@ -24,11 +24,13 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Timeout;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Compares primitive latency accumulation and packed encoding with the legacy
- * protobuf map implementation.
+ * Compares primitive latency accumulation with a boxed map baseline and
+ * measures packed SBP encoding.
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -45,14 +47,14 @@ public class GrpcLatencyAccumulatorBenchmark {
     @State(Scope.Thread)
     public static class RecordState {
         private GrpcLatencyAccumulator primitive;
-        private MessageLatenciesRecord.Builder protobufMap;
+        private Map<Long, Long> boxedMap;
         private long sequence;
 
         /** Initializes both exact-frequency implementations. */
         @Setup(Level.Trial)
         public void setup() {
             primitive = new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
-            protobufMap = MessageLatenciesRecord.newBuilder();
+            boxedMap = new HashMap<>();
             sequence = 0;
         }
 
@@ -93,17 +95,17 @@ public class GrpcLatencyAccumulatorBenchmark {
     }
 
     /**
-     * Records one measurement through the legacy boxed protobuf map.
+     * Records one measurement through a boxed map baseline.
      *
      * @param state benchmark state
      * @return number of distinct latency values
      */
     @Benchmark
-    public int recordProtobufMap(RecordState state) {
+    public int recordBoxedMap(RecordState state) {
         final long latency = state.nextLatency();
-        final long count = state.protobufMap.getLatencyMap().getOrDefault(latency, 0L);
-        state.protobufMap.putLatency(latency, count + 1);
-        return state.protobufMap.getLatencyCount();
+        final long count = state.boxedMap.getOrDefault(latency, 0L);
+        state.boxedMap.put(latency, count + 1);
+        return state.boxedMap.size();
     }
 
     /**
@@ -118,15 +120,4 @@ public class GrpcLatencyAccumulatorBenchmark {
         return state.builder.build();
     }
 
-    /**
-     * Encodes a complete exact distribution into the legacy protobuf map.
-     *
-     * @param state benchmark state
-     * @return immutable protobuf message
-     */
-    @Benchmark
-    public MessageLatenciesRecord encodeLegacyMap(EncodeState state) {
-        state.accumulator.writeLegacy(state.builder);
-        return state.builder.build();
-    }
 }

--- a/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
+++ b/sbk-api/src/jmh/java/io/sbk/logger/impl/GrpcLatencyAccumulatorBenchmark.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.perl.data.Bytes;
+import io.sbp.grpc.MessageLatenciesRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares primitive latency accumulation and packed encoding with the legacy
+ * protobuf map implementation.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Timeout(time = 30)
+public class GrpcLatencyAccumulatorBenchmark {
+    private static final int DISTINCT_LATENCIES = 4096;
+
+    /**
+     * Long-lived per-measurement accumulation state.
+     */
+    @State(Scope.Thread)
+    public static class RecordState {
+        private GrpcLatencyAccumulator primitive;
+        private MessageLatenciesRecord.Builder protobufMap;
+        private long sequence;
+
+        /** Initializes both exact-frequency implementations. */
+        @Setup(Level.Trial)
+        public void setup() {
+            primitive = new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+            protobufMap = MessageLatenciesRecord.newBuilder();
+            sequence = 0;
+        }
+
+        private long nextLatency() {
+            return 1_000 + sequence++ % DISTINCT_LATENCIES;
+        }
+    }
+
+    /**
+     * Complete-window encoding state rebuilt before every invocation.
+     */
+    @State(Scope.Thread)
+    public static class EncodeState {
+        private GrpcLatencyAccumulator accumulator;
+        private MessageLatenciesRecord.Builder builder;
+
+        /** Creates the same deterministic exact distribution for each encoding. */
+        @Setup(Level.Invocation)
+        public void setup() {
+            accumulator = new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+            builder = MessageLatenciesRecord.newBuilder();
+            for (int index = 0; index < DISTINCT_LATENCIES; index++) {
+                accumulator.record(1_000L + index, index + 1L);
+            }
+        }
+    }
+
+    /**
+     * Records one measurement into the primitive accumulator.
+     *
+     * @param state benchmark state
+     * @return number of distinct latency values
+     */
+    @Benchmark
+    public int recordPrimitive(RecordState state) {
+        state.primitive.record(state.nextLatency(), 1);
+        return state.primitive.size();
+    }
+
+    /**
+     * Records one measurement through the legacy boxed protobuf map.
+     *
+     * @param state benchmark state
+     * @return number of distinct latency values
+     */
+    @Benchmark
+    public int recordProtobufMap(RecordState state) {
+        final long latency = state.nextLatency();
+        final long count = state.protobufMap.getLatencyMap().getOrDefault(latency, 0L);
+        state.protobufMap.putLatency(latency, count + 1);
+        return state.protobufMap.getLatencyCount();
+    }
+
+    /**
+     * Encodes a complete exact distribution into packed primitive fields.
+     *
+     * @param state benchmark state
+     * @return immutable protobuf message
+     */
+    @Benchmark
+    public MessageLatenciesRecord encodePacked(EncodeState state) {
+        state.accumulator.writePacked(state.builder);
+        return state.builder.build();
+    }
+
+    /**
+     * Encodes a complete exact distribution into the legacy protobuf map.
+     *
+     * @param state benchmark state
+     * @return immutable protobuf message
+     */
+    @Benchmark
+    public MessageLatenciesRecord encodeLegacyMap(EncodeState state) {
+        state.accumulator.writeLegacy(state.builder);
+        return state.builder.build();
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/Sbk.java
@@ -281,6 +281,10 @@ final public class Sbk {
             Printer.log.error(ex.toString());
             params.printHelp();
             throw ex;
+        } catch (ParseException | IllegalArgumentException ex) {
+            Printer.log.error(ex.getMessage());
+            params.printHelp();
+            throw ex;
         } catch (HelpException ex) {
             System.out.println("\n" + ex.getHelpText());
             throw ex;

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
@@ -16,8 +16,7 @@ import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
  * Accumulates exact latency frequencies without boxing keys or values.
  *
  * <p>The protobuf builder is populated only when a batch is ready for
- * transport. This keeps protobuf map allocation and boxed {@link Long}
- * instances out of the per-measurement path.
+ * transport. This keeps protobuf allocation out of the per-measurement path.
  */
 final class GrpcLatencyAccumulator {
     static final int PACKED_ENTRY_MAX_BYTES = 20;
@@ -71,17 +70,6 @@ final class GrpcLatencyAccumulator {
             builder.addLatencyValues(latency);
             builder.addLatencyCounts(count);
         });
-    }
-
-    /**
-     * Copies frequencies to the legacy protobuf map.
-     *
-     * <p>This method is used only when communicating with an SBP 3.0 server.
-     *
-     * @param builder destination message builder
-     */
-    void writeLegacy(MessageLatenciesRecord.Builder builder) {
-        latencies.forEachKeyValue(builder::putLatency);
     }
 
     /**

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
@@ -9,6 +9,7 @@
  */
 package io.sbk.logger.impl;
 
+import com.google.protobuf.CodedOutputStream;
 import io.sbp.grpc.MessageLatenciesRecord;
 import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
 
@@ -19,10 +20,13 @@ import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
  * transport. This keeps protobuf allocation out of the per-measurement path.
  */
 final class GrpcLatencyAccumulator {
-    static final int PACKED_ENTRY_MAX_BYTES = 20;
+    private static final int LATENCY_VALUES_FIELD_NUMBER = 23;
+    private static final int LATENCY_COUNTS_FIELD_NUMBER = 24;
+    private static final int MAXIMUM_METADATA_BYTES = maximumMetadataBytes();
     private final LongLongHashMap latencies;
-    private final long maximumEstimatedBytes;
-    private long estimatedBytes;
+    private final long maximumMessageBytes;
+    private long latencyValuesBytes;
+    private long latencyCountsBytes;
 
     /**
      * Creates a primitive latency accumulator.
@@ -31,33 +35,49 @@ final class GrpcLatencyAccumulator {
      */
     GrpcLatencyAccumulator(long maximumMessageBytes) {
         this.latencies = new LongLongHashMap();
-        this.maximumEstimatedBytes = maximumMessageBytes * 3 / 4;
-        this.estimatedBytes = 0;
+        this.maximumMessageBytes = maximumMessageBytes;
+        this.latencyValuesBytes = 0;
+        this.latencyCountsBytes = 0;
     }
 
     /**
-     * Records an exact latency frequency.
+     * Records an exact latency frequency when it fits in the configured
+     * serialized protobuf limit.
+     *
+     * <p>The calculation uses the actual unsigned-varint widths of the packed
+     * latency and count arrays. The non-latency fields are represented by
+     * their schema-derived maximum serialized size, rather than reserving a
+     * percentage of the configured message capacity.
      *
      * @param latency non-negative latency value
      * @param count number of records represented by the latency
+     * @return {@code true} when recorded; {@code false} when the caller must
+     *         send the current batch first
      */
-    void record(long latency, long count) {
+    boolean recordIfFits(long latency, long count) {
         final long current = latencies.get(latency);
+        final long projectedValuesBytes;
+        final long projectedCountsBytes;
+        if (current == 0) {
+            projectedValuesBytes = latencyValuesBytes + unsignedVarintBytes(latency);
+            projectedCountsBytes = latencyCountsBytes + unsignedVarintBytes(count);
+        } else {
+            final long updated = current + count;
+            projectedValuesBytes = latencyValuesBytes;
+            projectedCountsBytes = latencyCountsBytes
+                    - unsignedVarintBytes(current) + unsignedVarintBytes(updated);
+        }
+        if (serializedBytes(projectedValuesBytes, projectedCountsBytes) > maximumMessageBytes) {
+            return false;
+        }
         if (current == 0) {
             latencies.put(latency, count);
-            estimatedBytes += PACKED_ENTRY_MAX_BYTES;
         } else {
             latencies.addToValue(latency, count);
         }
-    }
-
-    /**
-     * Reports whether the conservative packed-size threshold was reached.
-     *
-     * @return {@code true} when the current batch should be flushed
-     */
-    boolean isFull() {
-        return estimatedBytes >= maximumEstimatedBytes;
+        latencyValuesBytes = projectedValuesBytes;
+        latencyCountsBytes = projectedCountsBytes;
+        return true;
     }
 
     /**
@@ -86,6 +106,52 @@ final class GrpcLatencyAccumulator {
         if (latencies.notEmpty()) {
             latencies.clear();
         }
-        estimatedBytes = 0;
+        latencyValuesBytes = 0;
+        latencyCountsBytes = 0;
+    }
+
+    private static long serializedBytes(long valuesBytes, long countsBytes) {
+        return MAXIMUM_METADATA_BYTES
+                + packedFieldBytes(LATENCY_VALUES_FIELD_NUMBER, valuesBytes)
+                + packedFieldBytes(LATENCY_COUNTS_FIELD_NUMBER, countsBytes);
+    }
+
+    private static long packedFieldBytes(int fieldNumber, long payloadBytes) {
+        if (payloadBytes == 0) {
+            return 0;
+        }
+        return CodedOutputStream.computeTagSize(fieldNumber)
+                + unsignedVarintBytes(payloadBytes) + payloadBytes;
+    }
+
+    private static int unsignedVarintBytes(long value) {
+        return CodedOutputStream.computeUInt64SizeNoTag(value);
+    }
+
+    private static int maximumMetadataBytes() {
+        return MessageLatenciesRecord.newBuilder()
+                .setClientID(-1)
+                .setSequenceNumber(-1)
+                .setWriters(-1)
+                .setReaders(-1)
+                .setMaxWriters(-1)
+                .setMaxReaders(-1)
+                .setWriteRequestBytes(-1)
+                .setWriteRequestRecords(-1)
+                .setReadRequestBytes(-1)
+                .setReadRequestRecords(-1)
+                .setWriteTimeoutEvents(-1)
+                .setReadTimeoutEvents(-1)
+                .setTotalRecords(-1)
+                .setValidLatencyRecords(-1)
+                .setLowerLatencyDiscardRecords(-1)
+                .setHigherLatencyDiscardRecords(-1)
+                .setInvalidLatencyRecords(-1)
+                .setTotalBytes(-1)
+                .setTotalLatency(-1)
+                .setMinLatency(-1)
+                .setMaxLatency(-1)
+                .build()
+                .getSerializedSize();
     }
 }

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLatencyAccumulator.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.sbp.grpc.MessageLatenciesRecord;
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+
+/**
+ * Accumulates exact latency frequencies without boxing keys or values.
+ *
+ * <p>The protobuf builder is populated only when a batch is ready for
+ * transport. This keeps protobuf map allocation and boxed {@link Long}
+ * instances out of the per-measurement path.
+ */
+final class GrpcLatencyAccumulator {
+    static final int PACKED_ENTRY_MAX_BYTES = 20;
+    private final LongLongHashMap latencies;
+    private final long maximumEstimatedBytes;
+    private long estimatedBytes;
+
+    /**
+     * Creates a primitive latency accumulator.
+     *
+     * @param maximumMessageBytes configured maximum protobuf message size
+     */
+    GrpcLatencyAccumulator(long maximumMessageBytes) {
+        this.latencies = new LongLongHashMap();
+        this.maximumEstimatedBytes = maximumMessageBytes * 3 / 4;
+        this.estimatedBytes = 0;
+    }
+
+    /**
+     * Records an exact latency frequency.
+     *
+     * @param latency non-negative latency value
+     * @param count number of records represented by the latency
+     */
+    void record(long latency, long count) {
+        final long current = latencies.get(latency);
+        if (current == 0) {
+            latencies.put(latency, count);
+            estimatedBytes += PACKED_ENTRY_MAX_BYTES;
+        } else {
+            latencies.addToValue(latency, count);
+        }
+    }
+
+    /**
+     * Reports whether the conservative packed-size threshold was reached.
+     *
+     * @return {@code true} when the current batch should be flushed
+     */
+    boolean isFull() {
+        return estimatedBytes >= maximumEstimatedBytes;
+    }
+
+    /**
+     * Copies frequencies to packed primitive protobuf fields.
+     *
+     * @param builder destination message builder
+     */
+    void writePacked(MessageLatenciesRecord.Builder builder) {
+        latencies.forEachKeyValue((latency, count) -> {
+            builder.addLatencyValues(latency);
+            builder.addLatencyCounts(count);
+        });
+    }
+
+    /**
+     * Copies frequencies to the legacy protobuf map.
+     *
+     * <p>This method is used only when communicating with an SBP 3.0 server.
+     *
+     * @param builder destination message builder
+     */
+    void writeLegacy(MessageLatenciesRecord.Builder builder) {
+        latencies.forEachKeyValue(builder::putLatency);
+    }
+
+    /**
+     * Returns the number of distinct exact latency values.
+     *
+     * @return distinct latency count
+     */
+    int size() {
+        return latencies.size();
+    }
+
+    /** Clears frequencies while retaining the primitive backing table. */
+    void clear() {
+        if (latencies.notEmpty()) {
+            latencies.clear();
+        }
+        estimatedBytes = 0;
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
@@ -314,12 +314,18 @@ public class GrpcLogger extends SystemLogger {
             return;
         }
 
-        if (latencyAccumulator.isFull()) {
-            sendLatenciesRecord(0, 0, 0, 0, 0, 0);
+        final boolean validLatency = latency >= 0
+                && latency >= getMinLatency() && latency <= getMaxLatency();
+        if (validLatency && !latencyAccumulator.recordIfFits(latency, events)) {
+            if (latencyAccumulator.size() > 0) {
+                sendLatenciesRecord(0, 0, 0, 0, 0, 0);
+            }
+            if (!latencyAccumulator.recordIfFits(latency, events)) {
+                reportTransportFailure(new IOException("SBK gRPC latency value cannot fit within configured maximum "
+                        + maxMessageBytes + " bytes"));
+            }
         }
-        if (recorder.record(events, bytes, latency)) {
-            latencyAccumulator.record(latency, events);
-        }
+        recorder.record(events, bytes, latency);
     }
 
     @Override

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
@@ -37,54 +37,43 @@ import io.time.Time;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
- * Class for Recoding/Printing benchmark results on micrometer Composite Meter Registry.
+ * Streams exact SBK latency frequencies and request counters to an SBM aggregator.
  */
 public class GrpcLogger extends SystemLogger {
     private final static String CONFIG_FILE = "sbmhost.properties";
-    private final static int LATENCY_MAP_BYTES = 16;
     private final static String NO_HOST_STRING = "none";
+    private final static int STREAMING_SBP_MINOR_VERSION = 1;
+    private final static int MAXIMUM_PENDING_BATCHES = 8;
 
     private SbmHostConfig sbmHostConfig;
     private boolean enable;
+    private boolean streaming;
     private long clientID;
     private long seqNum;
-    private int latencyBytes;
-    private int maxLatencyBytes;
-    private boolean blocking;
+    private long maxMessageBytes;
     private LatencyRecorder recorder;
-
-    private AtomicLongArray ramWriteBytesArray;
-    private AtomicLongArray ramWriteRequestRecordsArray;
-    private AtomicLongArray ramWriteTimeoutEventsArray;
-    private AtomicLongArray ramReadBytesArray;
-    private AtomicLongArray ramReadRequestRecordsArray;
-    private AtomicLongArray ramReadTimeoutEventsArray;
+    private GrpcLatencyAccumulator latencyAccumulator;
     private ManagedChannel channel;
     private ServiceGrpc.ServiceStub stub;
     private ServiceGrpc.ServiceBlockingStub blockingStub;
     private MessageLatenciesRecord.Builder builder;
     private StreamObserver<com.google.protobuf.Empty> observer;
-    // Removed unused exceptionHandler field. If you need custom exception handling, implement setExceptionHandler logic here.
+    private GrpcStreamSender streamSender;
+    private ExceptionHandler exceptionHandler;
 
     /**
      * Construct a gRPC logger. Calls super to initialize base logging and metrics behavior.
      */
     public GrpcLogger() {
         super();
-        this.ramWriteBytesArray = null;
-        this.ramWriteRequestRecordsArray = null;
-        this.ramReadBytesArray = null;
-        this.ramReadRequestRecordsArray = null;
-        this.ramWriteTimeoutEventsArray = null;
-        this.ramReadTimeoutEventsArray = null;
+        this.exceptionHandler = null;
     }
 
     @Override
     public void setExceptionHandler(ExceptionHandler handler) {
-        // No-op as per edit hint.
+        this.exceptionHandler = handler;
     }
 
     /**
@@ -102,7 +91,7 @@ public class GrpcLogger extends SystemLogger {
             ex.printStackTrace();
             throw new IllegalArgumentException(ex);
         }
-        maxLatencyBytes = sbmHostConfig.maxRecordSizeMB * Bytes.BYTES_PER_MB;
+        maxMessageBytes = (long) sbmHostConfig.maxRecordSizeMB * Bytes.BYTES_PER_MB;
         sbmHostConfig.host = NO_HOST_STRING;
         params.addOption("sbm", true, "SBM host" +
                 "; '" + NO_HOST_STRING + "' disables this option, default: " + sbmHostConfig.host);
@@ -123,9 +112,6 @@ public class GrpcLogger extends SystemLogger {
             return;
         }
         sbmHostConfig.port = Integer.parseInt(params.getOptionValue("sbmport", Integer.toString(sbmHostConfig.port)));
-        //        blocking = Boolean.parseBoolean(params.getOptionValue("blocking", "false"));
-        blocking = false;
-        // exceptionHandler = null; // This line is removed as per edit hint.
     }
 
     /**
@@ -137,16 +123,11 @@ public class GrpcLogger extends SystemLogger {
         if (!enable) {
             return;
         }
-        this.ramWriteBytesArray = new AtomicLongArray(getMaxWriterIDs());
-        this.ramWriteRequestRecordsArray = new AtomicLongArray(getMaxWriterIDs());
-        this.ramReadBytesArray = new AtomicLongArray(getMaxReaderIDs());
-        this.ramReadRequestRecordsArray = new AtomicLongArray(getMaxReaderIDs());
-        this.ramWriteTimeoutEventsArray = new AtomicLongArray(getMaxWriterIDs());
-        this.ramReadTimeoutEventsArray = new AtomicLongArray(getMaxReaderIDs());
         channel = ManagedChannelBuilder.forTarget(sbmHostConfig.host + ":" + sbmHostConfig.port).usePlaintext().build();
         blockingStub = ServiceGrpc.newBlockingStub(channel);
+        Version sbmSbpVersion;
         try {
-            Version sbmSbpVersion = blockingStub.getVersion(Empty.newBuilder().build());
+            sbmSbpVersion = blockingStub.getVersion(Empty.getDefaultInstance());
             SbpVersion version = Sbp.getVersion();
             if (version.major != sbmSbpVersion.getMajor()) {
                 throw new IllegalArgumentException("SBM SBP Major Version: " + sbmSbpVersion.getMajor() +
@@ -163,7 +144,7 @@ public class GrpcLogger extends SystemLogger {
 
         Config config;
         try {
-            config = blockingStub.getConfig(Empty.newBuilder().build());
+            config = blockingStub.getConfig(Empty.getDefaultInstance());
         } catch (StatusRuntimeException ex) {
             ex.printStackTrace();
             throw new IOException("GRPC GetConfig failed");
@@ -198,6 +179,10 @@ public class GrpcLogger extends SystemLogger {
                     + ", local write request: " + isWriteRequestsEnabled() + " are not same!" +
                     ", set the option -wq to "+config.getIsWriteRequests());
         }
+        if (config.getMaxRecordSizeBytes() > 0) {
+            maxMessageBytes = Math.min(maxMessageBytes, config.getMaxRecordSizeBytes());
+        }
+        Printer.log.info("SBK GRPC Logger maximum latency-record size: " + maxMessageBytes + " bytes");
 
         try {
             clientID = blockingStub.registerClient(config).getId();
@@ -213,16 +198,20 @@ public class GrpcLogger extends SystemLogger {
         }
 
         seqNum = 0;
-        latencyBytes = 0;
         recorder = new LatencyRecorder(getMinLatency(), getMaxLatency(), LatencyConfig.LONG_MAX,
                 LatencyConfig.LONG_MAX, LatencyConfig.LONG_MAX);
+        latencyAccumulator = new GrpcLatencyAccumulator(maxMessageBytes);
         builder = MessageLatenciesRecord.newBuilder();
-        if (blocking) {
-            stub = null;
+        stub = ServiceGrpc.newStub(channel);
+        streaming = sbmSbpVersion.getMinor() >= STREAMING_SBP_MINOR_VERSION;
+        if (streaming) {
             observer = null;
+            streamSender = new GrpcStreamSender(stub, MAXIMUM_PENDING_BATCHES, this::reportTransportFailure);
+            Printer.log.info("SBK GRPC Logger transport: SBP client stream with packed primitive latencies");
         } else {
-            stub = ServiceGrpc.newStub(channel);
             observer = new ResponseObserver<>();
+            streamSender = null;
+            Printer.log.info("SBK GRPC Logger transport: SBP unary compatibility mode");
         }
         Printer.log.info("SBK GRPC Logger Started");
     }
@@ -236,48 +225,72 @@ public class GrpcLogger extends SystemLogger {
         if (!enable) {
             return;
         }
+        IOException failure = null;
         try {
-            builder.clear();
-            blockingStub.closeClient(ClientID.newBuilder().setId(clientID).build());
-            channel.shutdownNow().awaitTermination(1, TimeUnit.SECONDS);
-        } catch (InterruptedException ex) {
-            ex.printStackTrace();
+            if (streamSender != null) {
+                streamSender.close();
+            }
+        } catch (IOException exception) {
+            failure = exception;
         }
+        try {
+            blockingStub.closeClient(ClientID.newBuilder().setId(clientID).build());
+        } catch (StatusRuntimeException exception) {
+            if (failure == null) {
+                failure = new IOException("GRPC closeClient failed", exception);
+            } else {
+                failure.addSuppressed(exception);
+            }
+        }
+        channel.shutdown();
+        try {
+            if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+                channel.awaitTermination(1, TimeUnit.SECONDS);
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            channel.shutdownNow();
+            if (failure == null) {
+                failure = new IOException("Interrupted while closing the gRPC channel", exception);
+            } else {
+                failure.addSuppressed(exception);
+            }
+        }
+        builder.clear();
+        latencyAccumulator.clear();
         Printer.log.info("SBK GRPC Logger Shutdown");
+        if (failure != null) {
+            throw failure;
+        }
     }
 
     /**
      * Send the accumulated request/latency counters to SBM and reset local accumulators.
+     *
+     * @param writeRequestBytes write-request bytes represented by this batch
+     * @param writeRequestRecords write-request records represented by this batch
+     * @param readRequestBytes read-request bytes represented by this batch
+     * @param readRequestRecords read-request records represented by this batch
+     * @param writeTimeoutEvents write timeout events represented by this batch
+     * @param readTimeoutEvents read timeout events represented by this batch
      */
-    public void sendLatenciesRecord() {
-        long writeRequestsSum = 0;
-        long writeBytesSum = 0;
-        long readRequestsSum = 0;
-        long readBytesSum = 0;
-        long writeTimeoutEventsSum = 0;
-        long readTimeoutEventsSum = 0;
-        for (int i = 0; i < getMaxWriterIDs(); i++) {
-            writeRequestsSum += ramWriteRequestRecordsArray.getAndSet(i, 0);
-            writeBytesSum += ramWriteBytesArray.getAndSet(i, 0);
-            writeTimeoutEventsSum += ramWriteTimeoutEventsArray.getAndSet(i, 0);
-        }
-        for (int i = 0; i < getMaxReaderIDs(); i++) {
-            readRequestsSum += ramReadRequestRecordsArray.getAndSet(i, 0);
-            readBytesSum += ramReadBytesArray.getAndSet(i, 0);
-            readTimeoutEventsSum += ramReadTimeoutEventsArray.getAndSet(i, 0);
-        }
-        builder.setWriteRequestBytes(writeBytesSum);
-        builder.setWriteRequestRecords(writeRequestsSum);
-        builder.setReadRequestBytes(readBytesSum);
-        builder.setReadRequestRecords(readRequestsSum);
-        builder.setWriteTimeoutEvents(writeTimeoutEventsSum);
-        builder.setReadTimeoutEvents(readTimeoutEventsSum);
+    private void sendLatenciesRecord(long writeRequestBytes, long writeRequestRecords,
+                                     long readRequestBytes, long readRequestRecords,
+                                     long writeTimeoutEvents, long readTimeoutEvents) {
+        builder.setWriteRequestBytes(writeRequestBytes);
+        builder.setWriteRequestRecords(writeRequestRecords);
+        builder.setReadRequestBytes(readRequestBytes);
+        builder.setReadRequestRecords(readRequestRecords);
+        builder.setWriteTimeoutEvents(writeTimeoutEvents);
+        builder.setReadTimeoutEvents(readTimeoutEvents);
         builder.setClientID(clientID);
         builder.setSequenceNumber(++seqNum);
         builder.setMaxReaders(getMaxReadersCount());
         builder.setReaders(getReadersCount());
         builder.setWriters(getWritersCount());
         builder.setMaxWriters(getMaxWritersCount());
+        builder.setMinLatency(recorder.getMinLatency());
         builder.setMaxLatency(recorder.getMaxLatency());
         builder.setTotalLatency(recorder.getTotalLatency());
         builder.setInvalidLatencyRecords(recorder.getInvalidLatencyRecords());
@@ -287,60 +300,29 @@ public class GrpcLogger extends SystemLogger {
         builder.setLowerLatencyDiscardRecords(recorder.getLowerLatencyDiscardRecords());
         builder.setValidLatencyRecords(recorder.getValidLatencyRecords());
 
-        if (stub != null) {
-            stub.addLatenciesRecord(builder.build(), observer);
+        if (streaming) {
+            latencyAccumulator.writePacked(builder);
         } else {
-            blockingStub.addLatenciesRecord(builder.build());
+            latencyAccumulator.writeLegacy(builder);
+        }
+        final MessageLatenciesRecord record = builder.build();
+        if (record.getSerializedSize() > maxMessageBytes) {
+            reportTransportFailure(new IOException("SBK gRPC latency record size " + record.getSerializedSize()
+                    + " exceeds configured maximum " + maxMessageBytes + " bytes"));
+        } else {
+            try {
+                if (streamSender != null) {
+                    streamSender.send(record);
+                } else {
+                    stub.addLatenciesRecord(record, observer);
+                }
+            } catch (IOException exception) {
+                reportTransportFailure(exception);
+            }
         }
         recorder.reset();
         builder.clear();
-        latencyBytes = 0;
-    }
-
-    /**
-     * Record write requests locally and mirror them into RAM buffers for gRPC export when enabled.
-     */
-    @Override
-    public void recordWriteRequests(int writerId, long startTime, long bytes, long events) {
-        super.recordWriteRequests(writerId, startTime, bytes, events);
-        if (enable) {
-            ramWriteRequestRecordsArray.addAndGet(writerId, events);
-            ramWriteBytesArray.addAndGet(writerId, bytes);
-        }
-    }
-
-    /**
-     * Record read requests locally and mirror them into RAM buffers for gRPC export when enabled.
-     */
-    @Override
-    public void recordReadRequests(int readerId, long startTime, long bytes, long events) {
-        super.recordReadRequests(readerId, startTime, bytes, events);
-        if (enable) {
-            ramReadRequestRecordsArray.addAndGet(readerId, events);
-            ramReadBytesArray.addAndGet(readerId, bytes);
-        }
-    }
-    
-    /**
-     * Record write timeout events and mirror them into RAM buffers for gRPC export when enabled.
-     */
-    @Override
-    public void recordWriteTimeoutEvents(int readerId, long startTime, long events) {
-        super.recordWriteTimeoutEvents(readerId, startTime, events);
-        if (enable) {
-            ramWriteTimeoutEventsArray.addAndGet(readerId, events);
-        }
-    }
-
-    /**
-     * Record read timeout events and mirror them into RAM buffers for gRPC export when enabled.
-     */
-    @Override
-    public void recordReadTimeoutEvents(int writerId, long startTime, long events) {
-        super.recordReadTimeoutEvents(writerId, startTime, events);
-        if (enable) {
-            ramReadTimeoutEventsArray.addAndGet(writerId, events);
-        }
+        latencyAccumulator.clear();
     }
 
     /**
@@ -352,15 +334,11 @@ public class GrpcLogger extends SystemLogger {
             return;
         }
 
-        if (latencyBytes >= maxLatencyBytes) {
-            sendLatenciesRecord();
+        if (latencyAccumulator.isFull()) {
+            sendLatenciesRecord(0, 0, 0, 0, 0, 0);
         }
         if (recorder.record(events, bytes, latency)) {
-            final Long cnt = builder.getLatencyMap().getOrDefault(latency, 0L);
-            builder.putLatency(latency, cnt + events);
-            if (cnt == 0) {
-                latencyBytes += LATENCY_MAP_BYTES;
-            }
+            latencyAccumulator.record(latency, events);
         }
     }
 
@@ -386,11 +364,20 @@ public class GrpcLogger extends SystemLogger {
                 minLatency, maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
                 percentileLatencyCounts);
         if (enable) {
-            sendLatenciesRecord();
+            sendLatenciesRecord(writeRequestBytes, writeRequestRecords,
+                    readRequestBytes, readRequestRecords, writeTimeoutEvents, readTimeoutEvents);
         }
     }
 
-    private static class ResponseObserver<T> implements StreamObserver<T> {
+    private void reportTransportFailure(Throwable throwable) {
+        if (exceptionHandler != null) {
+            exceptionHandler.throwException(throwable);
+        } else {
+            Printer.log.error("SBK gRPC logger transport failure", throwable);
+        }
+    }
+
+    private final class ResponseObserver<T> implements StreamObserver<T> {
 
         @Override
         public void onNext(Object value) {
@@ -399,8 +386,7 @@ public class GrpcLogger extends SystemLogger {
 
         @Override
         public void onError(Throwable ex) {
-            // graceful exit may not work GRPC
-            Runtime.getRuntime().exit(1);
+            reportTransportFailure(ex);
         }
 
         @Override

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
@@ -67,6 +67,11 @@ public class GrpcLogger extends SystemLogger {
         this.exceptionHandler = null;
     }
 
+    /**
+     * Sets the benchmark exception handler notified when the gRPC transport fails.
+     *
+     * @param handler exception handler invoked on transport failure
+     */
     @Override
     public void setExceptionHandler(ExceptionHandler handler) {
         this.exceptionHandler = handler;
@@ -74,6 +79,9 @@ public class GrpcLogger extends SystemLogger {
 
     /**
      * Add SBM host/port options and load defaults from {@code sbmhost.properties}.
+     *
+     * @param params command-line option registry
+     * @throws IllegalArgumentException if the bundled SBM configuration cannot be loaded
      */
     @Override
     public void addArgs(final InputOptions params) throws IllegalArgumentException {
@@ -97,6 +105,7 @@ public class GrpcLogger extends SystemLogger {
     /**
      * Parse and validate the required SBM endpoint options.
      *
+     * @param params parsed command-line options
      * @throws IllegalArgumentException if the SBM host is absent or the port is invalid
      */
     @Override
@@ -131,6 +140,13 @@ public class GrpcLogger extends SystemLogger {
 
     /**
      * Open the logger, establish a gRPC channel, validate configuration with SBM, and prepare buffers.
+     *
+     * @param params parsed command-line options
+     * @param storageName storage driver name expected by SBM
+     * @param action benchmark action expected by SBM
+     * @param time benchmark time implementation
+     * @throws IllegalArgumentException if SBK and SBM configurations are incompatible
+     * @throws IOException if the gRPC channel, registration, or stream cannot be initialized
      */
     @Override
     public void open(final ParsedOptions params, final String storageName, Action action, Time time) throws IllegalArgumentException, IOException {
@@ -222,6 +238,10 @@ public class GrpcLogger extends SystemLogger {
 
     /**
      * Close the logger, unregister the client, and shutdown the gRPC channel.
+     *
+     * @param params parsed command-line options
+     * @throws IllegalArgumentException if inherited logger shutdown validation fails
+     * @throws IOException if the stream cannot drain or the channel cannot close cleanly
      */
     @Override
     public void close(final ParsedOptions params) throws IllegalArgumentException, IOException {
@@ -286,7 +306,8 @@ public class GrpcLogger extends SystemLogger {
         builder.setWriteTimeoutEvents(writeTimeoutEvents);
         builder.setReadTimeoutEvents(readTimeoutEvents);
         builder.setClientID(clientID);
-        builder.setSequenceNumber(++seqNum);
+        final long candidateSequenceNumber = seqNum + 1;
+        builder.setSequenceNumber(candidateSequenceNumber);
         builder.setMaxReaders(getMaxReadersCount());
         builder.setReaders(getReadersCount());
         builder.setWriters(getWritersCount());
@@ -309,6 +330,7 @@ public class GrpcLogger extends SystemLogger {
         } else {
             try {
                 streamSender.send(record);
+                seqNum = candidateSequenceNumber;
             } catch (IOException exception) {
                 reportTransportFailure(exception);
             }
@@ -320,6 +342,11 @@ public class GrpcLogger extends SystemLogger {
 
     /**
      * Record individual latency values into the local {@code LatencyRecorder} and stage them for gRPC export.
+     *
+     * @param startTime operation start time
+     * @param events number of operations represented by this measurement
+     * @param bytes number of bytes represented by this measurement
+     * @param latency measured operation latency
      */
     @Override
     public void recordLatency(long startTime, int events, int bytes, long latency) {
@@ -337,6 +364,48 @@ public class GrpcLogger extends SystemLogger {
         recorder.record(events, bytes, latency);
     }
 
+    /**
+     * Print periodic results locally and enqueue the corresponding exact latency batch for SBM.
+     *
+     * @param reportTime report time in milliseconds
+     * @param writers active writers
+     * @param maxWriters maximum writers
+     * @param readers active readers
+     * @param maxReaders maximum readers
+     * @param writeRequestBytes write request bytes
+     * @param writeRequestMbPerSec write request throughput in MB/sec
+     * @param writeRequestRecords write request records
+     * @param writeRequestRecordsPerSec write requests per second
+     * @param readRequestBytes read request bytes
+     * @param readRequestMbPerSec read request throughput in MB/sec
+     * @param readRequestRecords read request records
+     * @param readRequestRecordsPerSec read requests per second
+     * @param writeResponsePendingRecords pending write response records
+     * @param writeResponsePendingBytes pending write response bytes
+     * @param readResponsePendingRecords pending read response records
+     * @param readResponsePendingBytes pending read response bytes
+     * @param writeReadRequestPendingRecords write-read pending records
+     * @param writeReadRequestPendingBytes write-read pending bytes
+     * @param writeTimeoutEvents write timeout events
+     * @param writeTimeoutEventsPerSec write timeout events per second
+     * @param readTimeoutEvents read timeout events
+     * @param readTimeoutEventsPerSec read timeout events per second
+     * @param seconds reporting interval seconds
+     * @param bytes bytes processed
+     * @param records records processed
+     * @param recsPerSec records per second
+     * @param mbPerSec throughput in MB/sec
+     * @param avgLatency average latency
+     * @param minLatency minimum latency
+     * @param maxLatency maximum latency
+     * @param invalid invalid latency count
+     * @param lowerDiscard latencies discarded below the configured minimum
+     * @param higherDiscard latencies discarded above the configured maximum
+     * @param slc1 sliding latency coverage count 1
+     * @param slc2 sliding latency coverage count 2
+     * @param percentileLatencies percentile latency values
+     * @param percentileLatencyCounts percentile latency bucket counts
+     */
     @Override
     public void print(long reportTime, int writers, int maxWriters, int readers, int maxReaders,
                       long writeRequestBytes, double writeRequestMbPerSec, long writeRequestRecords,

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
@@ -42,11 +42,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class GrpcLogger extends SystemLogger {
     private final static String CONFIG_FILE = "sbmhost.properties";
-    private final static String NO_HOST_STRING = "none";
     private final static int MAXIMUM_PENDING_BATCHES = 8;
+    private final static int MINIMUM_PORT = 1;
+    private final static int MAXIMUM_PORT = 65535;
 
     private SbmHostConfig sbmHostConfig;
-    private boolean enable;
     private long clientID;
     private long seqNum;
     private long maxMessageBytes;
@@ -88,26 +88,45 @@ public class GrpcLogger extends SystemLogger {
             throw new IllegalArgumentException(ex);
         }
         maxMessageBytes = (long) sbmHostConfig.maxRecordSizeMB * Bytes.BYTES_PER_MB;
-        sbmHostConfig.host = NO_HOST_STRING;
-        params.addOption("sbm", true, "SBM host" +
-                "; '" + NO_HOST_STRING + "' disables this option, default: " + sbmHostConfig.host);
+        params.addOption("sbm", true, "Required SBM hostname or IP address");
         params.addOption("sbmport", true, "SBM Port" +
                 "; default: " + sbmHostConfig.port);
         //params.addOption("blocking", true, "blocking calls to SBM; default: false");
     }
 
     /**
-     * Parse SBM options and decide if gRPC export is enabled.
+     * Parse and validate the required SBM endpoint options.
+     *
+     * @throws IllegalArgumentException if the SBM host is absent or the port is invalid
      */
     @Override
     public void parseArgs(final ParsedOptions params) throws IllegalArgumentException {
         super.parseArgs(params);
-        sbmHostConfig.host = params.getOptionValue("sbm", sbmHostConfig.host);
-        enable = !sbmHostConfig.host.equalsIgnoreCase(NO_HOST_STRING);
-        if (!enable) {
-            return;
+        if (!params.hasOptionValue("sbm")) {
+            throw new IllegalArgumentException(
+                    "GrpcLogger requires '-sbm <hostname-or-IP>'");
         }
-        sbmHostConfig.port = Integer.parseInt(params.getOptionValue("sbmport", Integer.toString(sbmHostConfig.port)));
+        sbmHostConfig.host = params.getOptionValue("sbm").trim();
+        if (sbmHostConfig.host.isEmpty() || sbmHostConfig.host.equalsIgnoreCase("none")) {
+            throw new IllegalArgumentException(
+                    "Invalid SBM host: '-sbm' must specify a hostname or IP address");
+        }
+
+        final String portValue = params.getOptionValue(
+                "sbmport", Integer.toString(sbmHostConfig.port));
+        try {
+            sbmHostConfig.port = Integer.parseInt(portValue);
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException(
+                    "Invalid SBM port '" + portValue + "': expected an integer from "
+                            + MINIMUM_PORT + " through " + MAXIMUM_PORT,
+                    exception);
+        }
+        if (sbmHostConfig.port < MINIMUM_PORT || sbmHostConfig.port > MAXIMUM_PORT) {
+            throw new IllegalArgumentException(
+                    "Invalid SBM port '" + portValue + "': expected an integer from "
+                            + MINIMUM_PORT + " through " + MAXIMUM_PORT);
+        }
     }
 
     /**
@@ -116,9 +135,6 @@ public class GrpcLogger extends SystemLogger {
     @Override
     public void open(final ParsedOptions params, final String storageName, Action action, Time time) throws IllegalArgumentException, IOException {
         super.open(params, storageName, action, time);
-        if (!enable) {
-            return;
-        }
         channel = ManagedChannelBuilder.forTarget(sbmHostConfig.host + ":" + sbmHostConfig.port).usePlaintext().build();
         blockingStub = ServiceGrpc.newBlockingStub(channel);
         Version sbmSbpVersion;
@@ -210,9 +226,6 @@ public class GrpcLogger extends SystemLogger {
     @Override
     public void close(final ParsedOptions params) throws IllegalArgumentException, IOException {
         super.close(params);
-        if (!enable) {
-            return;
-        }
         IOException failure = null;
         try {
             if (streamSender != null) {
@@ -310,10 +323,6 @@ public class GrpcLogger extends SystemLogger {
      */
     @Override
     public void recordLatency(long startTime, int events, int bytes, long latency) {
-        if (!enable) {
-            return;
-        }
-
         final boolean validLatency = latency >= 0
                 && latency >= getMinLatency() && latency <= getMaxLatency();
         if (validLatency && !latencyAccumulator.recordIfFits(latency, events)) {
@@ -349,10 +358,8 @@ public class GrpcLogger extends SystemLogger {
                 readTimeoutEventsPerSec, seconds, bytes, records, recsPerSec, mbPerSec, avgLatency,
                 minLatency, maxLatency, invalid, lowerDiscard, higherDiscard, slc1, slc2, percentileLatencies,
                 percentileLatencyCounts);
-        if (enable) {
-            sendLatenciesRecord(writeRequestBytes, writeRequestRecords,
-                    readRequestBytes, readRequestRecords, writeTimeoutEvents, readTimeoutEvents);
-        }
+        sendLatenciesRecord(writeRequestBytes, writeRequestRecords,
+                readRequestBytes, readRequestRecords, writeTimeoutEvents, readTimeoutEvents);
     }
 
     private void reportTransportFailure(Throwable throwable) {

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcLogger.java
@@ -16,7 +16,6 @@ import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
 import io.perl.data.Bytes;
 import io.perl.config.LatencyConfig;
 import io.perl.api.LatencyRecorder;
@@ -44,12 +43,10 @@ import java.util.concurrent.TimeUnit;
 public class GrpcLogger extends SystemLogger {
     private final static String CONFIG_FILE = "sbmhost.properties";
     private final static String NO_HOST_STRING = "none";
-    private final static int STREAMING_SBP_MINOR_VERSION = 1;
     private final static int MAXIMUM_PENDING_BATCHES = 8;
 
     private SbmHostConfig sbmHostConfig;
     private boolean enable;
-    private boolean streaming;
     private long clientID;
     private long seqNum;
     private long maxMessageBytes;
@@ -59,7 +56,6 @@ public class GrpcLogger extends SystemLogger {
     private ServiceGrpc.ServiceStub stub;
     private ServiceGrpc.ServiceBlockingStub blockingStub;
     private MessageLatenciesRecord.Builder builder;
-    private StreamObserver<com.google.protobuf.Empty> observer;
     private GrpcStreamSender streamSender;
     private ExceptionHandler exceptionHandler;
 
@@ -203,16 +199,8 @@ public class GrpcLogger extends SystemLogger {
         latencyAccumulator = new GrpcLatencyAccumulator(maxMessageBytes);
         builder = MessageLatenciesRecord.newBuilder();
         stub = ServiceGrpc.newStub(channel);
-        streaming = sbmSbpVersion.getMinor() >= STREAMING_SBP_MINOR_VERSION;
-        if (streaming) {
-            observer = null;
-            streamSender = new GrpcStreamSender(stub, MAXIMUM_PENDING_BATCHES, this::reportTransportFailure);
-            Printer.log.info("SBK GRPC Logger transport: SBP client stream with packed primitive latencies");
-        } else {
-            observer = new ResponseObserver<>();
-            streamSender = null;
-            Printer.log.info("SBK GRPC Logger transport: SBP unary compatibility mode");
-        }
+        streamSender = new GrpcStreamSender(stub, MAXIMUM_PENDING_BATCHES, this::reportTransportFailure);
+        Printer.log.info("SBK GRPC Logger transport: SBP client stream with packed primitive latencies");
         Printer.log.info("SBK GRPC Logger Started");
     }
 
@@ -300,22 +288,14 @@ public class GrpcLogger extends SystemLogger {
         builder.setLowerLatencyDiscardRecords(recorder.getLowerLatencyDiscardRecords());
         builder.setValidLatencyRecords(recorder.getValidLatencyRecords());
 
-        if (streaming) {
-            latencyAccumulator.writePacked(builder);
-        } else {
-            latencyAccumulator.writeLegacy(builder);
-        }
+        latencyAccumulator.writePacked(builder);
         final MessageLatenciesRecord record = builder.build();
         if (record.getSerializedSize() > maxMessageBytes) {
             reportTransportFailure(new IOException("SBK gRPC latency record size " + record.getSerializedSize()
                     + " exceeds configured maximum " + maxMessageBytes + " bytes"));
         } else {
             try {
-                if (streamSender != null) {
-                    streamSender.send(record);
-                } else {
-                    stub.addLatenciesRecord(record, observer);
-                }
+                streamSender.send(record);
             } catch (IOException exception) {
                 reportTransportFailure(exception);
             }
@@ -374,24 +354,6 @@ public class GrpcLogger extends SystemLogger {
             exceptionHandler.throwException(throwable);
         } else {
             Printer.log.error("SBK gRPC logger transport failure", throwable);
-        }
-    }
-
-    private final class ResponseObserver<T> implements StreamObserver<T> {
-
-        @Override
-        public void onNext(Object value) {
-
-        }
-
-        @Override
-        public void onError(Throwable ex) {
-            reportTransportFailure(ex);
-        }
-
-        @Override
-        public void onCompleted() {
-
         }
     }
 

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcStreamSender.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcStreamSender.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import com.google.protobuf.Empty;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.perl.exception.ExceptionHandler;
+import io.sbp.grpc.MessageLatenciesRecord;
+import io.sbp.grpc.ServiceGrpc;
+
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Sends immutable latency batches over one flow-controlled client stream.
+ *
+ * <p>A bounded queue isolates protobuf serialization and network progress from
+ * the PerL consumer. The sender parks when HTTP/2 flow control reports that the
+ * stream is not ready; it never spin-waits and never grows memory without a
+ * configured bound.
+ */
+final class GrpcStreamSender implements AutoCloseable {
+    private static final Object END = new Object();
+    private static final long READY_PARK_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+    private final ArrayBlockingQueue<Object> batches;
+    private final CountDownLatch responseCompleted;
+    private final ExceptionHandler exceptionHandler;
+    private final Thread senderThread;
+    private volatile ClientCallStreamObserver<MessageLatenciesRecord> requestStream;
+    private volatile Throwable failure;
+    private volatile boolean closed;
+
+    /**
+     * Opens one client-streaming RPC and starts its dedicated sender thread.
+     *
+     * @param stub asynchronous service stub
+     * @param maximumPendingBatches maximum number of retained immutable batches
+     * @param exceptionHandler benchmark shutdown callback
+     */
+    GrpcStreamSender(ServiceGrpc.ServiceStub stub, int maximumPendingBatches,
+                     ExceptionHandler exceptionHandler) {
+        this.batches = new ArrayBlockingQueue<>(maximumPendingBatches);
+        this.responseCompleted = new CountDownLatch(1);
+        this.exceptionHandler = exceptionHandler;
+        this.closed = false;
+        final ClientResponseObserver<MessageLatenciesRecord, Empty> responseObserver =
+                new ClientResponseObserver<>() {
+                    @Override
+                    @SuppressFBWarnings(value = "EI_EXPOSE_REP2",
+                            justification = "The gRPC request stream is the transport handle owned by this sender")
+                    public void beforeStart(ClientCallStreamObserver<MessageLatenciesRecord> stream) {
+                        requestStream = stream;
+                        stream.setOnReadyHandler(() -> LockSupport.unpark(senderThread));
+                    }
+
+                    @Override
+                    public void onNext(Empty value) {
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {
+                        reportFailure(throwable);
+                        responseCompleted.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        responseCompleted.countDown();
+                    }
+                };
+        this.senderThread = Thread.ofPlatform()
+                .name("sbk-grpc-stream-sender")
+                .daemon(true)
+                .unstarted(this::sendLoop);
+        stub.streamLatencies(responseObserver);
+        senderThread.start();
+    }
+
+    /**
+     * Offers a completed immutable protobuf batch without waiting.
+     *
+     * @param record latency batch
+     * @throws IOException when the stream failed or its bounded queue is full
+     */
+    void send(MessageLatenciesRecord record) throws IOException {
+        checkFailure();
+        if (closed) {
+            throw new IOException("SBK gRPC latency stream is already closed");
+        }
+        if (!batches.offer(record)) {
+            final IOException exception = new IOException(
+                    "SBK gRPC latency stream is overloaded: pending batch queue is full");
+            reportFailure(exception);
+            throw exception;
+        }
+    }
+
+    private void sendLoop() {
+        try {
+            while (true) {
+                final Object next = batches.take();
+                if (next == END) {
+                    requestStream.onCompleted();
+                    return;
+                }
+                awaitReady();
+                requestStream.onNext((MessageLatenciesRecord) next);
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            reportFailure(exception);
+        } catch (IOException exception) {
+            reportFailure(exception);
+        } catch (RuntimeException exception) {
+            reportFailure(exception);
+        }
+    }
+
+    private void awaitReady() throws InterruptedException, IOException {
+        while (!requestStream.isReady()) {
+            checkFailure();
+            LockSupport.parkNanos(READY_PARK_NANOS);
+            if (Thread.interrupted()) {
+                throw new InterruptedException("SBK gRPC stream sender interrupted");
+            }
+        }
+    }
+
+    private void reportFailure(Throwable throwable) {
+        if (failure == null) {
+            failure = throwable;
+            LockSupport.unpark(senderThread);
+            if (exceptionHandler != null) {
+                exceptionHandler.throwException(throwable);
+            }
+        }
+    }
+
+    private void checkFailure() throws IOException {
+        final Throwable currentFailure = failure;
+        if (currentFailure != null) {
+            throw new IOException("SBK gRPC latency stream failed", currentFailure);
+        }
+    }
+
+    /**
+     * Drains queued batches, half-closes the request stream, and waits for the
+     * server acknowledgement.
+     *
+     * @throws IOException when draining or server acknowledgement fails
+     */
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            checkFailure();
+            return;
+        }
+        closed = true;
+        try {
+            if (!batches.offer(END, 5, TimeUnit.SECONDS)) {
+                throw new IOException("Timed out while scheduling the final gRPC stream drain");
+            }
+            senderThread.join(TimeUnit.SECONDS.toMillis(5));
+            if (senderThread.isAlive()) {
+                throw new IOException("Timed out while draining the gRPC latency stream");
+            }
+            if (!responseCompleted.await(5, TimeUnit.SECONDS)) {
+                throw new IOException("Timed out waiting for the SBM gRPC stream acknowledgement");
+            }
+            checkFailure();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while closing the gRPC latency stream", exception);
+        }
+    }
+}

--- a/sbk-api/src/main/java/io/sbk/logger/impl/GrpcStreamSender.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/GrpcStreamSender.java
@@ -176,7 +176,9 @@ final class GrpcStreamSender implements AutoCloseable {
             if (senderThread.isAlive()) {
                 throw new IOException("Timed out while draining the gRPC latency stream");
             }
+            checkFailure();
             if (!responseCompleted.await(5, TimeUnit.SECONDS)) {
+                checkFailure();
                 throw new IOException("Timed out waiting for the SBM gRPC stream acknowledgement");
             }
             checkFailure();

--- a/sbk-api/src/main/proto/sbp.proto
+++ b/sbk-api/src/main/proto/sbp.proto
@@ -28,7 +28,6 @@ service Service {
   rpc isVersionSupported (Version) returns (google.protobuf.BoolValue) {}
   rpc getConfig (google.protobuf.Empty) returns (Config) {}
   rpc registerClient (Config) returns (ClientID) {}
-  rpc addLatenciesRecord (MessageLatenciesRecord) returns (google.protobuf.Empty) {}
   rpc streamLatencies (stream MessageLatenciesRecord) returns (google.protobuf.Empty) {}
   rpc closeClient (ClientID) returns (google.protobuf.Empty) {}
 }
@@ -91,7 +90,7 @@ message MessageLatenciesRecord {
   int64 totalLatency = 19;
   int64 minLatency = 20;
   int64 maxLatency = 21;
-  map<int64, int64 > latency = 22;
+  reserved 22;
   repeated uint64 latencyValues = 23 [packed = true];
   repeated uint64 latencyCounts = 24 [packed = true];
 }

--- a/sbk-api/src/main/proto/sbp.proto
+++ b/sbk-api/src/main/proto/sbp.proto
@@ -29,6 +29,7 @@ service Service {
   rpc getConfig (google.protobuf.Empty) returns (Config) {}
   rpc registerClient (Config) returns (ClientID) {}
   rpc addLatenciesRecord (MessageLatenciesRecord) returns (google.protobuf.Empty) {}
+  rpc streamLatencies (stream MessageLatenciesRecord) returns (google.protobuf.Empty) {}
   rpc closeClient (ClientID) returns (google.protobuf.Empty) {}
 }
 
@@ -60,6 +61,7 @@ message Config {
   int64 maxLatency = 5;
   bool isWriteRequests = 6;
   bool isReadRequests = 7;
+  int64 maxRecordSizeBytes = 8;
 }
 
 message ClientID {
@@ -90,5 +92,6 @@ message MessageLatenciesRecord {
   int64 minLatency = 20;
   int64 maxLatency = 21;
   map<int64, int64 > latency = 22;
+  repeated uint64 latencyValues = 23 [packed = true];
+  repeated uint64 latencyCounts = 24 [packed = true];
 }
-

--- a/sbk-api/src/main/resources/sbmhost.properties
+++ b/sbk-api/src/main/resources/sbmhost.properties
@@ -6,9 +6,6 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-#hostname
-host=localhost
-
 #port
 port=9717
 

--- a/sbk-api/src/main/resources/sbmhost.properties
+++ b/sbk-api/src/main/resources/sbmhost.properties
@@ -13,4 +13,4 @@ host=localhost
 port=9717
 
 #max latency record size in MB
-maxRecordSizeMB=4
+maxRecordSizeMB=16

--- a/sbk-api/src/main/resources/sbp-version.properties
+++ b/sbk-api/src/main/resources/sbp-version.properties
@@ -7,7 +7,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 
 # Major Version
-major=3
+major=4
 
 # Minor Version
-minor=1
+minor=0

--- a/sbk-api/src/main/resources/sbp-version.properties
+++ b/sbk-api/src/main/resources/sbp-version.properties
@@ -10,4 +10,4 @@
 major=3
 
 # Minor Version
-minor=0
+minor=1

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
@@ -28,9 +28,9 @@ final class GrpcLatencyAccumulatorTest {
     void preservesExactCountsInPackedRepresentation() {
         final GrpcLatencyAccumulator accumulator =
                 new GrpcLatencyAccumulator(16L * Bytes.BYTES_PER_MB);
-        accumulator.record(100, 2);
-        accumulator.record(200, 3);
-        accumulator.record(100, 5);
+        assertTrue(accumulator.recordIfFits(100, 2));
+        assertTrue(accumulator.recordIfFits(200, 3));
+        assertTrue(accumulator.recordIfFits(100, 5));
 
         final MessageLatenciesRecord.Builder packedBuilder =
                 MessageLatenciesRecord.newBuilder();
@@ -46,32 +46,67 @@ final class GrpcLatencyAccumulatorTest {
     }
 
     @Test
-    void appliesConservativeMessageHeadroomAndReusesStorageAfterClear() {
+    void usesConfiguredLimitAndReusesStorageAfterClear() {
         final GrpcLatencyAccumulator accumulator =
-                new GrpcLatencyAccumulator(100);
-        accumulator.record(1, 1);
-        accumulator.record(2, 1);
-        accumulator.record(3, 1);
-        accumulator.record(4, 1);
+                new GrpcLatencyAccumulator(512);
+        long latency = Long.MAX_VALUE;
+        while (accumulator.recordIfFits(latency, Long.MAX_VALUE)) {
+            latency--;
+        }
 
-        assertTrue(accumulator.isFull());
+        final MessageLatenciesRecord.Builder builder = maximumMetadataBuilder();
+        accumulator.writePacked(builder);
+        assertTrue(builder.build().getSerializedSize() > 512 * 3 / 4);
         accumulator.clear();
         assertEquals(0, accumulator.size());
     }
 
     @Test
-    void conservativeThresholdKeepsWorstCasePackedRecordBelowTransportLimit() {
+    void exactThresholdKeepsWorstCasePackedRecordBelowTransportLimit() {
         final long maximumMessageBytes = 16L * Bytes.BYTES_PER_MB;
         final GrpcLatencyAccumulator accumulator =
                 new GrpcLatencyAccumulator(maximumMessageBytes);
         long latency = Long.MAX_VALUE;
-        while (!accumulator.isFull()) {
-            accumulator.record(latency--, Long.MAX_VALUE);
+        while (accumulator.recordIfFits(latency, Long.MAX_VALUE)) {
+            latency--;
         }
-        final MessageLatenciesRecord.Builder builder =
-                MessageLatenciesRecord.newBuilder();
+        final MessageLatenciesRecord.Builder builder = maximumMetadataBuilder();
         accumulator.writePacked(builder);
 
-        assertFalse(builder.build().getSerializedSize() > maximumMessageBytes);
+        assertTrue(builder.build().getSerializedSize() <= maximumMessageBytes);
+        assertFalse(accumulator.recordIfFits(latency, Long.MAX_VALUE));
+    }
+
+    @Test
+    void countVarintGrowthParticipatesInExactLimit() {
+        final GrpcLatencyAccumulator accumulator = new GrpcLatencyAccumulator(245);
+        assertTrue(accumulator.recordIfFits(1, 127));
+
+        assertFalse(accumulator.recordIfFits(1, 1));
+    }
+
+    private static MessageLatenciesRecord.Builder maximumMetadataBuilder() {
+        return MessageLatenciesRecord.newBuilder()
+                .setClientID(-1)
+                .setSequenceNumber(-1)
+                .setWriters(-1)
+                .setReaders(-1)
+                .setMaxWriters(-1)
+                .setMaxReaders(-1)
+                .setWriteRequestBytes(-1)
+                .setWriteRequestRecords(-1)
+                .setReadRequestBytes(-1)
+                .setReadRequestRecords(-1)
+                .setWriteTimeoutEvents(-1)
+                .setReadTimeoutEvents(-1)
+                .setTotalRecords(-1)
+                .setValidLatencyRecords(-1)
+                .setLowerLatencyDiscardRecords(-1)
+                .setHigherLatencyDiscardRecords(-1)
+                .setInvalidLatencyRecords(-1)
+                .setTotalBytes(-1)
+                .setTotalLatency(-1)
+                .setMinLatency(-1)
+                .setMaxLatency(-1);
     }
 }

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 final class GrpcLatencyAccumulatorTest {
     @Test
-    void preservesExactCountsInPackedAndLegacyRepresentations() {
+    void preservesExactCountsInPackedRepresentation() {
         final GrpcLatencyAccumulator accumulator =
                 new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
         accumulator.record(100, 2);
@@ -41,12 +41,7 @@ final class GrpcLatencyAccumulatorTest {
             packedValues.put(packed.getLatencyValues(index), packed.getLatencyCounts(index));
         }
 
-        final MessageLatenciesRecord.Builder legacyBuilder =
-                MessageLatenciesRecord.newBuilder();
-        accumulator.writeLegacy(legacyBuilder);
-
         assertEquals(Map.of(100L, 7L, 200L, 3L), packedValues);
-        assertEquals(packedValues, legacyBuilder.getLatencyMap());
         assertEquals(2, accumulator.size());
     }
 

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
@@ -27,7 +27,7 @@ final class GrpcLatencyAccumulatorTest {
     @Test
     void preservesExactCountsInPackedRepresentation() {
         final GrpcLatencyAccumulator accumulator =
-                new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+                new GrpcLatencyAccumulator(16L * Bytes.BYTES_PER_MB);
         accumulator.record(100, 2);
         accumulator.record(200, 3);
         accumulator.record(100, 5);
@@ -61,7 +61,7 @@ final class GrpcLatencyAccumulatorTest {
 
     @Test
     void conservativeThresholdKeepsWorstCasePackedRecordBelowTransportLimit() {
-        final long maximumMessageBytes = 4L * Bytes.BYTES_PER_MB;
+        final long maximumMessageBytes = 16L * Bytes.BYTES_PER_MB;
         final GrpcLatencyAccumulator accumulator =
                 new GrpcLatencyAccumulator(maximumMessageBytes);
         long latency = Long.MAX_VALUE;

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLatencyAccumulatorTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.perl.data.Bytes;
+import io.sbp.grpc.MessageLatenciesRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies exact primitive latency accumulation and protobuf conversion.
+ */
+final class GrpcLatencyAccumulatorTest {
+    @Test
+    void preservesExactCountsInPackedAndLegacyRepresentations() {
+        final GrpcLatencyAccumulator accumulator =
+                new GrpcLatencyAccumulator(4L * Bytes.BYTES_PER_MB);
+        accumulator.record(100, 2);
+        accumulator.record(200, 3);
+        accumulator.record(100, 5);
+
+        final MessageLatenciesRecord.Builder packedBuilder =
+                MessageLatenciesRecord.newBuilder();
+        accumulator.writePacked(packedBuilder);
+        final MessageLatenciesRecord packed = packedBuilder.build();
+        final Map<Long, Long> packedValues = new HashMap<>();
+        for (int index = 0; index < packed.getLatencyValuesCount(); index++) {
+            packedValues.put(packed.getLatencyValues(index), packed.getLatencyCounts(index));
+        }
+
+        final MessageLatenciesRecord.Builder legacyBuilder =
+                MessageLatenciesRecord.newBuilder();
+        accumulator.writeLegacy(legacyBuilder);
+
+        assertEquals(Map.of(100L, 7L, 200L, 3L), packedValues);
+        assertEquals(packedValues, legacyBuilder.getLatencyMap());
+        assertEquals(2, accumulator.size());
+    }
+
+    @Test
+    void appliesConservativeMessageHeadroomAndReusesStorageAfterClear() {
+        final GrpcLatencyAccumulator accumulator =
+                new GrpcLatencyAccumulator(100);
+        accumulator.record(1, 1);
+        accumulator.record(2, 1);
+        accumulator.record(3, 1);
+        accumulator.record(4, 1);
+
+        assertTrue(accumulator.isFull());
+        accumulator.clear();
+        assertEquals(0, accumulator.size());
+    }
+
+    @Test
+    void conservativeThresholdKeepsWorstCasePackedRecordBelowTransportLimit() {
+        final long maximumMessageBytes = 4L * Bytes.BYTES_PER_MB;
+        final GrpcLatencyAccumulator accumulator =
+                new GrpcLatencyAccumulator(maximumMessageBytes);
+        long latency = Long.MAX_VALUE;
+        while (!accumulator.isFull()) {
+            accumulator.record(latency--, Long.MAX_VALUE);
+        }
+        final MessageLatenciesRecord.Builder builder =
+                MessageLatenciesRecord.newBuilder();
+        accumulator.writePacked(builder);
+
+        assertFalse(builder.build().getSerializedSize() > maximumMessageBytes);
+    }
+}

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLoggerOptionsTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcLoggerOptionsTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.sbk.params.impl.SbkParameters;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies fail-fast validation of the SBM endpoint used by {@link GrpcLogger}.
+ */
+public final class GrpcLoggerOptionsTest {
+
+    /**
+     * A selected gRPC logger must not silently disable itself when the SBM host is absent.
+     *
+     * @throws Exception if the common SBK arguments cannot be parsed
+     */
+    @Test
+    public void rejectsMissingSbmHost() throws Exception {
+        final GrpcLogger logger = new GrpcLogger();
+        final SbkParameters parameters = parameters(logger,
+                "-writers", "1", "-size", "100", "-records", "1");
+
+        final IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class, () -> logger.parseArgs(parameters));
+
+        assertEquals("GrpcLogger requires '-sbm <hostname-or-IP>'", exception.getMessage());
+    }
+
+    /**
+     * The former disabling value is rejected as an invalid endpoint.
+     *
+     * @throws Exception if the common SBK arguments cannot be parsed
+     */
+    @Test
+    public void rejectsNoneSbmHost() throws Exception {
+        final GrpcLogger logger = new GrpcLogger();
+        final SbkParameters parameters = parameters(logger,
+                "-writers", "1", "-size", "100", "-records", "1",
+                "-sbm", "none");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> logger.parseArgs(parameters));
+    }
+
+    /**
+     * A non-numeric port is reported as an argument error.
+     *
+     * @throws Exception if the common SBK arguments cannot be parsed
+     */
+    @Test
+    public void rejectsNonNumericSbmPort() throws Exception {
+        final GrpcLogger logger = new GrpcLogger();
+        final SbkParameters parameters = parameters(logger,
+                "-writers", "1", "-size", "100", "-records", "1",
+                "-sbm", "127.0.0.1", "-sbmport", "invalid");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> logger.parseArgs(parameters));
+    }
+
+    /**
+     * TCP ports outside the valid range are rejected before a channel is opened.
+     *
+     * @throws Exception if the common SBK arguments cannot be parsed
+     */
+    @Test
+    public void rejectsOutOfRangeSbmPort() throws Exception {
+        final GrpcLogger logger = new GrpcLogger();
+        final SbkParameters parameters = parameters(logger,
+                "-writers", "1", "-size", "100", "-records", "1",
+                "-sbm", "127.0.0.1", "-sbmport", "65536");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> logger.parseArgs(parameters));
+    }
+
+    /**
+     * A valid explicit host and port pass endpoint validation.
+     *
+     * @throws Exception if the common SBK arguments cannot be parsed
+     */
+    @Test
+    public void acceptsValidSbmEndpoint() throws Exception {
+        final GrpcLogger logger = new GrpcLogger();
+        final SbkParameters parameters = parameters(logger,
+                "-writers", "1", "-size", "100", "-records", "1",
+                "-sbm", "127.0.0.1", "-sbmport", "9717");
+
+        assertDoesNotThrow(() -> logger.parseArgs(parameters));
+    }
+
+    private static SbkParameters parameters(GrpcLogger logger, String... arguments)
+            throws Exception {
+        final SbkParameters parameters = new SbkParameters("grpc-options-test");
+        logger.addArgs(parameters);
+        parameters.parseArgs(arguments);
+        return parameters;
+    }
+}

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcStreamSenderTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcStreamSenderTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.sbp.grpc.MessageLatenciesRecord;
+import io.sbp.grpc.ServiceGrpc;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies ordered streaming and final acknowledgement of queued latency
+ * batches.
+ */
+final class GrpcStreamSenderTest {
+    @Test
+    void drainsAllBatchesBeforeCompletingTheStream() throws Exception {
+        final String serverName = InProcessServerBuilder.generateName();
+        final List<Long> sequences = new ArrayList<>();
+        final Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ServiceGrpc.ServiceImplBase() {
+                    @Override
+                    public StreamObserver<MessageLatenciesRecord> streamLatencies(
+                            StreamObserver<Empty> responseObserver) {
+                        return new StreamObserver<>() {
+                            @Override
+                            public void onNext(MessageLatenciesRecord value) {
+                                sequences.add(value.getSequenceNumber());
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                responseObserver.onNext(Empty.getDefaultInstance());
+                                responseObserver.onCompleted();
+                            }
+                        };
+                    }
+                })
+                .build()
+                .start();
+        final ManagedChannel channel = InProcessChannelBuilder.forName(serverName)
+                .directExecutor()
+                .build();
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        try {
+            final GrpcStreamSender sender = new GrpcStreamSender(
+                    ServiceGrpc.newStub(channel), 4, failure::set);
+            sender.send(MessageLatenciesRecord.newBuilder().setSequenceNumber(1).build());
+            sender.send(MessageLatenciesRecord.newBuilder().setSequenceNumber(2).build());
+            sender.close();
+
+            assertEquals(List.of(1L, 2L), sequences);
+            assertNull(failure.get());
+        } finally {
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+}

--- a/sbk-api/src/test/java/io/sbk/logger/impl/GrpcStreamSenderTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/GrpcStreamSenderTest.java
@@ -10,21 +10,35 @@
 package io.sbk.logger.impl;
 
 import com.google.protobuf.Empty;
+import io.grpc.Status;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import io.sbp.grpc.MessageLatenciesRecord;
 import io.sbp.grpc.ServiceGrpc;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Verifies ordered streaming and final acknowledgement of queued latency
@@ -79,5 +93,114 @@ final class GrpcStreamSenderTest {
             channel.shutdownNow();
             server.shutdownNow();
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void rejectsBatchesWhenTheBoundedQueueIsFull() throws Exception {
+        final ServiceGrpc.ServiceStub stub = mock(ServiceGrpc.ServiceStub.class);
+        final ClientCallStreamObserver<MessageLatenciesRecord> requestStream =
+                mock(ClientCallStreamObserver.class);
+        when(requestStream.isReady()).thenReturn(false);
+        when(stub.streamLatencies(any())).thenAnswer(invocation -> {
+            final ClientResponseObserver<MessageLatenciesRecord, Empty> responseObserver =
+                    invocation.getArgument(0);
+            responseObserver.beforeStart(requestStream);
+            return requestStream;
+        });
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final GrpcStreamSender sender = new GrpcStreamSender(stub, 1, failure::set);
+
+        sender.send(MessageLatenciesRecord.getDefaultInstance());
+        verify(requestStream, timeout(1_000).atLeastOnce()).isReady();
+        sender.send(MessageLatenciesRecord.getDefaultInstance());
+
+        final IOException exception = assertThrows(IOException.class,
+                () -> sender.send(MessageLatenciesRecord.getDefaultInstance()));
+        assertTrue(exception.getMessage().contains("pending batch queue is full"));
+        assertEquals(exception, failure.get());
+    }
+
+    @Test
+    void closeSurfacesServerStreamFailure() throws Exception {
+        final String serverName = InProcessServerBuilder.generateName();
+        final Server server = InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(new ServiceGrpc.ServiceImplBase() {
+                    @Override
+                    public StreamObserver<MessageLatenciesRecord> streamLatencies(
+                            StreamObserver<Empty> responseObserver) {
+                        return new StreamObserver<>() {
+                            @Override
+                            public void onNext(MessageLatenciesRecord value) {
+                                responseObserver.onError(Status.UNAVAILABLE
+                                        .withDescription("test stream failure")
+                                        .asRuntimeException());
+                            }
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                            }
+                        };
+                    }
+                })
+                .build()
+                .start();
+        final ManagedChannel channel = InProcessChannelBuilder.forName(serverName)
+                .directExecutor()
+                .build();
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch failureReported = new CountDownLatch(1);
+
+        try {
+            final GrpcStreamSender sender = new GrpcStreamSender(
+                    ServiceGrpc.newStub(channel), 4, throwable -> {
+                        failure.set(throwable);
+                        failureReported.countDown();
+                    });
+            sender.send(MessageLatenciesRecord.getDefaultInstance());
+
+            assertTrue(failureReported.await(2, TimeUnit.SECONDS));
+            final IOException exception = assertThrows(IOException.class, sender::close);
+            assertEquals(failure.get(), exception.getCause());
+        } finally {
+            channel.shutdownNow();
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void closeImmediatelySurfacesSenderThreadFailure() throws Exception {
+        final ServiceGrpc.ServiceStub stub = mock(ServiceGrpc.ServiceStub.class);
+        final ClientCallStreamObserver<MessageLatenciesRecord> requestStream =
+                mock(ClientCallStreamObserver.class);
+        final IllegalStateException transportFailure =
+                new IllegalStateException("test request-stream failure");
+        when(requestStream.isReady()).thenReturn(true);
+        doThrow(transportFailure).when(requestStream).onNext(any());
+        when(stub.streamLatencies(any())).thenAnswer(invocation -> {
+            final ClientResponseObserver<MessageLatenciesRecord, Empty> responseObserver =
+                    invocation.getArgument(0);
+            responseObserver.beforeStart(requestStream);
+            return requestStream;
+        });
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch failureReported = new CountDownLatch(1);
+        final GrpcStreamSender sender = new GrpcStreamSender(stub, 1, throwable -> {
+            failure.set(throwable);
+            failureReported.countDown();
+        });
+
+        sender.send(MessageLatenciesRecord.getDefaultInstance());
+
+        assertTrue(failureReported.await(2, TimeUnit.SECONDS));
+        final IOException exception = assertThrows(IOException.class, sender::close);
+        assertEquals(transportFailure, failure.get());
+        assertEquals(transportFailure, exception.getCause());
     }
 }

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -18,6 +18,16 @@ limitations under the License.
 
 SBM is SBK's distributed measurement aggregator. SBK clients using `GrpcLogger` send SBP/gRPC latency records to SBM, which merges them into cluster-wide periodic and total statistics.
 
+SBP 3.1 uses one ordered client-streaming RPC per SBK process and packed
+primitive latency/count fields. `GrpcLogger` accumulates exact frequencies in
+a primitive map, submits immutable batches through a bounded sender queue,
+obeys gRPC flow control, and waits for the final stream acknowledgment during
+shutdown. The SBP 3.0 unary RPC and protobuf map remain available for
+backward compatibility.
+SBM explicitly configures and advertises its inbound record limit
+(`maxRecordSizeMB`, 4 MiB by default); SBK sends no more than the smaller
+client/server limit.
+
 SBM does not execute storage operations and does not launch remote processes. Use SBK for load generation and SBK-GEM for SSH orchestration.
 
 ## Data flow
@@ -90,7 +100,7 @@ Use a hostname or address reachable from every SBK client. Firewalls, containers
 | `io.sbm.main.SbmMain` | Executable entry point |
 | `io.sbm.api.impl.Sbm` | Logger discovery, arguments, and benchmark construction |
 | `SbmBenchmark` | gRPC server and aggregate-recorder lifecycle |
-| `SbmGrpcService` | SBP registration and latency-record endpoint |
+| `SbmGrpcService` | SBP registration, ordered stream validation, and latency-record endpoints |
 | `SbmLatencyBenchmark` | Concurrent queue ingestion and window dispatch |
 | `SbmTotalWindowLatencyPeriodicRecorder` | Periodic and total aggregate windows |
 | `SbmPrometheusLogger` | Aggregated output and metrics |
@@ -104,6 +114,7 @@ Protocol sources are under `sbk-api/src/main/proto`; generated Java/gRPC sources
 - Synchronize clocks when interpreting cross-host timestamps or correlated events.
 - Record client count, worker count, network topology, interval, and latency bounds.
 - Watch rejected registrations, disconnected clients, invalid latencies, and discarded lower/upper values.
+- Treat sequence-gap, stream-overload, and final-acknowledgment failures as invalid benchmark runs.
 - Do not combine already calculated client percentiles; SBM aggregates latency records/windows before reporting percentiles.
 
 ## Containers and dashboards

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -25,7 +25,7 @@ obeys gRPC flow control, and waits for the final stream acknowledgment during
 shutdown. SBP 4.0 intentionally removes the earlier unary latency RPC and
 protobuf map field, so SBK and SBM must use the same SBP major version.
 SBM explicitly configures and advertises its inbound record limit
-(`maxRecordSizeMB`, 4 MiB by default); SBK sends no more than the smaller
+(`maxRecordSizeMB`, 16 MiB by default); SBK sends no more than the smaller
 client/server limit.
 
 SBM does not execute storage operations and does not launch remote processes. Use SBK for load generation and SBK-GEM for SSH orchestration.

--- a/sbm/README.md
+++ b/sbm/README.md
@@ -18,12 +18,12 @@ limitations under the License.
 
 SBM is SBK's distributed measurement aggregator. SBK clients using `GrpcLogger` send SBP/gRPC latency records to SBM, which merges them into cluster-wide periodic and total statistics.
 
-SBP 3.1 uses one ordered client-streaming RPC per SBK process and packed
+SBP 4.0 uses one ordered client-streaming RPC per SBK process and packed
 primitive latency/count fields. `GrpcLogger` accumulates exact frequencies in
 a primitive map, submits immutable batches through a bounded sender queue,
 obeys gRPC flow control, and waits for the final stream acknowledgment during
-shutdown. The SBP 3.0 unary RPC and protobuf map remain available for
-backward compatibility.
+shutdown. SBP 4.0 intentionally removes the earlier unary latency RPC and
+protobuf map field, so SBK and SBM must use the same SBP major version.
 SBM explicitly configures and advertises its inbound record limit
 (`maxRecordSizeMB`, 4 MiB by default); SBK sends no more than the smaller
 client/server limit.

--- a/sbm/build.gradle
+++ b/sbm/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
     implementation "org.jetbrains:annotations:$jetbrainVersion"
     api project(":sbk-api")
+    testImplementation "io.grpc:grpc-inprocess:$grpcVersion"
 }
 
 

--- a/sbm/src/main/java/io/sbm/api/impl/SbmBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmBenchmark.java
@@ -102,9 +102,11 @@ final public class SbmBenchmark implements Benchmark {
         latencyRecorder = createLatencyRecorder();
         benchmark = new SbmLatencyBenchmark(sbmConfig.maxQueues, params.getIdleSleepMilliSeconds(), time, latencyRecorder,
                 logger.getPrintingIntervalSeconds() * Time.MS_PER_SEC);
+        final int maxRecordSizeBytes = Math.multiplyExact(sbmConfig.maxRecordSizeMB, Bytes.BYTES_PER_MB);
         service = new SbmGrpcService(params, time, logger.getMinLatency(), logger.getMaxLatency(), logger, benchmark,
-                coordinatedStart);
-        server = ServerBuilder.forPort(params.getPort()).addService(service).directExecutor().build();
+                coordinatedStart, maxRecordSizeBytes);
+        server = ServerBuilder.forPort(params.getPort()).maxInboundMessageSize(maxRecordSizeBytes)
+                .addService(service).directExecutor().build();
         retFuture = new CompletableFuture<>();
         state = State.BEGIN;
     }
@@ -147,7 +149,7 @@ final public class SbmBenchmark implements Benchmark {
         }
 
         return new SbmTotalWindowLatencyPeriodicRecorder(window, totalWindowExtension, logger, logger::printTotal,
-                logger, logger, logger, logger);
+                logger, logger, logger, logger, params.getMaxConnections());
     }
 
     /**

--- a/sbm/src/main/java/io/sbm/api/impl/SbmGrpcService.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmGrpcService.java
@@ -193,34 +193,6 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
     }
 
 
-    @Override
-    public void addLatenciesRecord(io.sbp.grpc.MessageLatenciesRecord request,
-                                   io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-        // Queue a latency record for aggregation; respond with Empty on success
-        try {
-            validateLatencyFields(request);
-            registry.enQueue(request);
-            if (responseObserver != null) {
-                responseObserver.onNext(Empty.getDefaultInstance());
-                responseObserver.onCompleted();
-            }
-        } catch (IllegalArgumentException ex) {
-            if (responseObserver != null) {
-                responseObserver.onError(Status.INVALID_ARGUMENT
-                        .withDescription(ex.getMessage())
-                        .withCause(ex)
-                        .asRuntimeException());
-            }
-        } catch (IllegalStateException ex) {
-            if (responseObserver != null) {
-                responseObserver.onError(Status.RESOURCE_EXHAUSTED
-                        .withDescription("SBM latency queue rejected a record")
-                        .withCause(ex)
-                        .asRuntimeException());
-            }
-        }
-    }
-
     /**
      * Opens a persistent ordered latency stream for an SBK client.
      *

--- a/sbm/src/main/java/io/sbm/api/impl/SbmGrpcService.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmGrpcService.java
@@ -13,10 +13,12 @@ package io.sbm.api.impl;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Empty;
 import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
 import io.sbp.api.Sbp;
 import io.sbp.config.SbpVersion;
 import io.sbp.grpc.ClientID;
 import io.sbp.grpc.Config;
+import io.sbp.grpc.MessageLatenciesRecord;
 import io.sbp.grpc.ServiceGrpc;
 import io.sbm.logger.CountConnections;
 import io.sbm.params.RamParameters;
@@ -26,7 +28,6 @@ import io.time.Time;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -65,7 +66,7 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
      */
     public SbmGrpcService(RamParameters params, Time time, long minLatency, long maxLatency,
                           CountConnections countConnections, SbmRegistry registry) {
-        this(params, time, minLatency, maxLatency, countConnections, registry, false);
+        this(params, time, minLatency, maxLatency, countConnections, registry, false, 0);
     }
 
     /**
@@ -81,6 +82,24 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
      */
     public SbmGrpcService(RamParameters params, Time time, long minLatency, long maxLatency,
                           CountConnections countConnections, SbmRegistry registry, boolean coordinatedStart) {
+        this(params, time, minLatency, maxLatency, countConnections, registry, coordinatedStart, 0);
+    }
+
+    /**
+     * Create the SBP service with registration-barrier and transport-size configuration.
+     *
+     * @param params SBM parameters
+     * @param time latency time implementation
+     * @param minLatency minimum accepted latency
+     * @param maxLatency maximum accepted latency
+     * @param countConnections connection metrics
+     * @param registry latency-record registry
+     * @param coordinatedStart whether all expected clients must register before any registration completes
+     * @param maxRecordSizeBytes maximum accepted serialized latency-record size
+     */
+    public SbmGrpcService(RamParameters params, Time time, long minLatency, long maxLatency,
+                          CountConnections countConnections, SbmRegistry registry, boolean coordinatedStart,
+                          long maxRecordSizeBytes) {
         super();
         connections = new AtomicInteger(0);
         Config.Builder builder = Config.newBuilder();
@@ -89,6 +108,7 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
         builder.setTimeUnitValue(time.getTimeUnit().ordinal());
         builder.setMaxLatency(maxLatency);
         builder.setMinLatency(minLatency);
+        builder.setMaxRecordSizeBytes(maxRecordSizeBytes);
         config = builder.build();
         this.params = params;
         this.countConnections = countConnections;
@@ -178,16 +198,102 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
                                    io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
         // Queue a latency record for aggregation; respond with Empty on success
         try {
+            validateLatencyFields(request);
             registry.enQueue(request);
             if (responseObserver != null) {
-                responseObserver.onNext(Empty.newBuilder().build());
+                responseObserver.onNext(Empty.getDefaultInstance());
                 responseObserver.onCompleted();
             }
-        } catch (IllegalStateException ex) {
-            ex.printStackTrace();
+        } catch (IllegalArgumentException ex) {
             if (responseObserver != null) {
-                responseObserver.onError(new InvalidKeyException());
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                        .withDescription(ex.getMessage())
+                        .withCause(ex)
+                        .asRuntimeException());
             }
+        } catch (IllegalStateException ex) {
+            if (responseObserver != null) {
+                responseObserver.onError(Status.RESOURCE_EXHAUSTED
+                        .withDescription("SBM latency queue rejected a record")
+                        .withCause(ex)
+                        .asRuntimeException());
+            }
+        }
+    }
+
+    /**
+     * Opens a persistent ordered latency stream for an SBK client.
+     *
+     * @param responseObserver final stream acknowledgement observer
+     * @return observer accepting ordered latency records
+     */
+    @Override
+    public StreamObserver<MessageLatenciesRecord> streamLatencies(
+            StreamObserver<Empty> responseObserver) {
+        return new StreamObserver<>() {
+            private long clientId = -1;
+            private long expectedSequence = 1;
+            private boolean terminated;
+
+            @Override
+            public void onNext(MessageLatenciesRecord record) {
+                if (terminated) {
+                    return;
+                }
+                if (clientId < 0) {
+                    clientId = record.getClientID();
+                }
+                if (record.getClientID() != clientId) {
+                    fail(Status.INVALID_ARGUMENT.withDescription(
+                            "SBM latency stream changed client ID from " + clientId
+                                    + " to " + record.getClientID()));
+                } else if (record.getSequenceNumber() != expectedSequence) {
+                    fail(Status.DATA_LOSS.withDescription(
+                            "SBM latency stream sequence mismatch for client " + clientId
+                                    + ": expected " + expectedSequence + " but received "
+                                    + record.getSequenceNumber()));
+                } else {
+                    try {
+                        validateLatencyFields(record);
+                        registry.enQueue(record);
+                        expectedSequence++;
+                    } catch (IllegalArgumentException exception) {
+                        fail(Status.INVALID_ARGUMENT
+                                .withDescription(exception.getMessage())
+                                .withCause(exception));
+                    } catch (IllegalStateException exception) {
+                        fail(Status.RESOURCE_EXHAUSTED
+                                .withDescription("SBM latency queue rejected a streamed record")
+                                .withCause(exception));
+                    }
+                }
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                terminated = true;
+            }
+
+            @Override
+            public void onCompleted() {
+                if (!terminated) {
+                    terminated = true;
+                    responseObserver.onNext(Empty.getDefaultInstance());
+                    responseObserver.onCompleted();
+                }
+            }
+
+            private void fail(Status status) {
+                terminated = true;
+                responseObserver.onError(status.asRuntimeException());
+            }
+        };
+    }
+
+    private static void validateLatencyFields(MessageLatenciesRecord record) {
+        if (record.getLatencyValuesCount() != record.getLatencyCountsCount()) {
+            throw new IllegalArgumentException("SBM packed latency values/counts have different lengths: "
+                    + record.getLatencyValuesCount() + " and " + record.getLatencyCountsCount());
         }
     }
 
@@ -198,7 +304,7 @@ final public class SbmGrpcService extends ServiceGrpc.ServiceImplBase {
         countConnections.decrementConnections();
         connections.decrementAndGet();
         if (responseObserver != null) {
-            responseObserver.onNext(Empty.newBuilder().build());
+            responseObserver.onNext(Empty.getDefaultInstance());
             responseObserver.onCompleted();
         }
     }

--- a/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
 final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<MessageLatenciesRecord> implements Benchmark,
         SbmRegistry {
     static final String CONSUMER_THREAD_NAME = "sbm-latency-consumer";
+    static final int MAXIMUM_DRAIN_BATCH = 64;
     private final int maxQs;
     private final int idleMS;
     private final Time time;
@@ -96,13 +97,15 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
         while (doWork) {
             notFound = true;
             for (int qIndex = 0; qIndex < maxQs; qIndex++) {
-                record = poll(qIndex);
-                if (record != null) {
+                int drained = 0;
+                while (drained < MAXIMUM_DRAIN_BATCH && (record = poll(qIndex)) != null) {
                     notFound = false;
+                    drained++;
                     if (record.getSequenceNumber() > 0) {
                         window.record(currentTime, record);
                     } else {
                         doWork = false;
+                        break;
                     }
                 }
             }

--- a/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmLatencyBenchmark.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicLong;
 final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<MessageLatenciesRecord> implements Benchmark,
         SbmRegistry {
     static final String CONSUMER_THREAD_NAME = "sbm-latency-consumer";
-    static final int MAXIMUM_DRAIN_BATCH = 64;
     private final int maxQs;
     private final int idleMS;
     private final Time time;
@@ -97,15 +96,13 @@ final public class SbmLatencyBenchmark extends ConcurrentLinkedQueueArray<Messag
         while (doWork) {
             notFound = true;
             for (int qIndex = 0; qIndex < maxQs; qIndex++) {
-                int drained = 0;
-                while (drained < MAXIMUM_DRAIN_BATCH && (record = poll(qIndex)) != null) {
+                record = poll(qIndex);
+                if (record != null) {
                     notFound = false;
-                    drained++;
                     if (record.getSequenceNumber() > 0) {
                         window.record(currentTime, record);
                     } else {
                         doWork = false;
-                        break;
                     }
                 }
             }

--- a/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
@@ -23,8 +23,6 @@ import io.sbk.logger.SetRW;
 import io.sbk.logger.WriteRequestsLogger;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-
 import static io.sbm.api.SbmRegistry.BASE_CLIENT_ID_VALUE;
 
 /**
@@ -37,7 +35,13 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
 
     final private WriteRequestsLogger wRequestLogger;
     final private ReadRequestsLogger rRequestLogger;
-    final private HashMap<Long, RW> table;
+    private final int[] readersByClient;
+    private final int[] writersByClient;
+    private final int[] maxReadersByClient;
+    private final int[] maxWritersByClient;
+    private final boolean[] activeClients;
+    private final int[] activeClientIds;
+    private int activeClientCount;
 
     /**
      * Constructor RamTotalWindowLatencyPeriodicRecorder initialize all values and pass all values to its upper class.
@@ -50,6 +54,7 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
      * @param setRW                 SetRW
      * @param wLogger               Write Requests Logger
      * @param rLogger               Read Requests Logger
+     * @param maximumClients        maximum number of concurrently registered clients
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public SbmTotalWindowLatencyPeriodicRecorder(LatencyRecordWindow window, LatencyRecordWindow totalWindow,
@@ -57,13 +62,20 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
                                                  ReportLatencies reportLatencies,
                                                  SetRW setRW,
                                                  WriteRequestsLogger wLogger,
-                                                 ReadRequestsLogger rLogger) {
+                                                 ReadRequestsLogger rLogger,
+                                                 int maximumClients) {
         super(window, totalWindow, windowLogger, totalLogger);
         this.reportLatencies = reportLatencies;
         this.setRW = setRW;
         this.wRequestLogger = wLogger;
         this.rRequestLogger = rLogger;
-        this.table = new HashMap<>();
+        this.readersByClient = new int[maximumClients];
+        this.writersByClient = new int[maximumClients];
+        this.maxReadersByClient = new int[maximumClients];
+        this.maxWritersByClient = new int[maximumClients];
+        this.activeClients = new boolean[maximumClients];
+        this.activeClientIds = new int[maximumClients];
+        this.activeClientCount = 0;
     }
 
     @Override
@@ -112,7 +124,14 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
                 record.getHigherLatencyDiscardRecords(), record.getValidLatencyRecords(),
                 record.getMinLatency(), record.getMaxLatency());
 
-        record.getLatencyMap().forEach(window::reportLatency);
+        if (record.getLatencyValuesCount() > 0) {
+            final int latencyCount = record.getLatencyValuesCount();
+            for (int index = 0; index < latencyCount; index++) {
+                window.reportLatency(record.getLatencyValues(index), record.getLatencyCounts(index));
+            }
+        } else {
+            record.getLatencyMap().forEach(window::reportLatency);
+        }
     }
 
     /**
@@ -121,12 +140,7 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
      * @param currentTime   long
      */
     public void flush(long currentTime) {
-        final RW rwStore = new RW();
-        sumRW(rwStore);
-        setRW.setReaders(rwStore.readers);
-        setRW.setWriters(rwStore.writers);
-        setRW.setMaxReaders(rwStore.maxReaders);
-        setRW.setMaxWriters(rwStore.maxWriters);
+        sumRW();
         window.print(currentTime, windowLogger, this);
     }
 
@@ -141,44 +155,42 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
     }
 
     private void addRW(long key, int readers, int writers, int maxReaders, int maxWriters) {
-        RW cur = table.get(key);
-        if (cur == null) {
-            cur = new RW();
-            table.put(key, cur);
+        final int clientIndex = Math.toIntExact(key - BASE_CLIENT_ID_VALUE);
+        if (clientIndex < 0 || clientIndex >= activeClients.length) {
+            throw new IllegalArgumentException("SBM client ID is outside the configured range: " + key);
         }
-        cur.update(readers, writers, maxReaders, maxWriters);
+        if (!activeClients[clientIndex]) {
+            activeClients[clientIndex] = true;
+            activeClientIds[activeClientCount++] = clientIndex;
+        }
+        readersByClient[clientIndex] = Math.max(readersByClient[clientIndex], readers);
+        writersByClient[clientIndex] = Math.max(writersByClient[clientIndex], writers);
+        maxReadersByClient[clientIndex] = Math.max(maxReadersByClient[clientIndex], maxReaders);
+        maxWritersByClient[clientIndex] = Math.max(maxWritersByClient[clientIndex], maxWriters);
     }
 
-    private void sumRW(RW ret) {
-        table.forEach((k, data) -> {
-            ret.readers += data.readers;
-            ret.writers += data.writers;
-            ret.maxReaders += data.maxReaders;
-            ret.maxWriters += data.maxWriters;
-        });
-        table.clear();
-    }
-
-    private static class RW {
-        public int readers;
-        public int writers;
-        public int maxReaders;
-        public int maxWriters;
-
-        public RW() {
-            reset();
+    private void sumRW() {
+        int readers = 0;
+        int writers = 0;
+        int maxReaders = 0;
+        int maxWriters = 0;
+        for (int activeIndex = 0; activeIndex < activeClientCount; activeIndex++) {
+            final int clientIndex = activeClientIds[activeIndex];
+            readers += readersByClient[clientIndex];
+            writers += writersByClient[clientIndex];
+            maxReaders += maxReadersByClient[clientIndex];
+            maxWriters += maxWritersByClient[clientIndex];
+            readersByClient[clientIndex] = 0;
+            writersByClient[clientIndex] = 0;
+            maxReadersByClient[clientIndex] = 0;
+            maxWritersByClient[clientIndex] = 0;
+            activeClients[clientIndex] = false;
         }
-
-        public void reset() {
-            readers = writers = maxWriters = maxReaders = 0;
-        }
-
-        public void update(int readers, int writers, int maxReaders, int maxWriters) {
-            this.readers = Math.max(this.readers, readers);
-            this.writers = Math.max(this.writers, writers);
-            this.maxReaders = Math.max(this.maxReaders, maxReaders);
-            this.maxWriters = Math.max(this.maxWriters, maxWriters);
-        }
+        activeClientCount = 0;
+        setRW.setReaders(readers);
+        setRW.setWriters(writers);
+        setRW.setMaxReaders(maxReaders);
+        setRW.setMaxWriters(maxWriters);
     }
 
 }

--- a/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
@@ -124,13 +124,9 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
                 record.getHigherLatencyDiscardRecords(), record.getValidLatencyRecords(),
                 record.getMinLatency(), record.getMaxLatency());
 
-        if (record.getLatencyValuesCount() > 0) {
-            final int latencyCount = record.getLatencyValuesCount();
-            for (int index = 0; index < latencyCount; index++) {
-                window.reportLatency(record.getLatencyValues(index), record.getLatencyCounts(index));
-            }
-        } else {
-            record.getLatencyMap().forEach(window::reportLatency);
+        final int latencyCount = record.getLatencyValuesCount();
+        for (int index = 0; index < latencyCount; index++) {
+            window.reportLatency(record.getLatencyValues(index), record.getLatencyCounts(index));
         }
     }
 

--- a/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
+++ b/sbm/src/main/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorder.java
@@ -106,6 +106,7 @@ final public class SbmTotalWindowLatencyPeriodicRecorder extends TotalLatencyRec
      * adds latencies record.
      *
      * @param record NotNull LatenciesRecord
+     * @throws IllegalArgumentException if the client ID is outside the configured range
      */
     public void addLatenciesRecord(@NotNull MessageLatenciesRecord record) {
         final int id = (int) (record.getClientID() - BASE_CLIENT_ID_VALUE);

--- a/sbm/src/main/java/io/sbm/config/SbmConfig.java
+++ b/sbm/src/main/java/io/sbm/config/SbmConfig.java
@@ -48,6 +48,10 @@ final public class SbmConfig extends LatencyConfig {
      * <code>int idleMS</code>.
      */
     public int idleMS;
+    /**
+     * Maximum inbound SBP latency-record size in MiB.
+     */
+    public int maxRecordSizeMB;
 
     /**
      * Creates an empty SBM configuration for property binding.

--- a/sbm/src/main/resources/sbm.properties
+++ b/sbm/src/main/resources/sbm.properties
@@ -19,7 +19,7 @@ maxQueues=10
 idleMS=10
 
 #Maximum SBP latency record size in MB
-maxRecordSizeMB=4
+maxRecordSizeMB=16
 
 #Max Latency Array Size
 maxArraySizeMB=128

--- a/sbm/src/main/resources/sbm.properties
+++ b/sbm/src/main/resources/sbm.properties
@@ -18,6 +18,9 @@ maxQueues=10
 #Max Idle Milliseconds to Wait
 idleMS=10
 
+#Maximum SBP latency record size in MB
+maxRecordSizeMB=4
+
 #Max Latency Array Size
 maxArraySizeMB=128
 

--- a/sbm/src/main/resources/sbm.properties
+++ b/sbm/src/main/resources/sbm.properties
@@ -18,7 +18,7 @@ maxQueues=10
 #Max Idle Milliseconds to Wait
 idleMS=10
 
-#Maximum SBP latency record size in MB
+#Maximum SBP latency record size in MiB
 maxRecordSizeMB=16
 
 #Max Latency Array Size

--- a/sbm/src/test/java/io/sbm/api/impl/SbmGrpcServiceTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmGrpcServiceTest.java
@@ -10,12 +10,16 @@
 
 package io.sbm.api.impl;
 
+import com.google.protobuf.Empty;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.sbm.api.SbmRegistry;
 import io.sbm.logger.CountConnections;
 import io.sbm.params.impl.SbmParameters;
 import io.sbp.grpc.ClientID;
 import io.sbp.grpc.Config;
+import io.sbp.grpc.MessageLatenciesRecord;
 import io.time.MilliSeconds;
 import org.junit.jupiter.api.Test;
 
@@ -25,12 +29,27 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests SBP registration coordination used by distributed SBK-GEM runs.
  */
 final class SbmGrpcServiceTest {
+    @Test
+    void advertisesTheConfiguredInboundRecordLimit() throws Exception {
+        final SbmParameters params = new SbmParameters("test", 0, 1, 0, null);
+        params.parseArgs(new String[]{"-class", "file", "-action", "r"});
+        final SbmGrpcService service = new SbmGrpcService(params, new MilliSeconds(), 0, 1000,
+                mock(CountConnections.class), mock(SbmRegistry.class), false, 4_194_304);
+        final CapturingConfigObserver response = new CapturingConfigObserver();
+
+        service.getConfig(Empty.getDefaultInstance(), response);
+
+        assertEquals(4_194_304, response.value.getMaxRecordSizeBytes());
+        assertTrue(response.completed);
+    }
+
     @Test
     void releasesAllClientsOnlyAfterExpectedNodesRegister() throws Exception {
         final SbmParameters params = new SbmParameters("test", 0, 2, 0, null);
@@ -53,6 +72,76 @@ final class SbmGrpcServiceTest {
         assertTrue(second.completed);
     }
 
+    @Test
+    void acceptsAnOrderedLatencyStreamAndAcknowledgesItsFinalDrain() throws Exception {
+        final SbmParameters params = new SbmParameters("test", 0, 2, 0, null);
+        params.parseArgs(new String[]{"-class", "file", "-action", "r", "-max", "2"});
+        final CountConnections connections = mock(CountConnections.class);
+        final SbmRegistry registry = mock(SbmRegistry.class);
+        final SbmGrpcService service = new SbmGrpcService(params, new MilliSeconds(), 0, 1000,
+                connections, registry);
+        final CapturingEmptyObserver response = new CapturingEmptyObserver();
+        final StreamObserver<MessageLatenciesRecord> stream = service.streamLatencies(response);
+        final MessageLatenciesRecord first = MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(1)
+                .addLatencyValues(10)
+                .addLatencyCounts(2)
+                .build();
+        final MessageLatenciesRecord second = MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(2)
+                .addLatencyValues(20)
+                .addLatencyCounts(3)
+                .build();
+
+        stream.onNext(first);
+        stream.onNext(second);
+        stream.onCompleted();
+
+        verify(registry).enQueue(first);
+        verify(registry).enQueue(second);
+        assertEquals(1, response.values);
+        assertTrue(response.completed);
+    }
+
+    @Test
+    void rejectsSequenceGapsBeforeTheyReachTheAggregator() throws Exception {
+        final SbmParameters params = new SbmParameters("test", 0, 1, 0, null);
+        params.parseArgs(new String[]{"-class", "file", "-action", "r"});
+        final SbmRegistry registry = mock(SbmRegistry.class);
+        final SbmGrpcService service = new SbmGrpcService(params, new MilliSeconds(), 0, 1000,
+                mock(CountConnections.class), registry);
+        final CapturingEmptyObserver response = new CapturingEmptyObserver();
+        final StreamObserver<MessageLatenciesRecord> stream = service.streamLatencies(response);
+
+        stream.onNext(MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(2)
+                .build());
+
+        assertEquals(Status.Code.DATA_LOSS, Status.fromThrowable(response.failure).getCode());
+    }
+
+    @Test
+    void rejectsMismatchedPackedLatencyArrays() throws Exception {
+        final SbmParameters params = new SbmParameters("test", 0, 1, 0, null);
+        params.parseArgs(new String[]{"-class", "file", "-action", "r"});
+        final SbmRegistry registry = mock(SbmRegistry.class);
+        final SbmGrpcService service = new SbmGrpcService(params, new MilliSeconds(), 0, 1000,
+                mock(CountConnections.class), registry);
+        final CapturingEmptyObserver response = new CapturingEmptyObserver();
+        final StreamObserver<MessageLatenciesRecord> stream = service.streamLatencies(response);
+
+        stream.onNext(MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(1)
+                .addLatencyValues(10)
+                .build());
+
+        assertEquals(Status.Code.INVALID_ARGUMENT, Status.fromThrowable(response.failure).getCode());
+    }
+
     private static final class CapturingObserver implements StreamObserver<ClientID> {
         private final List<Long> values = new ArrayList<>();
         private boolean completed;
@@ -60,6 +149,49 @@ final class SbmGrpcServiceTest {
         @Override
         public void onNext(ClientID value) {
             values.add(value.getId());
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            throw new AssertionError(throwable);
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+        }
+    }
+
+    private static final class CapturingEmptyObserver implements StreamObserver<Empty> {
+        private int values;
+        private boolean completed;
+        private Throwable failure;
+
+        @Override
+        public void onNext(Empty value) {
+            values++;
+        }
+
+        @Override
+        @SuppressFBWarnings(value = "EI_EXPOSE_REP2",
+                justification = "The throwable is retained only for the test assertion")
+        public void onError(Throwable throwable) {
+            failure = throwable;
+        }
+
+        @Override
+        public void onCompleted() {
+            completed = true;
+        }
+    }
+
+    private static final class CapturingConfigObserver implements StreamObserver<Config> {
+        private Config value;
+        private boolean completed;
+
+        @Override
+        public void onNext(Config config) {
+            value = config;
         }
 
         @Override

--- a/sbm/src/test/java/io/sbm/api/impl/SbmGrpcServiceTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmGrpcServiceTest.java
@@ -142,6 +142,29 @@ final class SbmGrpcServiceTest {
         assertEquals(Status.Code.INVALID_ARGUMENT, Status.fromThrowable(response.failure).getCode());
     }
 
+    @Test
+    void rejectsAClientIdChangeWithinOneStream() throws Exception {
+        final SbmParameters params = new SbmParameters("test", 0, 1, 0, null);
+        params.parseArgs(new String[]{"-class", "file", "-action", "r"});
+        final SbmRegistry registry = mock(SbmRegistry.class);
+        final SbmGrpcService service = new SbmGrpcService(params, new MilliSeconds(), 0, 1000,
+                mock(CountConnections.class), registry);
+        final CapturingEmptyObserver response = new CapturingEmptyObserver();
+        final StreamObserver<MessageLatenciesRecord> stream = service.streamLatencies(response);
+
+        stream.onNext(MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(1)
+                .build());
+        stream.onNext(MessageLatenciesRecord.newBuilder()
+                .setClientID(2)
+                .setSequenceNumber(2)
+                .build());
+
+        assertEquals(Status.Code.INVALID_ARGUMENT,
+                Status.fromThrowable(response.failure).getCode());
+    }
+
     private static final class CapturingObserver implements StreamObserver<ClientID> {
         private final List<Long> values = new ArrayList<>();
         private boolean completed;

--- a/sbm/src/test/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorderTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorderTest.java
@@ -17,7 +17,9 @@ import io.sbk.logger.SetRW;
 import io.sbk.logger.WriteRequestsLogger;
 import io.sbp.grpc.MessageLatenciesRecord;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -29,6 +31,7 @@ final class SbmTotalWindowLatencyPeriodicRecorderTest {
     void aggregatesPackedLatencyPairsAndExactSummaryBounds() {
         final LatencyRecordWindow window = mock(LatencyRecordWindow.class);
         final LatencyRecordWindow totalWindow = mock(LatencyRecordWindow.class);
+        final SetRW setRW = mock(SetRW.class);
         final SbmTotalWindowLatencyPeriodicRecorder recorder =
                 new SbmTotalWindowLatencyPeriodicRecorder(
                         window,
@@ -36,7 +39,7 @@ final class SbmTotalWindowLatencyPeriodicRecorderTest {
                         mock(Print.class),
                         mock(Print.class),
                         mock(ReportLatencies.class),
-                        mock(SetRW.class),
+                        setRW,
                         mock(WriteRequestsLogger.class),
                         mock(ReadRequestsLogger.class),
                         4);
@@ -49,16 +52,40 @@ final class SbmTotalWindowLatencyPeriodicRecorderTest {
                 .setTotalLatency(80)
                 .setMinLatency(10)
                 .setMaxLatency(20)
+                .setReaders(1)
+                .setWriters(2)
+                .setMaxReaders(3)
+                .setMaxWriters(4)
                 .addLatencyValues(10)
                 .addLatencyCounts(2)
                 .addLatencyValues(20)
                 .addLatencyCounts(3)
                 .build();
+        final MessageLatenciesRecord secondRecord = MessageLatenciesRecord.newBuilder()
+                .setClientID(2)
+                .setSequenceNumber(1)
+                .setReaders(5)
+                .setWriters(6)
+                .setMaxReaders(7)
+                .setMaxWriters(8)
+                .build();
 
         recorder.addLatenciesRecord(record);
+        recorder.addLatenciesRecord(secondRecord);
+        recorder.flush(100);
+        recorder.flush(200);
 
         verify(window).update(5, 80, 500, 0, 0, 0, 5, 10, 20);
         verify(window).reportLatency(10, 2);
         verify(window).reportLatency(20, 3);
+        final InOrder setRwOrder = inOrder(setRW);
+        setRwOrder.verify(setRW).setReaders(6);
+        setRwOrder.verify(setRW).setWriters(8);
+        setRwOrder.verify(setRW).setMaxReaders(10);
+        setRwOrder.verify(setRW).setMaxWriters(12);
+        setRwOrder.verify(setRW).setReaders(0);
+        setRwOrder.verify(setRW).setWriters(0);
+        setRwOrder.verify(setRW).setMaxReaders(0);
+        setRwOrder.verify(setRW).setMaxWriters(0);
     }
 }

--- a/sbm/src/test/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorderTest.java
+++ b/sbm/src/test/java/io/sbm/api/impl/SbmTotalWindowLatencyPeriodicRecorderTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbm.api.impl;
+
+import io.perl.api.LatencyRecordWindow;
+import io.perl.api.ReportLatencies;
+import io.perl.logger.Print;
+import io.sbk.logger.ReadRequestsLogger;
+import io.sbk.logger.SetRW;
+import io.sbk.logger.WriteRequestsLogger;
+import io.sbp.grpc.MessageLatenciesRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies packed SBP latency aggregation without a boxed protobuf map.
+ */
+final class SbmTotalWindowLatencyPeriodicRecorderTest {
+    @Test
+    void aggregatesPackedLatencyPairsAndExactSummaryBounds() {
+        final LatencyRecordWindow window = mock(LatencyRecordWindow.class);
+        final LatencyRecordWindow totalWindow = mock(LatencyRecordWindow.class);
+        final SbmTotalWindowLatencyPeriodicRecorder recorder =
+                new SbmTotalWindowLatencyPeriodicRecorder(
+                        window,
+                        totalWindow,
+                        mock(Print.class),
+                        mock(Print.class),
+                        mock(ReportLatencies.class),
+                        mock(SetRW.class),
+                        mock(WriteRequestsLogger.class),
+                        mock(ReadRequestsLogger.class),
+                        4);
+        final MessageLatenciesRecord record = MessageLatenciesRecord.newBuilder()
+                .setClientID(1)
+                .setSequenceNumber(1)
+                .setTotalRecords(5)
+                .setValidLatencyRecords(5)
+                .setTotalBytes(500)
+                .setTotalLatency(80)
+                .setMinLatency(10)
+                .setMaxLatency(20)
+                .addLatencyValues(10)
+                .addLatencyCounts(2)
+                .addLatencyValues(20)
+                .addLatencyCounts(3)
+                .build();
+
+        recorder.addLatenciesRecord(record);
+
+        verify(window).update(5, 80, 500, 0, 0, 0, 5, 10, 20);
+        verify(window).reportLatency(10, 2);
+        verify(window).reportLatency(20, 3);
+    }
+}


### PR DESCRIPTION
## Summary

- adopt SBP 4.0 as an intentional breaking wire-protocol revision
- use one ordered client-streaming RPC per SBK process
- encode exact latency distributions only as packed primitive latency/count arrays
- remove the earlier unary latency RPC, protobuf map field, client fallback, and server fallback
- reserve retired protobuf field 22 against accidental reuse
- replace per-record protobuf-map mutation in `GrpcLogger` with a reusable primitive accumulator
- send bounded batches over one persistent, flow-controlled gRPC stream
- propagate overload and transport failures through SBK's exception handler
- negotiate and enforce explicit client/server message-size limits
- validate stream client identity and sequence ordering before acknowledging completion
- reuse primitive per-client aggregation state in SBM
- retain SBM's original one-record-per-queue round-robin drain behavior
- document the SBP 4.0 data path, flow control, message limits, and version requirements

Recommendation 7 was intentionally not implemented: SBM continues to use its existing `ConcurrentLinkedQueueArray`.

## Compatibility

SBP 4.0 does not provide SBP 3.x wire compatibility. SBK and SBM must use
the same SBP major version. Version mismatch is rejected before benchmark
registration.

## Performance

JDK 25 JMH (`./gradlew :sbk-api:grpcLoggerPerformanceTest`):

| Path | Time | Allocation |
|---|---:|---:|
| Primitive hot-path accumulation | 4.045 ns/op | effectively 0 B/op |
| Boxed map baseline | 24.324 ns/op | 48.000 B/op |
| SBP 4 packed batch encoding | 69,758.604 ns/op | 510,296.086 B/op |

Primitive accumulation was 83.37% faster than the boxed-map baseline and
removed 48 B/op from the measurement path.

## Validation

- `./gradlew :sbk-api:check :sbm:check`
- `./gradlew clean`
- `./gradlew check`
- `./gradlew installDist`
- `./gradlew javadoc`
- `./gradlew :sbk-api:grpcLoggerPerformanceTest`
- SBK file write smoke test
- SBK-YAL file write smoke test with YAML/CLI override merging
- standalone SBK `GrpcLogger` to SBM end-to-end streaming test
- SBK-GEM localhost passwordless-SSH file benchmark
- SBK-GEM-YAL localhost passwordless-SSH file benchmark

The final SBP 4.0 executable test produced matching SBK and SBM totals of
5,493,772 records with zero invalid or discarded latencies.

## Test coverage

- packed encoding exactness, conservative size threshold, and accumulator reuse
- ordered persistent-stream drain and final acknowledgement
- stream sequence-gap and malformed-array rejection
- server-advertised message-size limit
- exact packed-summary aggregation in SBM
- original one-record-per-queue SBM round-robin draining


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded Storage Benchmark Protocol to SBP 4.0 using a single ordered client-streaming RPC for latency submission.
  * Switched latency payloads to packed latency values and counts (removing the legacy map format).
  * Added configurable maximum inbound latency-record size (default 16 MiB).
* **Bug Fixes**
  * Enforced client/sequence ordering and stricter validation for malformed latency submissions.
  * Improved batching/stream shutdown behavior with final acknowledgment after draining.
* **Tests**
  * Added coverage for ordered streaming delivery, accumulator packing/size limits, and option parsing validation.
* **Documentation**
  * Updated SBP/SBM ingestion and telemetry documentation to match SBP 4.0 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->