### PR TITLE
Identify Prometheus metrics by exporter component

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ SBK currently ships these logger implementations:
 - `PrometheusLogger`: CSV behavior plus Prometheus metrics exposure.
 - `GrpcLogger`: forwards measurements to SBM for distributed aggregation.
 
+Prometheus metrics include stable `component`, `class`, and `action` labels.
+`component="sbk"` identifies a direct SBK exporter, while `component="sbm"`
+identifies SBM aggregation, including benchmarks orchestrated by SBK-GEM.
+SBK-GEM is not a separate metrics component because SBM owns its metrics
+endpoint and aggregated measurements.
+
 ### SBK Local Web Console
 
 Use `WebLogger` when you want live graphs without Docker, Prometheus, or Grafana:

--- a/docs/sbk-internals.md
+++ b/docs/sbk-internals.md
@@ -1330,6 +1330,12 @@ Six shipping implementations:
 Selected at runtime by `-out <ClassName>`. The driver discovery and
 logger discovery use the same package-scan helper.
 
+Micrometer applies three low-cardinality common tags to every Prometheus
+meter: `component` identifies the exporting process (`sbk` or `sbm`), `class`
+identifies the resolved storage driver, and `action` identifies the workload.
+SBK-GEM launches and coordinates distributed work, but SBM owns the aggregated
+metrics endpoint; consequently GEM-managed metrics use `component="sbm"`.
+
 ### 4.5 Wiring a single benchmark — the bootstrap
 
 This is the control flow when a user runs

--- a/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
+++ b/sbk-api/src/main/java/io/sbk/api/impl/SbkBenchmark.java
@@ -29,7 +29,6 @@ import io.sbk.thread.ThreadType;
 import io.state.State;
 import io.time.Time;
 import lombok.Synchronized;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -202,8 +201,7 @@ final public class SbkBenchmark implements Benchmark {
         }
         state = State.RUN;
         Printer.log.info("SBK Benchmark Started");
-        rwLogger.open(params, StringUtils.capitalize(storage.getClass().getSimpleName().toLowerCase()),
-                params.getAction(), time);
+        rwLogger.open(params, storage.getClass().getSimpleName(), params.getAction(), time);
         storage.openStorage(params);
         final WriteRequestsLogger writeRequestsLogger = rwLogger.getMaxWriterIDs() > 0 ? rwLogger : null;
         final ReadRequestsLogger readRequestsLogger = rwLogger.getMaxReaderIDs() > 0 ? rwLogger : null;

--- a/sbk-api/src/main/java/io/sbk/logger/impl/SbkPrometheusServer.java
+++ b/sbk-api/src/main/java/io/sbk/logger/impl/SbkPrometheusServer.java
@@ -31,12 +31,15 @@ import java.util.concurrent.atomic.AtomicLong;
  * records/bytes, timeout events, as well as statistical latency metrics (avg/min/max/discards and
  * percentiles).
  *
- * <p>Metrics are tagged with the SBK storage class name (tag key: {@code class}) and the action
- * (tag key: {@code action}). Metric names are prefixed using an upper-cased header (for example,
- * {@code SBK_READ}) and follow a stable schema, such as
+ * <p>Metrics are tagged with the exporting component ({@code component="sbk"} for direct SBK or
+ * {@code component="sbm"} for SBM, including GEM-managed runs), the resolved storage driver class
+ * (tag key: {@code class}), and the benchmark action (tag key: {@code action}). Metric names are
+ * prefixed using an upper-cased header (for example, {@code SBK_READ}) and follow a stable schema, such as
  * {@code <prefix>_Write_Request_Bytes}, {@code <prefix>_Read_Request_RecordsPerSec}, etc.
  */
 public class SbkPrometheusServer extends PrometheusMetricsServer implements RWPrint {
+    /** Common metric tag identifying the process that exports the metrics. */
+    public static final String COMPONENT_TAG = "component";
     final private static String ACTION_TEXT = "action";
     /** Metric name prefix derived from the header (upper-cased and '_' separated). */
     final protected String rwMetricPrefix;
@@ -89,9 +92,26 @@ public class SbkPrometheusServer extends PrometheusMetricsServer implements RWPr
      */
     public SbkPrometheusServer(String header, String action, String className, double[] percentiles, Time time,
                                MetricsConfig config) throws IOException {
+        this(header, action, className, percentiles, time, config, Config.NAME);
+    }
+
+    /**
+     * Construct an SBK-compatible Prometheus server for a specific exporting component.
+     *
+     * @param header       metric name prefix
+     * @param action       benchmark action
+     * @param className    resolved storage driver class name
+     * @param percentiles  percentile configuration to publish
+     * @param time         time provider for latency measurements
+     * @param config       metrics endpoint configuration
+     * @param component    metrics exporter component, such as {@code sbk} or {@code sbm}
+     * @throws IOException if the underlying server cannot be initialized
+     */
+    protected SbkPrometheusServer(String header, String action, String className, double[] percentiles, Time time,
+                                  MetricsConfig config, String component) throws IOException {
         super(header.toUpperCase()+" "+action, percentiles, time,
                 config.latencyTimeUnit, config.port, config.context,
-                Tags.of(Config.CLASS_OPTION, className, ACTION_TEXT, action));
+                Tags.of(COMPONENT_TAG, component, Config.CLASS_OPTION, className, ACTION_TEXT, action));
         rwMetricPrefix =   header.toUpperCase().replace(" ", "_");
         final String writersName = rwMetricPrefix + "_Writers";
         final String readersName = rwMetricPrefix + "_Readers";

--- a/sbk-api/src/test/java/io/sbk/logger/impl/SbkPrometheusServerTest.java
+++ b/sbk-api/src/test/java/io/sbk/logger/impl/SbkPrometheusServerTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbk.logger.impl;
+
+import io.micrometer.core.instrument.Meter;
+import io.sbk.action.Action;
+import io.sbk.config.Config;
+import io.sbk.logger.MetricsConfig;
+import io.time.MilliSeconds;
+import io.time.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/** Verifies the stable common tags exported by direct SBK metrics. */
+final class SbkPrometheusServerTest {
+
+    @Test
+    void identifiesDirectSbkAsTheMetricsComponent() throws IOException {
+        final MetricsConfig config = metricsConfig();
+        final SbkPrometheusServer server = new SbkPrometheusServer(Config.NAME, Action.Reading.name(),
+                "ConcurrentQ", new double[]{50.0}, new MilliSeconds(), config);
+        try {
+            assertFalse(server.registry.getMeters().isEmpty());
+            for (Meter meter : server.registry.getMeters()) {
+                assertEquals(Config.NAME, meter.getId().getTag(SbkPrometheusServer.COMPONENT_TAG));
+                assertEquals("ConcurrentQ", meter.getId().getTag(Config.CLASS_OPTION));
+                assertEquals(Action.Reading.name(), meter.getId().getTag("action"));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static MetricsConfig metricsConfig() {
+        final MetricsConfig config = new MetricsConfig();
+        config.port = 0;
+        config.context = "/metrics";
+        config.latencyTimeUnit = TimeUnit.ms;
+        return config;
+    }
+}

--- a/sbk-gem/src/main/java/io/gem/api/impl/SbkGem.java
+++ b/sbk-gem/src/main/java/io/gem/api/impl/SbkGem.java
@@ -291,6 +291,8 @@ final public class SbkGem {
         }
 
         storageDrivers = storageDevice == null ? packageStore.getClassNames() : null;
+        final String resolvedClassName = storageDevice == null
+                ? className : storageDevice.getClass().getSimpleName();
 
         params = new SbkGemParameters(usageLine, storageDrivers, loggerNames, gemConfig, sbmConfig.port, sbmConfig.idleMS);
         logger.addArgs(params);
@@ -395,7 +397,7 @@ final public class SbkGem {
                 SbkUtils.removeOptionArgsAndValues(nextArgs, params.getOptionsArgs()), logger.getOptionsArgs());
         final List<String> sbkCommandArgs = new ArrayList<>();
         sbkCommandArgs.add(Config.CLASS_OPTION_ARG);
-        sbkCommandArgs.add(className);
+        sbkCommandArgs.add(resolvedClassName);
         Collections.addAll(sbkCommandArgs, sbkArgsList);
         sbkCommandArgs.add("-out");
         sbkCommandArgs.add(GrpcLogger.class.getSimpleName());
@@ -418,7 +420,7 @@ final public class SbkGem {
         sbmConfig.maxConnections = params.getConnections().length;
         final List<String> ramArgsList = new ArrayList<>();
         ramArgsList.add(Config.CLASS_OPTION_ARG);
-        ramArgsList.add(className);
+        ramArgsList.add(resolvedClassName);
         ramArgsList.add("-action");
         ramArgsList.add(actionString);
         /* Add the parsed args such as time, min and max latency and CSV file */

--- a/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusServer.java
+++ b/sbm/src/main/java/io/sbm/logger/impl/SbmPrometheusServer.java
@@ -11,6 +11,7 @@
 package io.sbm.logger.impl;
 
 import io.sbm.logger.CountConnections;
+import io.sbm.config.SbmConfig;
 import io.sbk.logger.MetricsConfig;
 import io.sbk.logger.impl.SbkPrometheusServer;
 import io.time.Time;
@@ -39,7 +40,7 @@ public final class SbmPrometheusServer extends SbkPrometheusServer implements Co
      */
     public SbmPrometheusServer(String header, String action, String storageName,
                                double[] percentiles, Time time, MetricsConfig config) throws IOException {
-        super(header, action, storageName, percentiles, time, config);
+        super(header, action, storageName, percentiles, time, config, SbmConfig.NAME);
         final String name = rwMetricPrefix + "_Connections";
         final String maxName = rwMetricPrefix + "_Max_Connections";
         this.connections = this.registry.gauge(name, new AtomicInteger());

--- a/sbm/src/main/java/io/sbm/params/impl/SbmParameters.java
+++ b/sbm/src/main/java/io/sbm/params/impl/SbmParameters.java
@@ -19,7 +19,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.UnrecognizedOptionException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 
@@ -100,7 +99,7 @@ final public class SbmParameters extends SbkInputOptions implements RamParameter
         if (name == null) {
             throw new UnrecognizedOptionException("storage 'class' name is NOT supplied! ");
         }
-        storageName = StringUtils.capitalize(name);
+        storageName = name;
 
         String actionString = getOptionValue("action", "r");
         action = switch (actionString.toLowerCase()) {

--- a/sbm/src/test/java/io/sbm/logger/impl/SbmPrometheusServerTest.java
+++ b/sbm/src/test/java/io/sbm/logger/impl/SbmPrometheusServerTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbm.logger.impl;
+
+import io.micrometer.core.instrument.Meter;
+import io.sbk.action.Action;
+import io.sbk.config.Config;
+import io.sbk.logger.MetricsConfig;
+import io.sbk.logger.impl.SbkPrometheusServer;
+import io.sbm.config.SbmConfig;
+import io.time.MilliSeconds;
+import io.time.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/** Verifies that standalone and GEM-managed SBM exporters identify as SBM. */
+final class SbmPrometheusServerTest {
+
+    @Test
+    void identifiesSbmAsTheMetricsComponent() throws IOException {
+        final MetricsConfig config = metricsConfig();
+        final SbmPrometheusServer server = new SbmPrometheusServer(Config.NAME, Action.Reading.name(),
+                "ConcurrentQ", new double[]{50.0}, new MilliSeconds(), config);
+        try {
+            assertFalse(server.registry.getMeters().isEmpty());
+            for (Meter meter : server.registry.getMeters()) {
+                assertEquals(SbmConfig.NAME, meter.getId().getTag(SbkPrometheusServer.COMPONENT_TAG));
+                assertEquals("ConcurrentQ", meter.getId().getTag(Config.CLASS_OPTION));
+                assertEquals(Action.Reading.name(), meter.getId().getTag("action"));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static MetricsConfig metricsConfig() {
+        final MetricsConfig config = new MetricsConfig();
+        config.port = 0;
+        config.context = "/metrics";
+        config.latencyTimeUnit = TimeUnit.ms;
+        return config;
+    }
+}

--- a/sbm/src/test/java/io/sbm/params/impl/SbmParametersTest.java
+++ b/sbm/src/test/java/io/sbm/params/impl/SbmParametersTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) KMG. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.sbm.params.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests parsing of storage identity used by SBM metrics. */
+final class SbmParametersTest {
+
+    @Test
+    void preservesCanonicalStorageClassName() throws Exception {
+        final SbmParameters parameters = new SbmParameters("test", 9717, 1, 0, null);
+
+        parameters.parseArgs(new String[]{"-class", "FdbRecord", "-action", "r"});
+
+        assertEquals("FdbRecord", parameters.getStorageName());
+    }
+
+    @Test
+    void doesNotRewriteStorageClassAcronyms() throws Exception {
+        final SbmParameters parameters = new SbmParameters("test", 9717, 1, 0, null);
+
+        parameters.parseArgs(new String[]{"-class", "MinIO", "-action", "w"});
+
+        assertEquals("MinIO", parameters.getStorageName());
+    }
+}


### PR DESCRIPTION
## Summary
- preserve resolved storage driver class names across direct SBK, SBK-GEM, and SBM metrics
- add a low-cardinality `component` common Micrometer tag to every Prometheus meter
- emit `component="sbk"` for direct SBK metrics and `component="sbm"` for standalone and GEM-managed SBM metrics
- document why SBK-GEM is not a separate metrics component: GEM orchestrates the run, while SBM owns the aggregated endpoint and measurements

## Design
The existing public `SbkPrometheusServer` constructor remains source-compatible and defaults to the SBK component. A protected constructor allows the SBM subclass to provide `SbmConfig.NAME`. `GemPrometheusLogger` continues to inherit the SBM implementation, so distributed metrics correctly identify as SBM without conditionals, `instanceof`, or an `sbk-gem` tag value.

Every exported meter now has the stable, low-cardinality identity set:
- `component`: `sbk` or `sbm`
- `class`: resolved storage driver simple class name
- `action`: benchmark action

Existing PromQL queries remain compatible because metric names and existing labels are unchanged; queries can optionally filter or group by `component`.

## Correctness coverage
- added SBK registry tests asserting every meter has `component="sbk"`, canonical `class`, and `action`
- added SBM registry tests asserting every meter has `component="sbm"`, canonical `class`, and `action`
- added canonical-name tests covering camel-case and acronym drivers (`FdbRecord`, `MinIO`)

## Validation
- `./gradlew :sbk-api:test --tests io.sbk.logger.impl.SbkPrometheusServerTest :sbm:test --tests io.sbm.logger.impl.SbmPrometheusServerTest`
- `./gradlew check installDist` -- 565 tasks, BUILD SUCCESSFUL
- `./gradlew :sbk-api:javadoc :sbm:check` -- BUILD SUCCESSFUL
- direct ConcurrentQ SBK Prometheus scrape: `SBK_Writers{action="Write_Reading",class="ConcurrentQ",component="sbk"}`
- standalone SBM Prometheus scrape: `SBK_Connections{action="Reading",class="ConcurrentQ",component="sbm"}`

## Compatibility and cardinality
The new label has exactly two bounded values. No run IDs, hostnames, timestamps, or other high-cardinality values are introduced. Existing dashboards that do not select `component` continue to match the same metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing Prometheus metric labels: `component`, `class`, and `action`.

* **New Features**
  * Prometheus metrics now include component identification to distinguish between SBK and SBM components.

* **Bug Fixes**
  * Storage class names are now preserved as provided instead of being automatically lowercased or capitalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->